### PR TITLE
Add section 21: loop engineering

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,14 +136,14 @@ awesome-agent-architecture/
 
 Each section folder is `NN-name/` and contains a `README.md`.
 
-Sections 1 to 20 also carry a runnable `src/`. The code accumulates section by section.
+Sections 1 to 21 also carry a runnable `src/`. The code accumulates section by section.
 Each section adds one mechanism and evolves `loop.py`, so a diff between adjacent sections shows what changed.
 
 ---
 
 ## Running the Demos
 
-Sections 1 to 20 ship runnable demos. Set up once from the repo root:
+Sections 1 to 21 ship runnable demos. Set up once from the repo root:
 
 ```bash
 uv venv

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center">
   <a href="#sections"><img src="https://img.shields.io/badge/Focus-Harness_Engineering-6e40c9?style=for-the-badge" alt="Focus: Harness Engineering"></a>
   <a href="#systems-under-study"><img src="https://img.shields.io/badge/Systems-2+-0a7bbb?style=for-the-badge" alt="Systems"></a>
-  <a href="#sections"><img src="https://img.shields.io/badge/Sections-21-green?style=for-the-badge" alt="Sections"></a>
+  <a href="#sections"><img src="https://img.shields.io/badge/Sections-22-green?style=for-the-badge" alt="Sections"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow?style=for-the-badge" alt="License"></a>
 </p>
 
@@ -19,9 +19,11 @@
   <strong>English</strong> · <a href="README.zh-TW.md">繁體中文</a> · <a href="README.zh-CN.md">简体中文</a>
 </p>
 
-The model reasons. The harness gives it action, state, and limits: it runs tools, keeps state across calls, gates side effects, and coordinates loops, none of which a model call does by itself.
+The model reasons. The harness gives it action, state, and limits:
+it runs tools, keeps state across calls, gates side effects, and coordinates loops, none of which a model call does by itself.
 
-This repo explains the harness section by section: loop, tools, memory, permissions, context, tasks, and interfaces. Learn it once and you can read many agents, since a coding tool, chat assistant, and autonomous runner mostly differ in harness choices.
+This repo explains the harness section by section: loop, tools, memory, permissions, context, tasks, and interfaces.
+Learn it once and you can read many agents, since a coding tool, chat assistant, and autonomous runner mostly differ in harness choices.
 
 **Contents:** [Systems](#systems-under-study) · [Loop](#the-agent-loop) · [Method](#method) ·
 [Sections](#sections) · [Structure](#repository-structure) · [Running](#running-the-demos)
@@ -34,8 +36,8 @@ Each system is a worked example for the sections below.
 
 | System | Why people use it | Read it for | Sections | Maintainer |
 | --- | --- | --- | --- | --- |
-| **Claude Code** | Frontier coding agent: edits files, runs commands, ships changes in real repos. | The full harness, start here | 0 to 20 (all) | Anthropic |
-| **Hermes Agent** | Long-term assistant: remembers you, learns workflows, runs across platforms. | Memory, skill evolution, always-on channels | 7, 9, 14, 16, 19 | Nous Research |
+| **Claude Code** | Frontier coding agent: edits files, runs commands, ships changes in real repos. | The full harness, start here | 0 to 21 (all) | Anthropic |
+| **Hermes Agent** | Long-term assistant: remembers you, learns workflows, runs anywhere. | Memory, skill evolution, always-on channels | 7, 9, 14, 16, 19, 21 | Nous Research |
 | *(more soon)* | | | | |
 
 > More systems can be added later, including OpenClaw, aider, and mini-swe-agent.
@@ -81,7 +83,7 @@ To learn from this repo:
 
 ## Sections
 
-Seven layers, from the basic loop to a multi-agent harness. Each row links to one self-contained writeup.
+Eight layers, from the basic loop to a harness that runs itself. Each row links to one self-contained writeup.
 
 | # | Section | Question | Key mechanisms |
 | --- | --- | --- | --- |
@@ -113,12 +115,14 @@ Seven layers, from the basic loop to a multi-agent harness. Each row links to on
 | | **Layer 6 · Extension & Integration** | | |
 | 19 | [MCP / plugins / channels](sections/19-mcp-plugins-channels/) | How does the harness reach the world? | Transports, channels, tool pool assembly |
 | 20 | [Observability & evaluation](sections/20-observability/) | How do we know it works? | Tracing, metrics, evals, failure analysis |
+| | **Layer 7 · Composition** | | |
+| 21 | [Loop engineering](sections/21-loop-engineering/) | How do loops stack into a system that runs itself? | Verification loop, triggers, budgets, maturity levels |
 
 ---
 
 ## Repository Structure
 
-All 21 section writeups are present, from `00-harness-thesis/` through `20-observability/`.
+All 22 section writeups are present, from `00-harness-thesis/` through `21-loop-engineering/`.
 
 ```text
 awesome-agent-architecture/
@@ -126,7 +130,7 @@ awesome-agent-architecture/
 ├── sections/                  # one folder per section
 │   ├── 00-harness-thesis/     # README.md per section
 │   ├── 01-agent-loop/src/     # runnable chain starts here
-│   └── 20-observability/
+│   └── 21-loop-engineering/
 └── references/                # primary sources and prior art
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -7,7 +7,7 @@
 <p align="center">
   <a href="#研究的系统"><img src="https://img.shields.io/badge/Focus-Harness_Engineering-6e40c9?style=for-the-badge" alt="Focus: Harness Engineering"></a>
   <a href="#研究的系统"><img src="https://img.shields.io/badge/Systems-2+-0a7bbb?style=for-the-badge" alt="Systems"></a>
-  <a href="#各章节"><img src="https://img.shields.io/badge/Sections-21-green?style=for-the-badge" alt="Sections"></a>
+  <a href="#各章节"><img src="https://img.shields.io/badge/Sections-22-green?style=for-the-badge" alt="Sections"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow?style=for-the-badge" alt="License"></a>
 </p>
 
@@ -34,8 +34,8 @@
 
 | 系统 | 大家为什么用它 | 值得看的地方 | 覆盖章节 | 维护者 |
 | --- | --- | --- | --- | --- |
-| **Claude Code** | 目前最强的 coding agent：改文件、跑命令，直接在真实 repo 里完成改动。 | 完整 harness 架构，从这里读起 | 0 到 20（全部） | Anthropic |
-| **Hermes Agent** | 长期助理：记得你、学会你的工作流程，还能跨平台跑任务。 | Memory, skill evolution, always-on channels | 7、9、14、16、19 | Nous Research |
+| **Claude Code** | 目前最强的 coding agent：改文件、跑命令，直接在真实 repo 里完成改动。 | 完整 harness 架构，从这里读起 | 0 到 21（全部） | Anthropic |
+| **Hermes Agent** | 长期助理：记得你、学会你的工作流程，还能跨平台跑任务。 | Memory, skill evolution, always-on channels | 7、9、14、16、19、21 | Nous Research |
 | *(更多陆续加入)* | | | | |
 
 > 之后可以再加入更多系统，例如 OpenClaw、aider 和 mini-swe-agent。
@@ -81,7 +81,7 @@ flowchart LR
 
 ## 各章节
 
-七层，从最基本的循环一路到多 agent 的 harness。每一行都链接到一篇可独立阅读的说明。
+八层，从最基本的循环一路到能自己运转的 harness。每一行都链接到一篇可独立阅读的说明。
 
 | # | 章节 | 问题 | 关键机制 |
 | --- | --- | --- | --- |
@@ -113,12 +113,14 @@ flowchart LR
 | | **第 6 层 · 扩展与集成** | | |
 | 19 | [MCP / plugins / channels](sections/19-mcp-plugins-channels/README.zh-CN.md) | harness 怎么连到外面的世界？ | Transports, channels, tool pool assembly |
 | 20 | [Observability & evaluation](sections/20-observability/README.zh-CN.md) | 我们怎么知道它有效？ | Tracing, metrics, evals, failure analysis |
+| | **第 7 层 · 组合** | | |
+| 21 | [Loop engineering](sections/21-loop-engineering/README.zh-CN.md) | 循环怎么叠成一个能自己运转的系统？ | Verification loop, triggers, budgets, maturity levels |
 
 ---
 
 ## 文件结构
 
-21 篇章节说明都已备齐，从 `00-harness-thesis/` 一路到 `20-observability/`。
+22 篇章节说明都已备齐，从 `00-harness-thesis/` 一路到 `21-loop-engineering/`。
 
 ```text
 awesome-agent-architecture/
@@ -126,20 +128,20 @@ awesome-agent-architecture/
 ├── sections/                  # 每个章节一个文件夹
 │   ├── 00-harness-thesis/     # 每章一份 README.md
 │   ├── 01-agent-loop/src/     # 可执行的代码链从这里开始
-│   └── 20-observability/
+│   └── 21-loop-engineering/
 └── references/                # 原始出处与前人成果
 ```
 
 每个章节文件夹都是 `NN-name/` 格式，里面有一份 `README.md`。
 
-第 1 到 20 章还带有可执行的 `src/`。代码一章一章累积上去。
+第 1 到 21 章还带有可执行的 `src/`。代码一章一章累积上去。
 每一章新增一个机制，并让 `loop.py` 演进，所以对比相邻两章的 diff，就能看出改了什么。
 
 ---
 
 ## 运行示范
 
-第 1 到 20 章都附有可执行的示范。从 repo 根目录配置一次就好：
+第 1 到 21 章都附有可执行的示范。从 repo 根目录配置一次就好：
 
 ```bash
 uv venv

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -7,7 +7,7 @@
 <p align="center">
   <a href="#研究的系統"><img src="https://img.shields.io/badge/Focus-Harness_Engineering-6e40c9?style=for-the-badge" alt="Focus: Harness Engineering"></a>
   <a href="#研究的系統"><img src="https://img.shields.io/badge/Systems-2+-0a7bbb?style=for-the-badge" alt="Systems"></a>
-  <a href="#各章節"><img src="https://img.shields.io/badge/Sections-21-green?style=for-the-badge" alt="Sections"></a>
+  <a href="#各章節"><img src="https://img.shields.io/badge/Sections-22-green?style=for-the-badge" alt="Sections"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow?style=for-the-badge" alt="License"></a>
 </p>
 
@@ -34,8 +34,8 @@
 
 | 系統                   | 大家為什麼用它                                                        | 值得看的地方                                | 覆蓋章節         | 維護者        |
 | ---------------------- | --------------------------------------------------------------------- | ------------------------------------------- | ---------------- | ------------- |
-| **Claude Code**  | 目前最強的 coding agent：改檔案、跑指令，直接在真實 repo 裡完成改動。 | 完整 harness 架構，從這裡讀起               | 0 到 20（全部）  | Anthropic     |
-| **Hermes Agent** | 長期助理：記得你、學會你的工作流程，還能跨平台跑任務。                | Memory, skill evolution, always-on channels | 7、9、14、16、19 | Nous Research |
+| **Claude Code**  | 目前最強的 coding agent：改檔案、跑指令，直接在真實 repo 裡完成改動。 | 完整 harness 架構，從這裡讀起               | 0 到 21（全部）  | Anthropic     |
+| **Hermes Agent** | 長期助理：記得你、學會你的工作流程，還能跨平台跑任務。                | Memory, skill evolution, always-on channels | 7、9、14、16、19、21 | Nous Research |
 | *(更多陸續加入)*     |                                                                       |                                             |                  |               |
 
 > 之後可以再加入更多系統，例如 OpenClaw、aider 和 mini-swe-agent。
@@ -81,7 +81,7 @@ flowchart LR
 
 ## 各章節
 
-七層，從最基本的迴圈一路到多 agent 的 harness。每一列都連到一篇可獨立閱讀的說明。
+八層，從最基本的迴圈一路到能自己運轉的 harness。每一列都連到一篇可獨立閱讀的說明。
 
 | #  | 章節                                                                      | 問題                           | 關鍵機制                                             |
 | -- | ------------------------------------------------------------------------- | ------------------------------ | ---------------------------------------------------- |
@@ -113,12 +113,14 @@ flowchart LR
 |    | **第 6 層 · 擴充與整合**                                           |                                |                                                      |
 | 19 | [MCP / plugins / channels](sections/19-mcp-plugins-channels/README.zh-TW.md) | harness 怎麼連到外面的世界？   | Transports, channels, tool pool assembly             |
 | 20 | [Observability &amp; evaluation](sections/20-observability/README.zh-TW.md)  | 我們怎麼知道它有效？           | Tracing, metrics, evals, failure analysis            |
+|    | **第 7 層 · 組合**                                                 |                                |                                                      |
+| 21 | [Loop engineering](sections/21-loop-engineering/README.zh-TW.md)             | 迴圈怎麼疊成一個能自己運轉的系統？ | Verification loop, triggers, budgets, maturity levels |
 
 ---
 
 ## 檔案結構
 
-21 篇章節說明都已備齊，從 `00-harness-thesis/` 一路到 `20-observability/`。
+22 篇章節說明都已備齊，從 `00-harness-thesis/` 一路到 `21-loop-engineering/`。
 
 ```text
 awesome-agent-architecture/
@@ -126,20 +128,20 @@ awesome-agent-architecture/
 ├── sections/                  # 每個章節一個資料夾
 │   ├── 00-harness-thesis/     # 每章一份 README.md
 │   ├── 01-agent-loop/src/     # 可執行的程式碼鏈從這裡開始
-│   └── 20-observability/
+│   └── 21-loop-engineering/
 └── references/                # 原始出處與前人成果
 ```
 
 每個章節資料夾都是 `NN-name/` 格式，裡面有一份 `README.md`。
 
-第 1 到 20 章還帶有可執行的 `src/`。程式碼一章一章累積上去。
+第 1 到 21 章還帶有可執行的 `src/`。程式碼一章一章累積上去。
 每一章新增一個機制，並讓 `loop.py` 演進，所以對比相鄰兩章的 diff，就能看出改了什麼。
 
 ---
 
 ## 執行示範
 
-第 1 到 20 章都附有可執行的示範。從 repo 根目錄設定一次就好：
+第 1 到 21 章都附有可執行的示範。從 repo 根目錄設定一次就好：
 
 ```bash
 uv venv

--- a/sections/21-loop-engineering/README.md
+++ b/sections/21-loop-engineering/README.md
@@ -44,31 +44,36 @@ Data moves outward. A trigger fires and enqueues a prompt. The agent loop produc
 A failure appends feedback and retries while budget remains. A pass delivers through the task's channel.
 The run's trace lands in telemetry, where the improvement loop reads it.
 
-### The verification loop
+### New: the verification loop
 
 The one loop earlier sections did not build. The inner loop stops when the model says it is done. The verification loop makes "done" a checked claim:
 
 ```python
-def verified_run(task, rubric, budget):
+def verified_run(task, worker, checker, budget=2):    # src/verify.py
     feedback = ""
-    for attempt in range(budget):
-        out = run_turn(task + feedback)          # the inner loop (section 1)
-        verdict = grade(out, rubric)             # a fresh checker agent (section 6)
-        if verdict.passed:
-            return out
-        feedback = f"\nPrior attempt failed: {verdict.reason}"
-    return escalate(task)                        # budget spent: report, do not retry forever
+    attempts = []
+    for n in range(1, budget + 1):                    # the ceiling: harness-enforced
+        out = worker(task + feedback)                 # the inner loop (section 1)
+        verdict = checker(task, out)                  # a separate checker (section 6)
+        attempts.append({"attempt": n, "passed": verdict["passed"], "reason": verdict["reason"]})
+        if verdict["passed"]:
+            return {"ok": True, "output": out, "attempts": attempts}
+        feedback = f"\n\nA prior attempt was rejected... Why it failed: {verdict['reason']}"
+    return {"ok": False, "output": None, "attempts": attempts}   # budget spent: escalate
 ```
 
 - The grader is a separate agent with a fresh context (section 6). A worker that grades its own output tends to pass it.
+  `agent_checker` builds one: each grade runs the inner loop on a new `messages[]`, with PASS or FAIL as the first word of the verdict.
 - The rubric is fixed outside the loop. The model can satisfy it, not rewrite it.
 - Feedback is data. The failed verdict rides into the retry as part of the prompt, so attempt two knows what attempt one got wrong.
+- `ok: False` is the escalation signal. The record of attempts goes to a human; the loop does not retry forever.
 
 ### Budgets and stop conditions
 
 Every loop needs a ceiling the model cannot talk its way past: an iteration count, a token budget, a wall-clock limit, or a dry counter (stop after K rounds that find nothing new).
 
 The harness enforces the ceiling. Asking the model to please stop is a hint, not a stop condition.
+In `verified_run` the ceiling is the `range()` bound: attempt `budget + 1` cannot happen.
 
 ### Maturity levels
 
@@ -89,6 +94,16 @@ This section adds no new primitive. It is the composition of earlier ones:
 - Parallel loops isolate in section 15 worktrees.
 - State between runs lives in section 9 memory and section 12 task records.
 - Reports and traces are section 20. The improvement loop closes section 20's measurements back into harness changes.
+
+The runnable wires it the same way. `run_turn` is byte-identical to section 20; verification wraps it from outside:
+
+```python
+def worker(prompt):                                # src/demo.py · the inner loop, unchanged
+    return run_turn([{"role": "user", "content": prompt}], model, reg, Session(mode=DEFAULT))
+
+checker = agent_checker(RUBRIC, model)             # a fresh grader agent, no tools
+result = verified_run("What is 27 + 15? Use the add tool.", worker, checker, budget=2)
+```
 
 What is new is the discipline: grade before done, budget before start, report always.
 
@@ -140,6 +155,23 @@ How each agent composes its outer loops.
   Mitigation: climb the maturity ladder one level at a time, gated by section 3 permissions.
 - **Silent drift.** An unattended loop degrades and nobody reads its output. Mitigation: heartbeats, always-delivered reports, and section 20 metrics on pass rate and cost.
 - **State amnesia.** Each run rediscovers the same work and redoes it. Mitigation: persist findings to memory or task records (sections 9, 12) and read them at run start.
+
+---
+
+## Runnable
+
+[`src/`](src/) carries 20 forward and adds:
+
+- [`verify.py`](src/verify.py): the verification loop (`verified_run`: grade, feedback retry, budget, escalate) and `agent_checker`, a fresh grader per verdict.
+- [`test.py`](src/test.py): offline checks for first-try pass, feedback reaching the retry, the budget ceiling, and the PASS/FAIL verdict contract.
+- [`demo.py`](src/demo.py): one live verified run: a worker with the add tool, a separate checker grading a fixed rubric, escalation when the budget is spent.
+
+The loop is unchanged. Verification wraps it from outside.
+
+```bash
+python sections/21-loop-engineering/src/test.py         # offline checks, no key
+uv run python sections/21-loop-engineering/src/demo.py  # live demo, needs a key
+```
 
 ---
 

--- a/sections/21-loop-engineering/README.md
+++ b/sections/21-loop-engineering/README.md
@@ -1,6 +1,6 @@
 # 21 · Loop engineering
 
-**English** · [繁體中文](README.zh-TW.md)
+**English** · [繁體中文](README.zh-TW.md) · [简体中文](README.zh-CN.md)
 
 > Stop writing the next prompt. Design the loop that runs the agent without you.
 

--- a/sections/21-loop-engineering/README.md
+++ b/sections/21-loop-engineering/README.md
@@ -1,0 +1,154 @@
+# 21 · Loop engineering
+
+> Stop writing the next prompt. Design the loop that runs the agent without you.
+
+Every earlier section adds one mechanism around one model call. This section composes them.
+
+Loop engineering names a shift in where the engineering effort goes.
+Instead of prompting an agent turn by turn, you build the outer system that discovers work, runs the agent, checks the output, and decides what happens next.
+The human moves from operator to designer.
+
+An outer loop must:
+
+1. Start runs from triggers, not only from a user (section 14).
+2. Check output before it counts as done.
+3. Stop on a budget, not on hope.
+4. Persist state so the next run continues instead of restarting (sections 9, 12).
+5. Report what happened, even when nobody was watching (section 20).
+
+Without this layer, a human is the outer loop. They prompt, read, judge, and retry by hand, and the agent stops working the moment they do.
+
+---
+
+## Mechanism
+
+The simple version: the agent loop, wrapped by three more loops. Each wraps the one inside it, and each answers a different question.
+
+1. **Agent loop** (section 1). Calls tools until the task looks done. Answers: how does one step get done.
+2. **Verification loop.** Grades the output against a rubric. A failure feeds back into a retry, up to a budget. Answers: is it actually done.
+3. **Event loop.** Cron schedules, webhooks, and channels start runs (section 14, section 19). Answers: when does work start.
+4. **Improvement loop.** Traces and evals (section 20) feed changes to the harness config, skills, or model. Answers: does the system get better.
+
+```mermaid
+flowchart LR
+    E["trigger · cron, webhook, channel"] --> A["agent loop"]
+    A --> O["candidate output"] --> G{"grader"}
+    G -->|"fail · budget left"| A
+    G -->|"budget spent"| X["escalate to human"]
+    G -->|"pass"| D["deliver"]
+    D --> T[("traces")]
+    T -.->|"tune harness"| E
+```
+
+Data moves outward. A trigger fires and enqueues a prompt. The agent loop produces a candidate. The grader scores it.
+A failure appends feedback and retries while budget remains. A pass delivers through the task's channel.
+The run's trace lands in telemetry, where the improvement loop reads it.
+
+### The verification loop
+
+The one loop earlier sections did not build. The inner loop stops when the model says it is done. The verification loop makes "done" a checked claim:
+
+```python
+def verified_run(task, rubric, budget):
+    feedback = ""
+    for attempt in range(budget):
+        out = run_turn(task + feedback)          # the inner loop (section 1)
+        verdict = grade(out, rubric)             # a fresh checker agent (section 6)
+        if verdict.passed:
+            return out
+        feedback = f"\nPrior attempt failed: {verdict.reason}"
+    return escalate(task)                        # budget spent: report, do not retry forever
+```
+
+- The grader is a separate agent with a fresh context (section 6). A worker that grades its own output tends to pass it.
+- The rubric is fixed outside the loop. The model can satisfy it, not rewrite it.
+- Feedback is data. The failed verdict rides into the retry as part of the prompt, so attempt two knows what attempt one got wrong.
+
+### Budgets and stop conditions
+
+Every loop needs a ceiling the model cannot talk its way past: an iteration count, a token budget, a wall-clock limit, or a dry counter (stop after K rounds that find nothing new).
+
+The harness enforces the ceiling. Asking the model to please stop is a hint, not a stop condition.
+
+### Maturity levels
+
+The loop-engineering sources grade loops by how much they are trusted to do:
+
+- **L1 · Report.** The loop reads and reports. A human acts.
+- **L2 · Assisted.** The loop drafts the change. A human approves it.
+- **L3 · Unattended.** The loop acts. A human audits after the fact.
+
+The level is a permissions decision (section 3). Promote a loop one level only after its output at the current level has been boringly correct.
+
+### How it integrates
+
+This section adds no new primitive. It is the composition of earlier ones:
+
+- Triggers are section 14 schedules and section 19 channels.
+- The worker is the section 1 loop, with section 6 subagents as the maker and checker split.
+- Parallel loops isolate in section 15 worktrees.
+- State between runs lives in section 9 memory and section 12 task records.
+- Reports and traces are section 20. The improvement loop closes section 20's measurements back into harness changes.
+
+What is new is the discipline: grade before done, budget before start, report always.
+
+---
+
+## Per system
+
+How each agent composes its outer loops.
+
+| System | Verification | Event loop | Improvement loop |
+| --- | --- | --- | --- |
+| **Claude Code** | Scripted verify stages with adversarial patterns. | Cron, self-paced wakeups, remote triggers. | Resumable workflow runs; no closed loop in source. |
+| **Hermes Agent** | Maker and checker via delegation; no built-in grader. | Gateway cron with restricted toolsets. | A curator agent consolidates skills from usage. |
+
+### Claude Code
+
+- `/loop <interval> <prompt>` re-runs a prompt on a cadence. Without an interval, the model self-paces with `ScheduleWakeup`, and `stop: true` ends the loop.
+- Sentinel prompts (`<<autonomous-loop>>`, `<<autonomous-loop-dynamic>>`) resolve loop instructions at fire time instead of freezing them at create time.
+- The `Workflow` tool scripts composition directly: `agent()`, `pipeline()`, and `parallel()` fan work out.
+  Its documented quality patterns are verification loops by name: adversarial verify, judge panel, loop-until-dry.
+- `budget.remaining()` makes a token target a hard ceiling. Past it, `agent()` throws.
+- A lifetime cap of 1000 agents per workflow backstops a runaway script.
+- `resumeFromRunId` replays completed `agent()` calls from cache, so a fixed script resumes instead of restarting.
+- Cron entries and remote triggers (section 14) supply the event loop.
+
+### Hermes Agent
+
+- `agent/iteration_budget.py` caps inner-loop iterations. The ceiling is harness-side.
+- `cron/scheduler.py` fires jobs with restricted toolsets, and `[SILENT]` suppresses delivery when a run finds nothing (section 14).
+- Watch patterns in `tools/process_registry.py` wake the agent on matching process output, rate limited with a circuit breaker.
+- There is no built-in grade-and-retry loop. Checking runs through `delegate_task()` maker and checker splits (section 6) and offline tests.
+- The improvement loop is the skill curator. `tools/skill_manager_tool.py` forks a background review agent that consolidates and prunes skills from usage.
+  `hermes_cli/curator.py` can pin, archive, and roll back what it changes.
+- `agent/trajectory.py` and `trajectory_compressor.py` turn runs into training data, closing the loop into the model itself.
+
+> **Trade-off:** an unattended loop multiplies output and multiplies mistakes at the same rate.
+> Verification and budgets are what make L3 safe to leave running.
+> A loop without a grader automates the work. A loop without a budget automates the bill.
+
+---
+
+## Failure modes
+
+- **No stop condition.** A retry loop with no ceiling burns tokens until someone notices the invoice. Mitigation: harness-enforced iteration, token, and time budgets.
+- **Self-grading.** The worker passes its own output, so the verification loop verifies nothing. Mitigation: a separate checker agent and a rubric fixed outside the loop.
+- **Rubber-stamp rubric.** A grader that always passes is worse than none, because it labels bad output as verified.
+  Mitigation: adversarial verify (prompt the checker to refute) and periodic human spot checks.
+- **Unattended too early.** A loop gets L3 write access before its L1 reports were ever checked.
+  Mitigation: climb the maturity ladder one level at a time, gated by section 3 permissions.
+- **Silent drift.** An unattended loop degrades and nobody reads its output. Mitigation: heartbeats, always-delivered reports, and section 20 metrics on pass rate and cost.
+- **State amnesia.** Each run rediscovers the same work and redoes it. Mitigation: persist findings to memory or task records (sections 9, 12) and read them at run start.
+
+---
+
+## Sources
+
+- cobusgreyling · loop-engineering: building blocks, seven production loop patterns, L1 to L3 readiness levels.
+- LangChain · The art of loop engineering: the four stacked loops (agent, verification, event-driven, hill climbing).
+- Addy Osmani · Loop engineering: composing automations, worktrees, skills, connectors, sub-agents, and state.
+- MindStudio · What is loop engineering: goal conditions and the control-theory framing.
+- Claude Code: `/loop` skill, `ScheduleWakeup`, `Workflow` tool schema (`agent`, `pipeline`, `budget`, quality patterns).
+  Described from tool schemas and documented behavior, not the source backup.
+- Hermes Agent source: `agent/iteration_budget.py`, `cron/scheduler.py`, `tools/skill_manager_tool.py`, `hermes_cli/curator.py`, `agent/trajectory.py`.

--- a/sections/21-loop-engineering/README.md
+++ b/sections/21-loop-engineering/README.md
@@ -28,6 +28,8 @@ The simple version: the agent loop, wrapped by three more loops. Each wraps the 
 2. **Verification loop.** Grades the output against a rubric. A failure feeds back into a retry, up to a budget. Answers: is it actually done.
 3. **Event loop.** Cron schedules, webhooks, and channels start runs (section 14, section 19). Answers: when does work start.
 4. **Improvement loop.** Traces and evals (section 20) feed changes to the harness config, skills, or model. Answers: does the system get better.
+   At its mature end this loop edits the harness itself: mine weaknesses from traces, propose a bounded edit, validate it against a regression set.
+   The loop structure becomes a search space, not a hand-designed template.
 
 ```mermaid
 flowchart LR
@@ -155,6 +157,8 @@ How each agent composes its outer loops.
   Mitigation: climb the maturity ladder one level at a time, gated by section 3 permissions.
 - **Silent drift.** An unattended loop degrades and nobody reads its output. Mitigation: heartbeats, always-delivered reports, and section 20 metrics on pass rate and cost.
 - **State amnesia.** Each run rediscovers the same work and redoes it. Mitigation: persist findings to memory or task records (sections 9, 12) and read them at run start.
+- **Self-editing harness escapes its gates.** An improvement loop that can modify harness code can modify the code that gates it.
+  Mitigation: permissions and budgets live outside anything the loop can edit (section 3).
 
 ---
 
@@ -181,5 +185,6 @@ uv run python sections/21-loop-engineering/src/demo.py  # live demo, needs a key
 - [LangChain · The art of loop engineering](https://www.langchain.com/blog/the-art-of-loop-engineering): the four stacked loops.
 - [Addy Osmani · Loop engineering](https://addyosmani.com/blog/loop-engineering/): the composed building blocks.
 - [MindStudio · What is loop engineering](https://www.mindstudio.ai/blog/what-is-loop-engineering-autonomous-ai-agent-workflows): goal conditions.
+- [Lilian Weng · Harness engineering for self-improvement](https://lilianweng.github.io/posts/2026-07-04-harness/): the improvement loop in depth; gates outside the loop.
 - Claude Code: `/loop`, `ScheduleWakeup`, `Workflow` schema. From tool schemas and documented behavior, not the source backup.
 - Hermes Agent source: `agent/iteration_budget.py`, `cron/scheduler.py`, `tools/skill_manager_tool.py`, `hermes_cli/curator.py`, `agent/trajectory.py`.

--- a/sections/21-loop-engineering/README.md
+++ b/sections/21-loop-engineering/README.md
@@ -1,5 +1,7 @@
 # 21 · Loop engineering
 
+**English** · [繁體中文](README.zh-TW.md)
+
 > Stop writing the next prompt. Design the loop that runs the agent without you.
 
 Every earlier section adds one mechanism around one model call. This section composes them.

--- a/sections/21-loop-engineering/README.md
+++ b/sections/21-loop-engineering/README.md
@@ -145,10 +145,9 @@ How each agent composes its outer loops.
 
 ## Sources
 
-- cobusgreyling · loop-engineering: building blocks, seven production loop patterns, L1 to L3 readiness levels.
-- LangChain · The art of loop engineering: the four stacked loops (agent, verification, event-driven, hill climbing).
-- Addy Osmani · Loop engineering: composing automations, worktrees, skills, connectors, sub-agents, and state.
-- MindStudio · What is loop engineering: goal conditions and the control-theory framing.
-- Claude Code: `/loop` skill, `ScheduleWakeup`, `Workflow` tool schema (`agent`, `pipeline`, `budget`, quality patterns).
-  Described from tool schemas and documented behavior, not the source backup.
+- [cobusgreyling/loop-engineering](https://github.com/cobusgreyling/loop-engineering): building blocks and readiness levels.
+- [LangChain · The art of loop engineering](https://www.langchain.com/blog/the-art-of-loop-engineering): the four stacked loops.
+- [Addy Osmani · Loop engineering](https://addyosmani.com/blog/loop-engineering/): the composed building blocks.
+- [MindStudio · What is loop engineering](https://www.mindstudio.ai/blog/what-is-loop-engineering-autonomous-ai-agent-workflows): goal conditions.
+- Claude Code: `/loop`, `ScheduleWakeup`, `Workflow` schema. From tool schemas and documented behavior, not the source backup.
 - Hermes Agent source: `agent/iteration_budget.py`, `cron/scheduler.py`, `tools/skill_manager_tool.py`, `hermes_cli/curator.py`, `agent/trajectory.py`.

--- a/sections/21-loop-engineering/README.zh-CN.md
+++ b/sections/21-loop-engineering/README.zh-CN.md
@@ -1,0 +1,192 @@
+# 21 · Loop engineering
+
+[English](README.md) · [繁體中文](README.zh-TW.md) · **简体中文**
+
+> 别再想下一句 prompt 要写什么。去设计那个不需要你也能把 agent 跑起来的 loop。
+
+前面每一章都是在一次 model 调用的周围加上一个机制。这一章把它们组合起来。
+
+Loop engineering 说的是工程重心的转移。
+与其一个 turn 一个 turn 地下 prompt，不如打造外层系统：由它找出要做的工作、把 agent 跑起来、检查输出，再决定下一步。
+人从操作者变成设计者。
+
+外层 loop 必须：
+
+1. 由 trigger 启动执行，而不是只靠 user（第 14 章）。
+2. 输出要先通过检查，才算完成。
+3. 靠 budget（预先设好的花费上限）停下来，而不是靠运气。
+4. 把状态存下来，让下一次执行接着做，而不是从头来过（第 9、12 章）。
+5. 就算没人在看，也要报告发生了什么（第 20 章）。
+
+少了这一层，外层 loop 就是人本身：下 prompt、读输出、判断、重试都靠手动。人一停下来，agent 也跟着停。
+
+---
+
+## 机制
+
+最简单的说法：agent loop 外面再包三层 loop。一层包着一层，每一层回答一个不同的问题。
+
+1. **Agent loop**（第 1 章）：调用 tool 直到任务看起来完成。回答的是：这一步怎么做完。
+2. **验证 loop（verification loop）**：拿 rubric（评分准则）为输出评分。没过就带着 feedback 重试，最多试到 budget 用完。回答的是：是不是真的完成了。
+3. **事件 loop（event loop）**：cron 调度、webhook 和 channel 负责启动执行（第 14、19 章）。回答的是：工作什么时候开始。
+4. **改进 loop（improvement loop）**：trace 和 eval（第 20 章）回头改 harness 配置、skill 或 model。回答的是：整个系统有没有变好。
+   这个 loop 成熟到极致时，改的是 harness 本身：从 trace 里挖出弱点、提出一个范围受限的修改、再用 regression 测试验证。
+   loop 的结构本身变成一个可以搜索的空间，而不是手工设计的模板。
+
+```mermaid
+flowchart LR
+    E["trigger · cron, webhook, channel"] --> A["agent loop"]
+    A --> O["candidate output"] --> G{"grader"}
+    G -->|"fail · budget left"| A
+    G -->|"budget spent"| X["escalate to human"]
+    G -->|"pass"| D["deliver"]
+    D --> T[("traces")]
+    T -.->|"tune harness"| E
+```
+
+数据由内往外流。trigger fire 之后把一个 prompt 放进 queue。agent loop 产出一个候选输出，评分者为它打分。
+没过而且 budget 还有剩，就带着 feedback 重试；过了就通过该 task 的 channel 投递出去。
+这次执行做了什么，会记录成 trace 留在 telemetry（第 20 章）。改进 loop 之后就是读这些记录，来决定 harness 哪里该改。
+
+### New：验证 loop
+
+这是前面章节唯一没做过的 loop。内层 loop 是 model 自己说完成就停。有了验证 loop，“完成”不再是 model 说了算，要通过检查才算数：
+
+```python
+def verified_run(task, worker, checker, budget=2):    # src/verify.py
+    feedback = ""
+    attempts = []
+    for n in range(1, budget + 1):                    # the ceiling: harness-enforced
+        out = worker(task + feedback)                 # the inner loop (section 1)
+        verdict = checker(task, out)                  # a separate checker (section 6)
+        attempts.append({"attempt": n, "passed": verdict["passed"], "reason": verdict["reason"]})
+        if verdict["passed"]:
+            return {"ok": True, "output": out, "attempts": attempts}
+        feedback = f"\n\nA prior attempt was rejected... Why it failed: {verdict['reason']}"
+    return {"ok": False, "output": None, "attempts": attempts}   # budget spent: escalate
+```
+
+- 评分者是另一个 agent，用全新的 context（第 6 章）。让 worker 评自己的输出，多半都会给过。
+  `agent_checker` 做的就是这件事：每次评分都在新的 `messages[]` 上跑内层 loop，verdict 的第一个词是 PASS 或 FAIL。
+- rubric 定在 loop 之外。model 只能想办法满足它，不能改写它。
+- feedback 是数据。没过的 verdict 会并进重试的 prompt，所以第二次尝试知道第一次错在哪。
+- `ok: False` 是要交给人接手的信号。尝试记录会一并交出去；loop 不会永远重试下去。
+
+### Budget 与停止条件
+
+每个 loop 都需要一个 model 说什么都绕不过去的上限：迭代次数、token budget、时间上限，或 dry counter（连续 K 轮都没有新发现就停）。
+
+上限由 harness 强制执行。拜托 model 自己停下来只是提示，不是停止条件。
+在 `verified_run` 里，上限就是 `range()` 的边界：第 `budget + 1` 次尝试不可能发生。
+
+### 成熟度等级
+
+Loop engineering 的几个出处都用“敢让它做多少事”来给 loop 分级：
+
+- **L1 · 报告：**loop 只读取和报告。动手的是人。
+- **L2 · 协作：**loop 起草修改。由人批准。
+- **L3 · 无人看管：**loop 直接动手。人事后审计。
+
+等级是一个权限决定（第 3 章）。只有在当前等级的输出已经稳定到让人觉得无聊时，才把 loop 升一级。
+
+### 如何整合
+
+这一章没有加任何新的基本组件。它是前面各章的组合：
+
+- trigger 是第 14 章的 schedule 和第 19 章的 channel。
+- worker 是第 1 章的 loop；maker 和 checker 的分工用第 6 章的 subagent。
+- 并行的 loop 用第 15 章的 worktree 隔离。
+- 执行之间的状态放在第 9 章的记忆和第 12 章的 task 记录。
+- 报告和 trace 是第 20 章。改进 loop 把第 20 章测到的东西接回 harness 的修改。
+
+可执行的 src 也是同样的组合方式。`run_turn` 完全没改，跟第 20 章一模一样；`verified_run` 只是在外面多包一层验证：
+
+```python
+def worker(prompt):                                # src/demo.py · the inner loop, unchanged
+    return run_turn([{"role": "user", "content": prompt}], model, reg, Session(mode=DEFAULT))
+
+checker = agent_checker(RUBRIC, model)             # a fresh grader agent, no tools
+result = verified_run("What is 27 + 15? Use the add tool.", worker, checker, budget=2)
+```
+
+这一章新加的是纪律：说完成之前先评分、开始之前先设 budget、无论如何都要报告。
+
+---
+
+## 各系统做法
+
+各个 agent 如何组合自己的外层 loop。
+
+| System | 验证 | 事件 loop | 改进 loop |
+| --- | --- | --- | --- |
+| **Claude Code** | 以代码编排的 verify 阶段，含对抗式模式。 | Cron、自定节奏唤醒、remote trigger。 | workflow 可断点续跑；源码中没有闭环。 |
+| **Hermes Agent** | 靠 delegation 分出 maker 和 checker；没有内置评分者。 | gateway cron 加受限 toolset。 | curator agent 从使用情况整合 skill。 |
+
+### Claude Code
+
+- `/loop <interval> <prompt>` 让一个 prompt 按节奏重复执行。不给 interval 时，model 用 `ScheduleWakeup` 自定节奏，`stop: true` 结束 loop。
+- 哨兵 prompt（`<<autonomous-loop>>`、`<<autonomous-loop-dynamic>>`）在 fire 的时刻才解析 loop 指令，而不是在创建时就把内容冻结。
+- `Workflow` tool 直接用代码描述组合方式：`agent()`、`pipeline()` 和 `parallel()` 把工作扇出。
+  它文档里的质量模式本身就是各种验证 loop：adversarial verify、judge panel、loop-until-dry。
+- `budget.remaining()` 把 token 目标变成硬上限。超过之后，`agent()` 会直接抛出错误。
+- 每个 workflow 一生最多 1000 个 agent，为失控的 workflow 兜底。
+- `resumeFromRunId` 会从缓存重放已完成的 `agent()` 调用，所以修好的 workflow 是接着跑，不是从头跑。
+- 事件 loop 由 cron 条目和 remote trigger（第 14 章）提供。
+
+### Hermes Agent
+
+- `agent/iteration_budget.py` 限制内层 loop 的迭代次数。上限在 harness 这一侧。
+- `cron/scheduler.py` 用受限的 toolset fire job；执行后没发现值得说的东西时，`[SILENT]` 会抑制投递（第 14 章）。
+- `tools/process_registry.py` 的 watch pattern 在 process 输出匹配到时唤醒 agent，带 rate limit 和 circuit breaker。
+- 没有内置的评分重试 loop。检查靠 `delegate_task()` 的 maker 和 checker 分工（第 6 章）和离线测试。
+- 改进 loop 是 skill curator：`tools/skill_manager_tool.py` fork 一个后台审查 agent，从使用情况整合、修剪 skill。
+  `hermes_cli/curator.py` 可以 pin、归档和回滚它改过的东西。
+- `agent/trajectory.py` 和 `trajectory_compressor.py` 把执行过程变成训练数据，把这个 loop 一路闭合到 model 本身。
+
+> **取舍：**无人看管的 loop 把产出放大几倍，也把错误放大几倍。
+> 让 L3 可以放着跑的，正是验证和 budget。
+> 没有评分者的 loop，自动化的是工作；没有 budget 的 loop，自动化的是账单。
+
+---
+
+## 失效模式
+
+- **没有停止条件（No stop condition）：**没有上限的重试 loop 会一直烧 token，直到有人看到账单。缓解：由 harness 强制执行的迭代、token 和时间 budget。
+- **自己评自己（Self-grading）：**worker 给自己的输出打分，验证 loop 等于什么都没验。缓解：独立的 checker agent，加上定在 loop 之外的 rubric。
+- **评什么都过（Rubber-stamp rubric）：**永远给过的评分者比没有还糟，因为它给烂输出盖上“已验证”的章。
+  缓解：对抗式验证（要求 checker 想办法推翻），加上定期的人工抽查。
+- **太早放手（Unattended too early）：**L1 的报告从来没人核对过，loop 就拿到了 L3 的写入权限。
+  缓解：成熟度阶梯一次只升一级，由第 3 章的权限把关。
+- **无声劣化（Silent drift）：**无人看管的 loop 越跑越差，却没有人读它的输出。缓解：heartbeat、一律投递的报告，以及第 20 章对通过率和成本的度量。
+- **状态失忆（State amnesia）：**每次执行都重新发现同样的工作、重做一遍。缓解：把发现存进记忆或 task 记录（第 9、12 章），并在执行开始时读取。
+- **自我修改的 harness 绕过关卡（Self-editing harness escapes its gates）：**能改 harness 代码的改进 loop，也能改那些把关它的代码。
+  缓解：权限和 budget 放在这个 loop 改不到的地方（第 3 章）。
+
+---
+
+## 可执行程序
+
+[`src/`](src/) 把 20 带了过来，并加上：
+
+- [`verify.py`](src/verify.py)：验证 loop（`verified_run`：评分、带 feedback 重试、budget、交回给人）和 `agent_checker`，每个 verdict 都由一个全新的评分者做出。
+- [`test.py`](src/test.py)：离线检查第一次就通过、feedback 有进到重试、budget 上限，以及 PASS/FAIL 的 verdict 约定。
+- [`demo.py`](src/demo.py)：实际跑一次 verified run：worker 带着 add tool，独立的 checker 按固定 rubric 评分，budget 用完就交回给人。
+
+loop 本身完全没改，验证那一层是包在外面的。
+
+```bash
+python sections/21-loop-engineering/src/test.py         # offline checks, no key
+uv run python sections/21-loop-engineering/src/demo.py  # live demo, needs a key
+```
+
+---
+
+## 出处
+
+- [cobusgreyling/loop-engineering](https://github.com/cobusgreyling/loop-engineering)：building block 与成熟度分级。
+- [LangChain · The art of loop engineering](https://www.langchain.com/blog/the-art-of-loop-engineering)：四层堆叠的 loop。
+- [Addy Osmani · Loop engineering](https://addyosmani.com/blog/loop-engineering/)：building block 的组合方式。
+- [MindStudio · What is loop engineering](https://www.mindstudio.ai/blog/what-is-loop-engineering-autonomous-ai-agent-workflows)：目标条件。
+- [Lilian Weng · Harness engineering for self-improvement](https://lilianweng.github.io/posts/2026-07-04-harness/)：深入讲改进 loop；关卡要放在 loop 之外。
+- Claude Code：`/loop` skill、`ScheduleWakeup`、`Workflow` schema。依据 tool schema 与文档记载的行为描述，非 source backup。
+- Hermes Agent 源码：`agent/iteration_budget.py`、`cron/scheduler.py`、`tools/skill_manager_tool.py`、`hermes_cli/curator.py`、`agent/trajectory.py`。

--- a/sections/21-loop-engineering/README.zh-TW.md
+++ b/sections/21-loop-engineering/README.zh-TW.md
@@ -1,6 +1,6 @@
 # 21 · Loop engineering
 
-[English](README.md) · **繁體中文**
+[English](README.md) · **繁體中文** · [简体中文](README.zh-CN.md)
 
 > 別再想下一句 prompt 要寫什麼。去設計那個不需要你也能把 agent 跑起來的 loop。
 

--- a/sections/21-loop-engineering/README.zh-TW.md
+++ b/sections/21-loop-engineering/README.zh-TW.md
@@ -7,7 +7,7 @@
 前面每一章都是在一次 model 呼叫的周圍加上一個機制。這一章把它們組合起來。
 
 Loop engineering 說的是工程重心的轉移。
-與其一個 turn 一個 turn 地下 prompt，不如打造外層系統：由它找出要做的工作、把 agent 跑起來、檢查輸出，再決定下一步。
+與其一個 turn 一個 turn 的下 prompt，不如打造外層系統：由它找出要做的工作、把 agent 跑起來、檢查輸出，再決定下一步。
 人從操作者變成設計者。
 
 外層 loop 必須：
@@ -46,7 +46,7 @@ flowchart LR
 
 資料由內往外流。trigger fire 之後把一個 prompt 放進 queue。agent loop 產出一個候選輸出，評分者替它打分數。
 沒過而且 budget 還有剩，就帶著 feedback 重試；過了就透過該 task 的 channel 投遞出去。
-這次執行的 trace 會進到 telemetry，改進 loop 再從那裡讀。
+這次執行做了什麼，會記錄成 trace 留在 telemetry（第 20 章）。改進 loop 之後就是讀這些紀錄，來決定 harness 哪裡該改。
 
 ### New：驗證 loop
 
@@ -117,10 +117,10 @@ result = verified_run("What is 27 + 15? Use the add tool.", worker, checker, bud
 
 各個 agent 如何組合自己的外層 loop。
 
-| System | 驗證 | 事件 loop | 改進 loop |
-| --- | --- | --- | --- |
-| **Claude Code** | 以程式編排的 verify 階段，含對抗式模式。 | Cron、自訂節奏喚醒、remote trigger。 | workflow 可斷點續跑；原始碼中沒有閉環。 |
-| **Hermes Agent** | 靠 delegation 分出 maker 和 checker；沒有內建評分者。 | gateway cron 加受限 toolset。 | curator agent 從使用情況整併 skill。 |
+| System                 | 驗證                                                  | 事件 loop                            | 改進 loop                               |
+| ---------------------- | ----------------------------------------------------- | ------------------------------------ | --------------------------------------- |
+| **Claude Code**  | 以程式編排的 verify 階段，含對抗式模式。              | Cron、自訂節奏喚醒、remote trigger。 | workflow 可斷點續跑；原始碼中沒有閉環。 |
+| **Hermes Agent** | 靠 delegation 分出 maker 和 checker；沒有內建評分者。 | gateway cron 加受限 toolset。        | curator agent 從使用情況整併 skill。    |
 
 ### Claude Code
 

--- a/sections/21-loop-engineering/README.zh-TW.md
+++ b/sections/21-loop-engineering/README.zh-TW.md
@@ -1,0 +1,192 @@
+# 21 · Loop engineering
+
+[English](README.md) · **繁體中文**
+
+> 別再想下一句 prompt 要寫什麼。去設計那個不需要你也能把 agent 跑起來的 loop。
+
+前面每一章都是在一次 model 呼叫的周圍加上一個機制。這一章把它們組合起來。
+
+Loop engineering 說的是工程重心的轉移。
+與其一個 turn 一個 turn 地下 prompt，不如打造外層系統：由它找出要做的工作、把 agent 跑起來、檢查輸出，再決定下一步。
+人從操作者變成設計者。
+
+外層 loop 必須：
+
+1. 由 trigger 啟動執行，而不是只靠 user（第 14 章）。
+2. 輸出要先通過檢查，才算完成。
+3. 靠 budget（預先設好的花費上限）停下來，而不是靠運氣。
+4. 把狀態存下來，讓下一次執行接著做，而不是從頭來過（第 9、12 章）。
+5. 就算沒人在看，也要回報發生了什麼（第 20 章）。
+
+少了這一層，外層 loop 就是人本身：下 prompt、讀輸出、判斷、重試都靠手動。人一停下來，agent 也跟著停。
+
+---
+
+## 機制
+
+最簡單的說法：agent loop 外面再包三層 loop。一層包著一層，每一層回答一個不同的問題。
+
+1. **Agent loop**（第 1 章）：呼叫 tool 直到任務看起來完成。回答的是：這一步怎麼做完。
+2. **驗證 loop（verification loop）**：拿 rubric（評分準則）替輸出評分。沒過就帶著 feedback 重試，最多試到 budget 用完。回答的是：是不是真的完成了。
+3. **事件 loop（event loop）**：cron 排程、webhook 和 channel 負責啟動執行（第 14、19 章）。回答的是：工作什麼時候開始。
+4. **改進 loop（improvement loop）**：trace 和 eval（第 20 章）回頭改 harness 設定、skill 或 model。回答的是：整個系統有沒有變好。
+   這個 loop 成熟到極致時，改的是 harness 本身：從 trace 裡挖出弱點、提出一個範圍受限的修改、再用 regression 測試驗證。
+   loop 的結構本身變成一個可以搜尋的空間，而不是手工設計的模板。
+
+```mermaid
+flowchart LR
+    E["trigger · cron, webhook, channel"] --> A["agent loop"]
+    A --> O["candidate output"] --> G{"grader"}
+    G -->|"fail · budget left"| A
+    G -->|"budget spent"| X["escalate to human"]
+    G -->|"pass"| D["deliver"]
+    D --> T[("traces")]
+    T -.->|"tune harness"| E
+```
+
+資料由內往外流。trigger fire 之後把一個 prompt 放進 queue。agent loop 產出一個候選輸出，評分者替它打分數。
+沒過而且 budget 還有剩，就帶著 feedback 重試；過了就透過該 task 的 channel 投遞出去。
+這次執行的 trace 會進到 telemetry，改進 loop 再從那裡讀。
+
+### New：驗證 loop
+
+這是前面章節唯一沒做過的 loop。內層 loop 是 model 自己說完成就停。驗證 loop 把「完成」變成要通過檢查才算數的宣稱：
+
+```python
+def verified_run(task, worker, checker, budget=2):    # src/verify.py
+    feedback = ""
+    attempts = []
+    for n in range(1, budget + 1):                    # the ceiling: harness-enforced
+        out = worker(task + feedback)                 # the inner loop (section 1)
+        verdict = checker(task, out)                  # a separate checker (section 6)
+        attempts.append({"attempt": n, "passed": verdict["passed"], "reason": verdict["reason"]})
+        if verdict["passed"]:
+            return {"ok": True, "output": out, "attempts": attempts}
+        feedback = f"\n\nA prior attempt was rejected... Why it failed: {verdict['reason']}"
+    return {"ok": False, "output": None, "attempts": attempts}   # budget spent: escalate
+```
+
+- 評分者是另一個 agent，用全新的 context（第 6 章）。讓 worker 評自己的輸出，多半都會給過。
+  `agent_checker` 做的就是這件事：每次評分都在新的 `messages[]` 上跑內層 loop，verdict 的第一個字是 PASS 或 FAIL。
+- rubric 定在 loop 之外。model 只能想辦法滿足它，不能改寫它。
+- feedback 是資料。沒過的 verdict 會併進重試的 prompt，所以第二次嘗試知道第一次錯在哪。
+- `ok: False` 是要交給人接手的訊號。嘗試紀錄會一併交出去；loop 不會永遠重試下去。
+
+### Budget 與停止條件
+
+每個 loop 都需要一個 model 說什麼都繞不過去的上限：迭代次數、token budget、時間上限，或 dry counter（連續 K 輪都沒有新發現就停）。
+
+上限由 harness 強制執行。拜託 model 自己停下來只是提示，不是停止條件。
+在 `verified_run` 裡，上限就是 `range()` 的邊界：第 `budget + 1` 次嘗試不可能發生。
+
+### 成熟度等級
+
+Loop engineering 的幾個出處都用「敢讓它做多少事」來替 loop 分級：
+
+- **L1 · 回報：**loop 只讀取和回報。動手的是人。
+- **L2 · 協作：**loop 起草修改。由人核准。
+- **L3 · 無人看管：**loop 直接動手。人事後稽核。
+
+等級是一個權限決定（第 3 章）。只有在目前等級的輸出已經穩定到讓人覺得無聊時，才把 loop 升一級。
+
+### 如何整合
+
+這一章沒有加任何新的基本元件。它是前面各章的組合：
+
+- trigger 是第 14 章的 schedule 和第 19 章的 channel。
+- worker 是第 1 章的 loop；maker 和 checker 的分工用第 6 章的 subagent。
+- 平行的 loop 用第 15 章的 worktree 隔離。
+- 執行之間的狀態放在第 9 章的記憶和第 12 章的 task 紀錄。
+- 回報和 trace 是第 20 章。改進 loop 把第 20 章量到的東西接回 harness 的修改。
+
+可執行程式也是這樣接的。`run_turn` 和第 20 章一模一樣；驗證從外面把它包起來：
+
+```python
+def worker(prompt):                                # src/demo.py · the inner loop, unchanged
+    return run_turn([{"role": "user", "content": prompt}], model, reg, Session(mode=DEFAULT))
+
+checker = agent_checker(RUBRIC, model)             # a fresh grader agent, no tools
+result = verified_run("What is 27 + 15? Use the add tool.", worker, checker, budget=2)
+```
+
+這一章新加的是紀律：說完成之前先評分、開始之前先設 budget、無論如何都要回報。
+
+---
+
+## 各系統做法
+
+各個 agent 如何組合自己的外層 loop。
+
+| System | 驗證 | 事件 loop | 改進 loop |
+| --- | --- | --- | --- |
+| **Claude Code** | 以程式編排的 verify 階段，含對抗式模式。 | Cron、自訂節奏喚醒、remote trigger。 | workflow 可斷點續跑；原始碼中沒有閉環。 |
+| **Hermes Agent** | 靠 delegation 分出 maker 和 checker；沒有內建評分者。 | gateway cron 加受限 toolset。 | curator agent 從使用情況整併 skill。 |
+
+### Claude Code
+
+- `/loop <interval> <prompt>` 讓一個 prompt 按節奏重複執行。不給 interval 時，model 用 `ScheduleWakeup` 自訂節奏，`stop: true` 結束 loop。
+- 哨兵 prompt（`<<autonomous-loop>>`、`<<autonomous-loop-dynamic>>`）在 fire 的時刻才解析 loop 指令，而不是在建立時就把內容凍結。
+- `Workflow` tool 直接用程式描述組合方式：`agent()`、`pipeline()` 和 `parallel()` 把工作扇出。
+  它文件裡的品質模式本身就是各種驗證 loop：adversarial verify、judge panel、loop-until-dry。
+- `budget.remaining()` 把 token 目標變成硬上限。超過之後，`agent()` 會直接拋出錯誤。
+- 每個 workflow 一生最多 1000 個 agent，替失控的 workflow 兜底。
+- `resumeFromRunId` 會從快取重放已完成的 `agent()` 呼叫，所以修好的 workflow 是接著跑，不是從頭跑。
+- 事件 loop 由 cron 項目和 remote trigger（第 14 章）提供。
+
+### Hermes Agent
+
+- `agent/iteration_budget.py` 限制內層 loop 的迭代次數。上限在 harness 這一側。
+- `cron/scheduler.py` 用受限的 toolset fire job；執行後沒發現值得說的東西時，`[SILENT]` 會抑制投遞（第 14 章）。
+- `tools/process_registry.py` 的 watch pattern 在 process 輸出比對到時喚醒 agent，帶 rate limit 和 circuit breaker。
+- 沒有內建的評分重試 loop。檢查靠 `delegate_task()` 的 maker 和 checker 分工（第 6 章）和離線測試。
+- 改進 loop 是 skill curator：`tools/skill_manager_tool.py` fork 一個背景審查 agent，從使用情況整併、修剪 skill。
+  `hermes_cli/curator.py` 可以 pin、封存和回滾它改過的東西。
+- `agent/trajectory.py` 和 `trajectory_compressor.py` 把執行過程變成訓練資料，把這個 loop 一路閉合到 model 本身。
+
+> **取捨：**無人看管的 loop 把產出放大幾倍，也把錯誤放大幾倍。
+> 讓 L3 可以放著跑的，正是驗證和 budget。
+> 沒有評分者的 loop，自動化的是工作；沒有 budget 的 loop，自動化的是帳單。
+
+---
+
+## 失效模式
+
+- **沒有停止條件（No stop condition）：**沒有上限的重試 loop 會一直燒 token，直到有人看到帳單。緩解：由 harness 強制執行的迭代、token 和時間 budget。
+- **自己評自己（Self-grading）：**worker 給自己的輸出打分數，驗證 loop 等於什麼都沒驗。緩解：獨立的 checker agent，加上定在 loop 之外的 rubric。
+- **評什麼都過（Rubber-stamp rubric）：**永遠給過的評分者比沒有還糟，因為它替爛輸出蓋上「已驗證」的章。
+  緩解：對抗式驗證（要求 checker 想辦法推翻），加上定期的人工抽查。
+- **太早放手（Unattended too early）：**L1 的回報從來沒人核對過，loop 就拿到了 L3 的寫入權限。
+  緩解：成熟度階梯一次只升一級，由第 3 章的權限把關。
+- **無聲劣化（Silent drift）：**無人看管的 loop 越跑越差，卻沒有人讀它的輸出。緩解：heartbeat、一律投遞的回報，以及第 20 章對通過率和成本的量測。
+- **狀態失憶（State amnesia）：**每次執行都重新發現同樣的工作、重做一遍。緩解：把發現存進記憶或 task 紀錄（第 9、12 章），並在執行開始時讀取。
+- **自我修改的 harness 繞過關卡（Self-editing harness escapes its gates）：**能改 harness 程式碼的改進 loop，也能改那些把關它的程式碼。
+  緩解：權限和 budget 放在這個 loop 改不到的地方（第 3 章）。
+
+---
+
+## 可執行程式
+
+[`src/`](src/) 把 20 帶了過來，並加上：
+
+- [`verify.py`](src/verify.py)：驗證 loop（`verified_run`：評分、帶 feedback 重試、budget、交回給人）和 `agent_checker`，每個 verdict 都由一個全新的評分者做出。
+- [`test.py`](src/test.py)：離線檢查第一次就通過、feedback 有進到重試、budget 上限，以及 PASS/FAIL 的 verdict 約定。
+- [`demo.py`](src/demo.py)：實際跑一次 verified run：worker 帶著 add tool，獨立的 checker 按固定 rubric 評分，budget 用完就交回給人。
+
+loop 沒有改變。驗證從外面把它包起來。
+
+```bash
+python sections/21-loop-engineering/src/test.py         # offline checks, no key
+uv run python sections/21-loop-engineering/src/demo.py  # live demo, needs a key
+```
+
+---
+
+## 出處
+
+- [cobusgreyling/loop-engineering](https://github.com/cobusgreyling/loop-engineering)：building block 與成熟度分級。
+- [LangChain · The art of loop engineering](https://www.langchain.com/blog/the-art-of-loop-engineering)：四層堆疊的 loop。
+- [Addy Osmani · Loop engineering](https://addyosmani.com/blog/loop-engineering/)：building block 的組合方式。
+- [MindStudio · What is loop engineering](https://www.mindstudio.ai/blog/what-is-loop-engineering-autonomous-ai-agent-workflows)：目標條件。
+- [Lilian Weng · Harness engineering for self-improvement](https://lilianweng.github.io/posts/2026-07-04-harness/)：深入談改進 loop；關卡要放在 loop 之外。
+- Claude Code：`/loop` skill、`ScheduleWakeup`、`Workflow` schema。依據 tool schema 與文件記載的行為描述，非 source backup。
+- Hermes Agent 原始碼：`agent/iteration_budget.py`、`cron/scheduler.py`、`tools/skill_manager_tool.py`、`hermes_cli/curator.py`、`agent/trajectory.py`。

--- a/sections/21-loop-engineering/README.zh-TW.md
+++ b/sections/21-loop-engineering/README.zh-TW.md
@@ -99,7 +99,7 @@ Loop engineering 的幾個出處都用「敢讓它做多少事」來替 loop 分
 - 執行之間的狀態放在第 9 章的記憶和第 12 章的 task 紀錄。
 - 回報和 trace 是第 20 章。改進 loop 把第 20 章量到的東西接回 harness 的修改。
 
-可執行程式也是這樣接的。`run_turn` 和第 20 章一模一樣；驗證從外面把它包起來：
+可執行的 src 也是同一套組法。`run_turn` 完全沒改，跟第 20 章一模一樣；`verified_run` 只是在外面多包一層驗證：
 
 ```python
 def worker(prompt):                                # src/demo.py · the inner loop, unchanged
@@ -172,7 +172,7 @@ result = verified_run("What is 27 + 15? Use the add tool.", worker, checker, bud
 - [`test.py`](src/test.py)：離線檢查第一次就通過、feedback 有進到重試、budget 上限，以及 PASS/FAIL 的 verdict 約定。
 - [`demo.py`](src/demo.py)：實際跑一次 verified run：worker 帶著 add tool，獨立的 checker 按固定 rubric 評分，budget 用完就交回給人。
 
-loop 沒有改變。驗證從外面把它包起來。
+loop 本身完全沒改，驗證那一層是包在外面的。
 
 ```bash
 python sections/21-loop-engineering/src/test.py         # offline checks, no key

--- a/sections/21-loop-engineering/README.zh-TW.md
+++ b/sections/21-loop-engineering/README.zh-TW.md
@@ -50,7 +50,7 @@ flowchart LR
 
 ### New：驗證 loop
 
-這是前面章節唯一沒做過的 loop。內層 loop 是 model 自己說完成就停。驗證 loop 把「完成」變成要通過檢查才算數的宣稱：
+這是前面章節唯一沒做過的 loop。內層 loop 是 model 自己說完成就停。有了驗證 loop，「完成」不再是 model 說了算，要通過檢查才算數：
 
 ```python
 def verified_run(task, worker, checker, budget=2):    # src/verify.py

--- a/sections/21-loop-engineering/src/autonomy.py
+++ b/sections/21-loop-engineering/src/autonomy.py
@@ -1,0 +1,108 @@
+"""Autonomy (section 18): an outer loop around the agent loop (section 1) so a
+teammate keeps working with no human prompt. Introduced in section 18, extending
+section 17's run_teammate with the task board.
+
+The inner loop is the normal run_turn (section 1). When it ends, the agent does
+not return; it idles and polls three sources in priority order:
+
+  1. A shutdown request (section 17): confirm it and stop. Checked first, so a
+     flood of peer chatter cannot starve a stop.
+  2. An inbox message (section 16): lead before peers, folded into one prompt.
+  3. The task board (section 12): claim the first pending, unowned, unblocked
+     task. The claim is lock-serialized in TaskStore, so two idle agents cannot
+     both win the same task; this only proposes a candidate to try.
+
+Whatever the poll finds becomes the next prompt and the inner loop runs again.
+The loop and the subagent path do not change; autonomy only wraps them.
+
+ponytail: max_idle_polls bounds the idle wait so the demo and test terminate; a
+real teammate polls until shutdown or abort, with no upper bound.
+"""
+from __future__ import annotations
+
+import time
+
+from mailbox import _fold
+from protocols import Protocol
+
+POLL_INTERVAL = 0.05    # seconds between idle polls; short so demo/test do not wait
+
+
+def claim_next(store, me):
+    """Scan the board oldest-first and claim the first pending, unowned task.
+    Returns the claimed task or None. TaskStore.claim (section 12) rejects a
+    blocked task and is lock-serialized, so a claim race has exactly one winner."""
+    for t in store.list():
+        if t["status"] == "pending" and t["owner"] is None:
+            got = store.claim(t["id"], me)
+            if got["ok"]:
+                return got["task"]
+            # not ok: another agent won it or it just became blocked, so try the next
+    return None
+
+
+def _is(msg, type_):
+    content = msg["content"]
+    return isinstance(content, dict) and content.get("type") == type_
+
+
+def next_action(proto, team, store, me):
+    """One idle poll. Drain the inbox once, then pick the next thing to do in
+    priority order: a shutdown request (confirm and stop), a peer/lead message,
+    or a claimed task. Returns (kind, payload), or None when there is nothing to
+    do. Shutdown is checked before chat so peer traffic cannot starve a stop."""
+    inbox = team.drain(me)
+    shutdown = next((m for m in inbox if _is(m, "shutdown_request")), None)
+    if shutdown is not None:
+        proto.reply(shutdown, "shutdown_approved")     # inner loop already flushed at end_turn
+        return ("shutdown", shutdown["content"].get("reason"))
+    chat = [m for m in inbox if isinstance(m["content"], str)]
+    if chat:
+        chat.sort(key=lambda m: m["from"] != "lead")   # lead before peers; sort is stable
+        return ("message", _fold(chat))
+    task = claim_next(store, me)
+    if task is not None:
+        return ("task", task)
+    return None                                         # idle: caller sleeps and polls again
+
+
+def task_prompt(task):
+    """Turn a claimed task into the next user prompt for the inner loop."""
+    return (f"You claimed task {task['id']}: {task['subject']}. "
+            f"Do it, then call TaskUpdate to mark it completed.")
+
+
+def run_teammate(team, store, me, lead, work, *, max_idle_polls=None):
+    """Section 17's run_teammate (protocols.py) idles on an empty inbox; this adds
+    the task board, so an idle teammate claims a task instead of just waiting. Run
+    the inner agent loop on a prompt, then idle-poll for the next thing to do.
+    `work(prompt, task)` runs one inner loop (section 1) to end_turn on the claimed
+    task (None on a message-driven turn). Two stop modes,
+    both the worker's own decision at end_turn. max_idle_polls=None: idle until a
+    shutdown handshake lands (a long-lived worker on a dynamic board, kept warm
+    for the coordinator to end it; section 17). A small int: stop after that many
+    empty polls (a worker on a known, finite board decides the work is gone and
+    winds itself down). Returns 'shutdown' or 'drained'."""
+    proto = Protocol(team, me)
+    prompt = claimed = None
+    idle = 0
+    while True:
+        if prompt is not None:
+            work(prompt, claimed)                       # inner loop (section 1), runs to end_turn
+            prompt = claimed = None
+            team.send(me, lead, {"type": "idle", "reason": "available"})   # sendIdleNotification
+        action = next_action(proto, team, store, me)
+        if action is None:                              # nothing to do this pass
+            idle += 1
+            if max_idle_polls is not None and idle >= max_idle_polls:
+                return "drained"                        # only a lead-less single worker hits this
+            time.sleep(POLL_INTERVAL)
+            continue
+        idle = 0
+        kind, payload = action
+        if kind == "shutdown":
+            return "shutdown"
+        if kind == "task":
+            prompt, claimed = task_prompt(payload), payload
+        else:                                           # message: no task to thread through
+            prompt = payload

--- a/sections/21-loop-engineering/src/background.py
+++ b/sections/21-loop-engineering/src/background.py
@@ -1,0 +1,91 @@
+"""Background execution (section 13): start slow work off the loop, return a
+handle now, deliver the result later through a notification queue.
+
+Introduced in section 13, then carried forward unchanged.
+
+Runtime.start() runs any thunk on a worker thread and returns at once with a
+task id (the tool's placeholder tool_result, section 1). On completion the
+worker enqueues a <task_notification>; drain_into() pulls those notes on a later
+turn and prepends them to the next user message. One tool_use still gets exactly
+one tool_result, the completion is a separate event.
+
+Backgrounding is a property of execution, not of one tool: backgroundable()
+wraps ANY tool so the model can run it off-loop with run_in_background. A shell
+command, a subagent (section 6), a build, or a memory-consolidation pass all
+take the same path. Mirrors Claude Code's task framework backing LocalShellTask,
+DreamTask, and friends through one messageQueueManager drain.
+"""
+from __future__ import annotations
+
+import queue
+import threading
+from dataclasses import replace
+
+from tools import Tool
+
+
+class Runtime:
+    """Tracks background tasks and queues their completion notifications."""
+
+    def __init__(self):
+        self._next = 0
+        self._state: dict[int, str] = {}        # task id -> running | completed | failed
+        self._notes: queue.Queue = queue.Queue()
+
+    def start(self, fn):
+        """Run any thunk on a worker thread; return a task id immediately (never blocks)."""
+        self._next += 1
+        tid = self._next
+        self._state[tid] = "running"
+
+        def work():
+            try:
+                self._finish(tid, "completed", str(fn()))
+            except Exception as e:              # a failed background task still reports back
+                self._finish(tid, "failed", f"{type(e).__name__}: {e}")
+
+        threading.Thread(target=work, daemon=True).start()
+        return tid
+
+    def state(self, tid):
+        return self._state.get(tid)
+
+    def drain(self):
+        """Every completion notification enqueued so far, oldest first; empties the queue."""
+        out = []
+        while True:
+            try:
+                out.append(self._notes.get_nowait())
+            except queue.Empty:
+                return out
+
+    def _finish(self, tid, status, output):
+        self._state[tid] = status
+        self._notes.put(f"<task_notification>task {tid} {status}: {output}</task_notification>")
+
+
+def drain_into(messages, runtime):
+    """Prepend any completed-task notifications to the latest user message, so a
+    background result surfaces on the next turn (Claude Code's queue drain)."""
+    notes = runtime.drain() if runtime else []
+    if notes and messages and isinstance(messages[-1].get("content"), str):
+        messages[-1]["content"] = "\n".join(notes) + "\n\n" + messages[-1]["content"]
+    return messages
+
+
+def backgroundable(tool: Tool, runtime: Runtime) -> Tool:
+    """Wrap any tool so the model can run it off-loop with run_in_background.
+    A shell command, a subagent (section 6), a build, or a long compute task all
+    take the same path: start the thunk, return a handle, notify on completion."""
+    def run(a):
+        if a.get("run_in_background"):
+            inner = {k: v for k, v in a.items() if k != "run_in_background"}
+            tid = runtime.start(lambda: tool.run(inner))
+            return f"started background task {tid} ({tool.name}); its result arrives in a later message"
+        return tool.run(a)
+
+    schema = {**tool.input_schema,
+              "properties": {**tool.input_schema.get("properties", {}),
+                             "run_in_background": {"type": "boolean"}}}
+    return replace(tool, run=run, input_schema=schema,                  # keeps is_read_only etc.
+                   description=tool.description + " Set run_in_background for slow work.")

--- a/sections/21-loop-engineering/src/context.py
+++ b/sections/21-loop-engineering/src/context.py
@@ -1,0 +1,87 @@
+"""Context management (section 8): keep messages[] under the window.
+
+Introduced in section 8, then carried forward unchanged.
+
+messages[] only grows (section 1), so every turn runs cheap, near-lossless
+passes first and the expensive lossy summary only as a last resort. Order
+matters: budget (persist huge results) before micro (stub old result bodies),
+summary last. In the Anthropic format a tool result is a block inside a user
+message, so the passes walk those blocks. Mirrors Claude Code's per-turn
+budget -> micro -> auto sequence in query.ts.
+"""
+from __future__ import annotations
+
+TOKEN_LIMIT = 1500       # tiny so the demo trips it; real Claude Code uses the model's window
+MAX_RESULT_CHARS = 400   # a single tool result over this is persisted to a preview stub
+KEEP_RECENT = 4          # tail messages always kept verbatim
+PREVIEW_CHARS = 60
+
+
+def manage(messages, summarizer=None):
+    """Run the cheap passes every turn; summarize only if still over the limit."""
+    _budget(messages)                                        # persist huge results   (lossless)
+    _micro(messages, KEEP_RECENT)                            # stub old result bodies (cheap)
+    if summarizer and estimate_tokens(messages) > TOKEN_LIMIT:
+        return _auto(messages, KEEP_RECENT, summarizer)      # summarize history (lossy, last resort)
+    return messages
+
+
+def _tool_results(message):
+    """The tool_result blocks in a user message, or [] if it has none."""
+    content = message.get("content")
+    if message.get("role") == "user" and isinstance(content, list):
+        return [b for b in content if isinstance(b, dict) and b.get("type") == "tool_result"]
+    return []
+
+
+def _budget(messages):
+    """A tool result over the cap is persisted; only a preview stays in context."""
+    for m in messages:
+        for block in _tool_results(m):
+            c = block.get("content")
+            if isinstance(c, str) and len(c) > MAX_RESULT_CHARS:
+                block["content"] = c[:PREVIEW_CHARS] + " ...<persisted-output>"   # full text on disk in real CC
+
+
+def _micro(messages, keep_recent):
+    """Old tool-result bodies become a stub; the model can re-read if it needs them."""
+    for m in messages[:len(messages) - keep_recent]:
+        for block in _tool_results(m):
+            if block.get("content") != "<elided>":
+                block["content"] = "<elided>"
+
+
+def _auto(messages, keep_recent, summarizer):
+    """Replace the middle with one summary; keep the first turn and recent tail.
+
+    ponytail: drops the middle and keeps head + tail, nudging the cut forward so
+    it never starts on an orphaned tool_result (which must keep its tool_use turn).
+    """
+    if len(messages) <= keep_recent + 1:
+        return messages
+
+    cut = len(messages) - keep_recent
+    while cut < len(messages) and _tool_results(messages[cut]):
+        cut += 1
+    if cut >= len(messages):
+        return messages
+
+    summary = {"role": "user",
+               "content": f"[summary of {cut} earlier messages] {summarizer(messages)}"}
+    return messages[:1] + [summary] + messages[cut:]
+
+
+def estimate_tokens(messages) -> int:
+    return sum(_content_len(m.get("content")) for m in messages) // 4   # ~4 chars per token
+
+
+def _content_len(content) -> int:
+    if isinstance(content, str):
+        return len(content)
+    total = 0
+    for block in content or []:
+        if isinstance(block, dict):
+            total += len(str(block.get("content", "")))
+        else:                                   # SDK block object (text / tool_use)
+            total += len(getattr(block, "text", "") or "")
+    return total

--- a/sections/21-loop-engineering/src/demo.py
+++ b/sections/21-loop-engineering/src/demo.py
@@ -1,0 +1,63 @@
+"""Section 21 demo: one verified run. A worker answers, a separate checker
+grades it against a fixed rubric, and the harness retries with feedback or
+escalates at the budget.
+
+verified_run wraps run_turn from outside; the inner loop is unchanged. The
+checker is its own agent on a fresh messages[] (section 6), so the worker
+never grades its own output. A section-14 trigger could start this run
+instead of the script; the verification loop is the same either way.
+
+    uv run python sections/21-loop-engineering/src/demo.py   (needs ANTHROPIC_API_KEY; see root README)
+"""
+import os
+
+from anthropic import Anthropic
+from dotenv import load_dotenv
+
+from loop import Session, run_turn
+from permissions import DEFAULT
+from tools import Registry, Tool
+from verify import agent_checker, verified_run
+
+load_dotenv(override=True)
+
+MODEL = os.environ.get("ANTHROPIC_MODEL", "claude-sonnet-4-6")
+RUBRIC = "The output is exactly one number and nothing else."
+
+ADD = Tool(name="add", run=lambda a: a["x"] + a["y"], description="Add two integers.",
+           input_schema={"type": "object",
+                         "properties": {"x": {"type": "integer"}, "y": {"type": "integer"}},
+                         "required": ["x", "y"]},
+           is_read_only=True)
+
+
+def demo():
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        print("21 loop-eng: set ANTHROPIC_API_KEY to run the live demo (offline checks: test.py)")
+        return
+
+    client = Anthropic(base_url=os.environ.get("ANTHROPIC_BASE_URL") or None)
+
+    def model(messages, registry, system):
+        kwargs = {"system": system} if system else {}
+        return client.messages.create(model=MODEL, messages=messages,
+                                      tools=registry.schemas(), max_tokens=256, **kwargs)
+
+    reg = Registry()
+    reg.register(ADD)
+
+    def worker(prompt):                            # the inner loop, unchanged (section 1)
+        return run_turn([{"role": "user", "content": prompt}], model, reg, Session(mode=DEFAULT))
+
+    checker = agent_checker(RUBRIC, model)         # a fresh grader agent, no tools (section 6)
+
+    result = verified_run("What is 27 + 15? Use the add tool. Answer with just the number.",
+                          worker, checker, budget=2)
+    for a in result["attempts"]:
+        print(f"21 loop-eng: attempt {a['attempt']}: "
+              f"{'PASS' if a['passed'] else 'FAIL'} · {a['reason']}")
+    print("21 loop-eng:", result["output"] if result["ok"] else "budget spent, escalating to a human")
+
+
+if __name__ == "__main__":
+    demo()

--- a/sections/21-loop-engineering/src/hooks.py
+++ b/sections/21-loop-engineering/src/hooks.py
@@ -1,0 +1,34 @@
+"""Hooks (section 4): PreToolUse / PostToolUse interception around tool calls.
+Introduced in section 4, then carried forward unchanged.
+
+A PreToolUse hook may block a call or rewrite its input; it cannot grant
+permission a call lacks (so hooks here only deny or modify, never allow).
+PostToolUse hooks observe results. Mirrors Claude Code's types/hooks.ts.
+"""
+from __future__ import annotations
+
+PRE_TOOL_USE, POST_TOOL_USE = "PreToolUse", "PostToolUse"
+
+
+class Hooks:
+    def __init__(self):
+        self._hooks = {PRE_TOOL_USE: [], POST_TOOL_USE: []}
+
+    def on(self, event, fn):
+        self._hooks[event].append(fn)
+
+    def fire_pre(self, name, args):
+        """Run PreToolUse hooks. Returns (blocked, args, message); a hook may
+        rewrite args or, by returning {'deny': True}, block the call."""
+        for fn in self._hooks[PRE_TOOL_USE]:
+            out = fn(name, args) or {}
+            if out.get("updated_args"):
+                args = out["updated_args"]
+            if out.get("deny"):
+                return True, args, out.get("message", "blocked by hook")
+
+        return False, args, ""
+
+    def fire_post(self, name, args, result):
+        for fn in self._hooks[POST_TOOL_USE]:
+            fn(name, args, result)

--- a/sections/21-loop-engineering/src/loop.py
+++ b/sections/21-loop-engineering/src/loop.py
@@ -1,0 +1,106 @@
+"""Agent loop (sections 1 to 13). Changed from section 11: background-task
+completions are drained in at the start of a turn (section 13).
+
+A tool may start slow work off-loop and return a handle immediately (section
+13); its result arrives later as a <task_notification>. background.drain_into
+folds any pending notifications into the next user turn before the model call.
+Everything else is the section-11 loop: retry (section 11), prompt assembly
+(section 10), memory (section 9), context.manage (section 8).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import background
+import context
+import permissions
+import recovery
+from hooks import Hooks
+from tools import Registry, run_tool
+
+
+@dataclass
+class Session:
+    """Mutable harness state that outlives a turn."""
+    mode: str = permissions.DEFAULT
+    allow_rules: set = field(default_factory=set)
+    todos: list = field(default_factory=list)
+
+
+def run_turn(messages, model, registry: Registry, session: Session, hooks: Hooks | None = None,
+        approver=None, summarizer=None, memory=None, prompt=None, fallback_model=None,
+        runtime=None, max_steps=20):
+    hooks = hooks or Hooks()
+    approver = approver or (lambda name, args: False)
+
+    background.drain_into(messages, runtime)               # 13 · fold in any background completions
+
+    if memory is not None:
+        user_text = messages[-1]["content"]                # the new user turn (already appended)
+        recalled = memory.recall(user_text)                # 9 · inject relevant memories (read-only)
+        if recalled:
+            messages[-1]["content"] = f"<system-reminder>\n{recalled}\n</system-reminder>\n\n{user_text}"
+
+    for _ in range(max_steps):
+        messages = context.manage(messages, summarizer=summarizer)   # 8 · keep context under the window
+        system = prompt(registry, session) if prompt else None       # 10 · assemble from live state each turn
+        response = recovery.with_retry(                              # 11 · retry / adapt / fall back
+            lambda: model(messages, registry, system),
+            on_overflow=lambda: _reactive_trim(messages),
+            fallback_model=fallback_model)
+        messages.append({"role": "assistant", "content": response.content})
+
+        if response.stop_reason != "tool_use":
+            if memory is not None:
+                memory.write(messages)                     # 9 · extract new memories at run end (write-only)
+            return final_text(response)
+
+        results = [_dispatch(b, registry, session, hooks, approver)
+                   for b in response.content if b.type == "tool_use"]
+        messages.append({"role": "user", "content": results})
+
+    raise RuntimeError("hit max_steps without end_turn")
+
+
+def _reactive_trim(messages, keep_recent=4):
+    """Last-resort in-place compaction when a call overflows: keep the first
+    message and the recent tail, drop the middle, never stranding a tool_result."""
+    if len(messages) <= keep_recent + 1:
+        return
+    cut = len(messages) - keep_recent
+    while cut < len(messages) and _is_tool_result(messages[cut]):
+        cut += 1
+    del messages[1:cut]
+
+
+def _is_tool_result(m):
+    c = m.get("content")
+    return m.get("role") == "user" and isinstance(c, list) and \
+        any(isinstance(b, dict) and b.get("type") == "tool_result" for b in c)
+
+
+def _dispatch(block, registry, session, hooks, approver):
+    name, args = block.name, block.input
+    tool = registry.get(name)
+    res = lambda content: {"type": "tool_result", "tool_use_id": block.id, "content": content}
+    if tool is None:
+        return res(f"error: no tool {name!r}")
+
+    blocked, args, msg = hooks.fire_pre(name, args)                         # 4 · PreToolUse
+    if blocked:
+        return res(msg)
+
+    decision = permissions.decide(tool, session.mode, session.allow_rules)  # 3 · gate (live mode)
+    if decision == "deny":
+        return res(f"{name} not allowed in {session.mode} mode")
+    if decision == "ask" and not approver(name, args):
+        return res(f"{name} denied by user")
+
+    out = res(run_tool(tool, args))
+    hooks.fire_post(name, args, out)                                        # 4 · PostToolUse
+    return out
+
+
+def final_text(response):
+    """The model's last words: concatenate its text blocks."""
+    return "".join(b.text for b in response.content if b.type == "text")

--- a/sections/21-loop-engineering/src/mailbox.py
+++ b/sections/21-loop-engineering/src/mailbox.py
@@ -1,0 +1,221 @@
+"""Coordination (section 16): a team of named inboxes so several agents can run
+at once and talk. Introduced in section 16, then carried forward unchanged.
+
+A large job exceeds one context window, so it fans out across teammates. They
+need three things a lone loop lacks: addressing (stable names), a channel (a way
+to deliver a message the recipient will see), and escalation (a teammate hitting
+a gated action must reach a human, not stall or self-approve).
+
+Each agent owns an inbox: one JSON file per teammate under a shared team dir.
+To talk you append to the recipient's inbox under a file lock, so concurrent
+senders serialize; `to="*"` broadcasts. There is no broker. Delivery is the
+recipient draining its own inbox and folding new messages into its next turn
+(the poll-and-fold model: an agent never hard-blocks on a peer). Permission
+requests ride the same channel: a teammate sends a permission_request, the lead
+routes it to a human, and the verdict returns as a permission_response.
+
+The lead does not hand-start teammates. It calls SpawnTeammate, and the harness
+runs each teammate's serve_mailbox loop on a background thread (section 13). A
+teammate pulls its own inbox and acts, so the script drives no one. There is no
+graceful stop yet, the thread is a daemon; section 17 adds the shutdown
+handshake, and section 18 adds pulling tasks off a shared board.
+
+ponytail: one fcntl lock around the whole team (proper-lockfile's analog); split
+to per-inbox locks only if a large roster makes that one lock a bottleneck.
+"""
+from __future__ import annotations
+
+import fcntl
+import json
+import time
+from contextlib import contextmanager
+from pathlib import Path
+
+from tools import Tool
+
+
+class Team:
+    """A roster of named inboxes under `root`/inboxes, one JSON file each.
+    The roster is closed: you can only address a registered teammate, which is
+    also the trust boundary (a name becomes a path, so it must be known)."""
+
+    def __init__(self, root, members):
+        self.dir = Path(root) / "inboxes"
+        self.dir.mkdir(parents=True, exist_ok=True)
+        self.members = list(members)
+        for m in self.members:
+            self._path(m).write_text("[]")          # empty inbox per teammate
+
+    def send(self, frm, to, content):
+        """Append a message to the recipient's inbox; to='*' broadcasts to every
+        teammate but the sender. One lock serializes concurrent senders."""
+        targets = [m for m in self.members if m != frm] if to == "*" else [self._check(to)]
+        with self._lock():
+            for t in targets:
+                inbox = self._read(t)
+                inbox.append({"from": self._check(frm), "to": t, "content": content})
+                self._path(t).write_text(json.dumps(inbox))
+
+    def drain(self, name):
+        """Read and clear a teammate's inbox, oldest first. Delivery is the
+        recipient draining its own inbox, so a peer never blocks waiting on it."""
+        with self._lock():
+            inbox = self._read(name)
+            self._path(name).write_text("[]")
+            return inbox
+
+    # --- disk plumbing ---
+    def _check(self, name):
+        if name not in self.members:                # closed roster = the trust boundary
+            raise ValueError(f"not a teammate: {name!r}")
+        return name
+
+    def _path(self, name):
+        return self.dir / f"{self._check(name)}.json"
+
+    def _read(self, name):
+        return json.loads(self._path(name).read_text())
+
+    @contextmanager
+    def _lock(self):
+        f = open(self.dir / ".lock", "w")
+        try:
+            fcntl.flock(f, fcntl.LOCK_EX)           # blocks until the other sender releases
+            yield
+        finally:
+            fcntl.flock(f, fcntl.LOCK_UN)
+            f.close()
+
+
+def _fold(chat):
+    """Render chat messages as one prompt block, the wire format a teammate reads.
+    One definition so fold_inbox and serve_mailbox cannot drift."""
+    return "\n".join(f"<message from={m['from']!r}>{m['content']}</message>" for m in chat)
+
+
+def fold_inbox(messages, team, name):
+    """Drain `name`'s inbox and surface chat (string) messages on its next turn,
+    so a teammate folds peers' messages in between turns instead of blocking on
+    them. Mirrors how background completions (section 13) prepend to the next
+    turn. Returns every drained message (not just chat), so a structured message
+    is never silently lost; the caller routes the rest (e.g. permission replies)."""
+    drained = team.drain(name)
+    chat = [m for m in drained if isinstance(m["content"], str)]
+    if chat and messages and isinstance(messages[-1].get("content"), str):
+        messages[-1]["content"] = _fold(chat) + "\n\n" + messages[-1]["content"]
+    return drained
+
+
+def serve_mailbox(team, me, work, *, poll=0.05, max_idle_polls=None):
+    """A teammate's own loop, spawned on a background thread (section 13): pull the
+    inbox, act, repeat. Each pass drains `me`'s inbox; chat messages fold into one
+    prompt and run `work(prompt)` (one inner loop, section 1), and an empty inbox
+    just sleeps and polls again. So a teammate reacts on its own thread instead of
+    the script driving it. No graceful stop yet: the thread is a daemon that dies
+    with the process. Section 17 adds the shutdown handshake; section 18 adds
+    claiming tasks off a board when the inbox is empty. max_idle_polls bounds the
+    idle wait so a demo or test ends; None runs until the process does. Returns
+    'idle' when a bounded loop gives up."""
+    idle = 0
+    while True:
+        chat = [m for m in team.drain(me) if isinstance(m["content"], str)]
+        if chat:
+            idle = 0
+            work(_fold(chat))                           # one inner loop on the folded message
+            continue
+        idle += 1
+        if max_idle_polls is not None and idle >= max_idle_polls:
+            return "idle"
+        time.sleep(poll)
+
+
+def bubbling_approver(team, me, lead, human=None, timeout=0.0, poll=0.05):
+    """An approver (section 3) for a teammate with no human in its own loop: a
+    gated call escalates to the lead. The request and the verdict both travel the
+    inbox channel; the teammate returns on what it reads back from its own inbox,
+    so the answer is an inbox message, not a direct call.
+
+    With `human`, the lead's approval UI answers inline (synchronous round-trip).
+    Without it, the answer must arrive from elsewhere (a lead on another thread, a
+    person on a chat platform), so the teammate polls its inbox up to `timeout`
+    and then DENIES: an unanswered permission is a no, never a stall or a yes.
+    Mirrors Hermes' clarify gateway (register / wait_for_response with timeout).
+    ponytail: the wait drains chat messages too; route drained non-responses if
+    teammates chat while a permission is pending."""
+    def approve(name, args):
+        team.send(me, lead, {"kind": "permission_request", "tool": name, "args": args})
+        if human is not None:                       # the lead routes it to its approval UI
+            team.send(lead, me, {"kind": "permission_response", "tool": name, "ok": human(name, args)})
+        deadline = time.time() + timeout
+        while True:
+            responses = [m["content"] for m in team.drain(me)
+                         if isinstance(m["content"], dict) and m["content"].get("kind") == "permission_response"]
+            if responses:
+                return bool(responses[-1]["ok"])
+            if time.time() >= deadline:
+                return False                        # nobody answered in time: default deny
+            time.sleep(poll)
+    return approve
+
+
+def _send_tool(get_team, me):
+    """The SendMessage tool, shared by message_tools and team_tools. `me` is bound
+    by the harness, not the model, so a teammate cannot spoof another. get_team()
+    returns the team at call time, so one implementation serves both a teammate
+    with a fixed team and a lead whose team exists only after TeamCreate (None
+    until then). Mirrors Claude Code's SendMessageTool."""
+    def send(a):
+        team = get_team()
+        if team is None:
+            return "no team yet: call TeamCreate with the member names first"
+        team.send(me, a["to"], a["message"])
+        return f"sent to {a['to']}"
+
+    return Tool("SendMessage", send,
+                description="Send a message to a teammate by name. Use 'lead' to reach the team lead.",
+                input_schema={"type": "object",
+                              "properties": {"to": {"type": "string"}, "message": {"type": "string"}},
+                              "required": ["to", "message"]})
+
+
+def message_tools(team, me):
+    """SendMessage over an existing team: the model decides to message a teammate,
+    and the harness delivers it over the inbox channel."""
+    return [_send_tool(lambda: team, me)]
+
+
+def team_tools(root, me, formed):
+    """Forming the team is the model's decision, not the script's. TeamCreate
+    materializes the inboxes under `root` into `formed`; the shared SendMessage
+    stays inert until then, so the lead creates the team before it can talk to it.
+    `formed` is a one-slot holder the harness reads back to hand the same Team to
+    teammates that join (ponytail: an in-process stand-in for a team registry;
+    back it with a roster file on disk to let a teammate in another process join)."""
+    def create(a):
+        members = list(dict.fromkeys([me, *a["members"]]))   # the creator joins its own team
+        formed["team"] = Team(root, members)                 # the tool call brings the team into being
+        return f"team created: {', '.join(members)}"
+
+    return [Tool("TeamCreate", create,
+                 description="Create the team with a list of member names. Call this before messaging.",
+                 input_schema={"type": "object",
+                               "properties": {"members": {"type": "array", "items": {"type": "string"}}},
+                               "required": ["members"]}),
+            _send_tool(lambda: formed["team"], me)]          # SendMessage, late-bound on the formed team
+
+
+def teammate_tools(runtime, spawn_worker):
+    """SpawnTeammate as a tool: the lead's model decides to add a teammate, and the
+    harness starts its loop on a background thread (section 13's runtime).
+    `spawn_worker(name)` is the app-supplied thunk that runs that teammate's loop
+    (serve_mailbox here; an autonomy loop from section 18). Whether to spawn is the
+    model's call, not the script's. Mirrors Claude Code spawning an
+    InProcessTeammateTask."""
+    def spawn(a):
+        runtime.start(lambda: spawn_worker(a["name"]))
+        return f"spawned teammate {a['name']}; it runs on its own thread and pulls its own work"
+
+    return [Tool("SpawnTeammate", spawn, is_read_only=True,
+                 description="Spawn a teammate by name; it runs on its own thread and pulls its own work.",
+                 input_schema={"type": "object", "properties": {"name": {"type": "string"}},
+                               "required": ["name"]})]

--- a/sections/21-loop-engineering/src/mcp.py
+++ b/sections/21-loop-engineering/src/mcp.py
@@ -1,0 +1,108 @@
+"""MCP / plugins / channels (section 19): reach outside the harness.
+
+connect() discovers an external server's tools (the MCP tools/list step) and
+wraps each as a runtime Tool (section 2), namespaced mcp__<server>__<tool>, so
+they merge into the one pool the loop dispatches. The loop, permission gate
+(section 3), and dispatch do not change: an MCP tool is just a Tool whose run()
+calls out over a transport instead of running in-process.
+
+An MCP annotation (readOnlyHint / destructiveHint) rides along and becomes the
+permission hint the gate reads, so a server declares how risky each tool is.
+
+merge_servers() layers plugin/user/project/local config by precedence, the way
+a plugin contributes servers alongside user and project config.
+
+wrap_channel() turns a server push into a tagged message folded into the next
+turn, so Slack, Discord, or SMS ride the same protocol as a two-way surface.
+gate_inbound() runs that push through gates first: an inbound channel message is
+untrusted input, so a gate may drop or rewrite it before the loop ever sees it
+(Hermes' pre_gateway_dispatch hook, fired before auth on every incoming message).
+
+Mirrors Claude Code services/mcp/: buildMcpToolName namespaces each tool,
+normalizeNameForMCP sanitizes it, the readOnlyHint annotation drives the
+permission hint, config.ts merges by precedence, and channelNotification.ts
+wraps a push in CHANNEL_TAG.
+"""
+from __future__ import annotations
+
+import re
+
+from tools import NO_INPUT, Tool
+
+_BAD = re.compile(r"[^a-zA-Z0-9_-]")             # the API's allowed name charset
+CHANNEL_TAG = "channel"
+PRECEDENCE = ("plugin", "user", "project", "local")   # low to high; later wins
+
+
+def normalize(name: str) -> str:
+    """normalizeNameForMCP: any char outside [a-zA-Z0-9_-] becomes _."""
+    return _BAD.sub("_", name)
+
+
+def tool_name(server: str, tool: str) -> str:
+    """buildMcpToolName: mcp__<server>__<tool>, so two servers never collide."""
+    return f"mcp__{normalize(server)}__{normalize(tool)}"
+
+
+def wrap(server: str, spec: dict, call) -> Tool:
+    """One discovered tool spec -> a runtime Tool bound to the server.
+
+    call(tool, args) reaches the server over its transport. The MCP annotations
+    map to the permission hints the gate (section 3) reads; a read-only tool may
+    also share a parallel batch (section 2)."""
+    ann = spec.get("annotations", {})
+    read_only = bool(ann.get("readOnlyHint"))
+    bare = spec["name"]
+    return Tool(
+        name=tool_name(server, bare),
+        run=lambda args, _t=bare: call(_t, args),        # dispatch calls out over the transport
+        description=spec.get("description", ""),
+        input_schema=spec.get("inputSchema") or dict(NO_INPUT),
+        is_read_only=read_only,
+        is_concurrency_safe=read_only,                   # reads are safe to run in parallel
+    )
+
+
+def connect(server: str, conn) -> list[Tool]:
+    """Discover a server's tools and wrap each as a namespaced Tool.
+
+    conn is a live transport (stdio / http / sse in production; in-process here):
+    .list_tools() -> tool specs, .call(tool, args) -> result. Merge the returned
+    Tools into the loop's Registry and they dispatch like any built-in."""
+    return [wrap(server, spec, conn.call) for spec in conn.list_tools()]
+
+
+def merge_servers(*layers: dict) -> dict:
+    """Layer server config by precedence plugin < user < project < local.
+
+    Each layer maps server name -> config; a later layer overrides an earlier one
+    for the same name. This is how a plugin's servers combine with user and
+    project config (config.ts)."""
+    merged: dict = {}
+    for scope in PRECEDENCE:
+        for layer in layers:
+            merged.update(layer.get(scope, {}))
+    return merged
+
+
+def wrap_channel(source: str, payload: str) -> str:
+    """A server push (notifications/claude/channel) becomes a tagged message the
+    loop folds into the next turn (section 13's queue, section 16's inbox)."""
+    return f'<{CHANNEL_TAG} source="{source}">{payload}</{CHANNEL_TAG}>'
+
+
+def gate_inbound(source: str, payload: str, gates=()) -> str | None:
+    """Run an inbound channel message through gates before it becomes a turn.
+
+    Each gate(source, payload) may return {'drop': True} to discard the message
+    or {'rewrite': str} to replace its payload; anything else passes it through.
+    Returns the tagged message for the loop, or None when a gate dropped it.
+    A channel is an open door, so the gate runs before the model ever reads the
+    text (Hermes: pre_gateway_dispatch, skip / rewrite / allow)."""
+    for gate in gates:
+        out = gate(source, payload) or {}
+        if out.get("drop"):
+            return None
+        if out.get("rewrite") is not None:
+            payload = out["rewrite"]
+    return wrap_channel(source, payload)

--- a/sections/21-loop-engineering/src/memory.py
+++ b/sections/21-loop-engineering/src/memory.py
@@ -1,0 +1,183 @@
+"""Memory (section 9): a durable file store the agent recalls from and writes to.
+
+Introduced in section 9, then carried forward unchanged.
+
+messages[] dies with the run (section 1) and degrades under compaction
+(section 8). Memory is the layer outside the conversation: small .md files with
+frontmatter, recall that injects only the few relevant bodies into a turn, and
+extraction that writes new files at run end. Four operations, never conflated:
+  selection    : what is worth keeping. the type taxonomy gates the store, so
+                 derivable facts (code, git) are never written.
+  recall       : read-only, at query time. rank the index, inject a few bodies.
+  extraction   : write-only, at run end. append new files.
+  consolidation: rare, background (section 13). dedupe + prune. not shown here.
+Mirrors Claude Code's memdir (findRelevantMemories, memoryScan) + extractMemories.
+
+A second recall path searches raw history instead of extracted facts (Hermes
+Agent's session_search over state.db, SQLite FTS5): log_run() appends each run's
+text to a searchable session log, and search_sessions() returns actual past
+messages, ranked, with no model call. Extraction keeps distilled facts; the log
+keeps everything, so a fact extraction missed is still findable.
+"""
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+from tools import Tool
+
+TYPES = ("user", "feedback", "project", "reference")   # non-derivable only; the rest is grep's job
+RECALL_K = 5                                            # cap injected memories (precision over recall)
+SEARCH_K = 3                                            # cap returned past messages, same reason
+
+
+@dataclass
+class Memory:
+    name: str
+    type: str          # one of TYPES
+    description: str    # the cheap index line, ranked at recall time
+    path: Path          # the .md file; its body is read only when recalled
+
+
+def load_index(memory_dir) -> list[Memory]:
+    """Scan <dir>/*.md, keeping frontmatter only. The cheap manifest, never the bodies."""
+    mems = []
+    for md in sorted(Path(memory_dir).glob("*.md")):
+        if md.name == "MEMORY.md":          # the index file itself is not a memory
+            continue
+        meta, _body = _split(md.read_text())
+        mems.append(Memory(md.stem, meta.get("type", ""), meta.get("description", ""), md))
+    return mems
+
+
+def manifest(mems) -> str:
+    """One line per memory: name, type, description. Always-on and cheap (section 10)."""
+    return "\n".join(f"- {m.name} ({m.type}): {m.description}" for m in mems)
+
+
+def recall(mems, query, k=RECALL_K, selector=None) -> list[Memory]:
+    """Pick the few memories relevant to `query`. `selector` is the live relevance
+    judge (an LLM reading the manifest); without it, fall back to word overlap."""
+    if selector is not None:
+        chosen = set(selector(manifest(mems), query))     # LLM returns the names to inject
+        return [m for m in mems if m.name in chosen][:k]
+    scored = ((_overlap(query, m), m) for m in mems)
+    hits = sorted((s for s in scored if s[0]), key=lambda s: s[0], reverse=True)
+    return [m for _score, m in hits[:k]]
+
+
+def recall_block(mems, query, k=RECALL_K, selector=None) -> str:
+    """The recalled bodies, formatted for injection into a turn. '' if nothing fits."""
+    hits = recall(mems, query, k, selector)
+    return "\n\n".join(f"[memory · {m.type}] {_split(m.path.read_text())[1]}" for m in hits)
+
+
+def extract(memory_dir, messages, extractor) -> list[Path]:
+    """Run end: the extractor proposes new memories from the transcript; write each.
+    The only operation that grows the store. extractor(messages) returns dicts of
+    {name, type, description, body}; an empty list writes nothing."""
+    written = []
+    for m in extractor(messages) or []:
+        path = Path(memory_dir) / f"{m['name']}.md"
+        path.write_text(_render(m))
+        written.append(path)
+    return written
+
+
+def log_run(db_path, session_id, messages) -> int:
+    """Run end: append the run's text to the searchable session log. Everything
+    with text lands, not just what extraction kept (Hermes indexes all session
+    messages into state.db). ponytail: FTS5 ships in CPython's sqlite3."""
+    rows = [(session_id, m["role"], t) for m in messages if (t := _text_of(m))]
+    con = _db(db_path)
+    con.executemany("INSERT INTO session_log VALUES (?, ?, ?)", rows)
+    con.commit()
+    con.close()
+    return len(rows)
+
+
+def search_sessions(db_path, query, k=SEARCH_K) -> list[tuple]:
+    """Recall actual past messages by keyword, best match first (bm25), zero model
+    cost. Returns (session_id, role, content) rows; [] when nothing matches."""
+    words = _words(query)
+    if not words or not Path(db_path).exists():
+        return []
+    con = _db(db_path)
+    rows = con.execute("SELECT session_id, role, content FROM session_log "
+                       "WHERE session_log MATCH ? ORDER BY rank LIMIT ?",
+                       (" OR ".join(sorted(words)), k)).fetchall()
+    con.close()
+    return rows
+
+
+def search_tool(db_path) -> Tool:
+    """SessionSearch: the model-facing handle for search_sessions, so the agent
+    decides when past sessions are worth consulting (Hermes' session_search)."""
+    def search(a):
+        rows = search_sessions(db_path, a["query"])
+        if not rows:
+            return "no past sessions match"
+        return "\n".join(f"[session {sid} · {role}] {content}" for sid, role, content in rows)
+
+    return Tool("SessionSearch", search, is_read_only=True,
+                description="Search past session transcripts by keywords; returns matching messages.",
+                input_schema={"type": "object", "properties": {"query": {"type": "string"}},
+                              "required": ["query"]})
+
+
+@dataclass
+class Store:
+    """The handle threaded into the loop (loop.py): recall before the run, extract
+    after. `selector` / `extractor` are the live LLM hooks; both optional. With a
+    `db`, run end also logs the transcript for cross-session search."""
+    root: Path
+    selector: Callable | None = None
+    extractor: Callable | None = None
+    db: Path | None = None
+    session_id: str = "session"
+
+    def recall(self, query, k=RECALL_K) -> str:
+        return recall_block(load_index(self.root), query, k, self.selector)
+
+    def write(self, messages) -> list[Path]:
+        if self.db is not None:
+            log_run(self.db, self.session_id, messages)
+        return extract(self.root, messages, self.extractor) if self.extractor else []
+
+
+def _db(path):
+    con = sqlite3.connect(path)
+    con.execute("CREATE VIRTUAL TABLE IF NOT EXISTS session_log "
+                "USING fts5(session_id, role, content)")
+    return con
+
+
+def _text_of(message) -> str:
+    """The searchable text of one message: a plain string, or the text blocks of
+    an API response. Tool-use blocks carry no text and are skipped."""
+    content = message.get("content")
+    if isinstance(content, str):
+        return content
+    return "\n".join(t for b in content if (t := getattr(b, "text", "")))
+
+
+def _overlap(query, mem) -> int:
+    return len(_words(query) & _words(mem.name + " " + mem.description))
+
+
+def _words(text) -> set:
+    return {w for w in "".join(c if c.isalnum() else " " for c in text.lower()).split() if len(w) > 2}
+
+
+def _render(m) -> str:
+    return f"---\ntype: {m['type']}\ndescription: {m['description']}\n---\n{m['body']}\n"
+
+
+def _split(text):
+    """Minimal frontmatter parse into (meta dict, body). Same shape as skills.py."""
+    _, frontmatter, body = text.split("---", 2)
+    meta = {k.strip(): v.strip() for k, v in
+            (line.split(":", 1) for line in frontmatter.strip().splitlines() if ":" in line)}
+    return meta, body.strip()

--- a/sections/21-loop-engineering/src/permissions.py
+++ b/sections/21-loop-engineering/src/permissions.py
@@ -1,0 +1,27 @@
+"""Permission gate (section 3): the allow / ask / deny decision between a
+model's tool request and execution. Introduced in section 3, then carried
+forward unchanged. Modes mirror Claude Code's types/permissions.ts.
+"""
+from __future__ import annotations
+
+DEFAULT, ACCEPT_EDITS, PLAN, BYPASS = "default", "acceptEdits", "plan", "bypassPermissions"
+
+
+def decide(tool, mode: str, allow_rules: set) -> str:
+    """Return 'allow', 'ask', or 'deny' for running `tool` under `mode`."""
+    if mode == BYPASS:
+        return "allow"                       # user opted out of the gate entirely
+
+    if mode == PLAN:
+        if tool.is_read_only:
+            return "allow"                   # reading is fine while planning
+        if tool.name == "ExitPlanMode":
+            return "ask"                     # the plan-approval handshake (section 5)
+        return "deny"                        # no side effects until the plan is approved
+
+    if tool.is_read_only or tool.name in allow_rules:
+        return "allow"
+    if mode == ACCEPT_EDITS and tool.is_edit:
+        return "allow"                       # edits pre-approved for this session
+
+    return "ask"                             # default: a human decides

--- a/sections/21-loop-engineering/src/planning.py
+++ b/sections/21-loop-engineering/src/planning.py
@@ -1,0 +1,44 @@
+"""Planning and todos (section 5): a TodoWrite tool and plan mode. Introduced
+in section 5, then carried forward unchanged. Both tools mutate the Session
+(loop.py): TodoWrite records the plan, ExitPlanMode flips the mode once the
+plan is approved. Mirrors Claude Code's TodoWriteTool and Enter/ExitPlanMode.
+"""
+from __future__ import annotations
+
+import permissions
+from tools import Tool
+
+TODOS_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "todos": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {"step": {"type": "string"}, "status": {"type": "string"}},
+                "required": ["step", "status"],
+            },
+        },
+    },
+    "required": ["todos"],
+}
+
+
+def todo_tool(session) -> Tool:
+    """TodoWrite: record the plan as a list of steps on the session."""
+    def write(a):
+        session.todos = list(a["todos"])
+        done = sum(1 for t in session.todos if t.get("status") == "completed")
+        return f"{len(session.todos)} todos ({done} done)"
+    return Tool("TodoWrite", write,
+                description="Record the plan as a checklist of {step, status} items.",
+                input_schema=TODOS_SCHEMA, is_read_only=True)   # agent state only, no side effect
+
+
+def exit_plan_mode_tool(session, to_mode=permissions.ACCEPT_EDITS) -> Tool:
+    """ExitPlanMode: once the plan is approved, leave plan mode for `to_mode`."""
+    def exit_plan(_a):
+        session.mode = to_mode
+        return f"plan approved, mode now {to_mode}"
+    return Tool("ExitPlanMode", exit_plan,
+                description="Present the plan and leave plan mode once the user approves.")

--- a/sections/21-loop-engineering/src/prompt.py
+++ b/sections/21-loop-engineering/src/prompt.py
@@ -1,0 +1,48 @@
+"""System prompt assembly (section 10): build the system prompt each turn from
+named sections chosen by live state, not one hardcoded string.
+
+Introduced in section 10, then carried forward unchanged.
+
+A section is static (always present) or dynamic (compute(state) -> str | None).
+assemble() runs every section against current state, drops the Nones, and joins.
+A section is included by state, not keywords: the env section appears only with a
+cwd, the mcp section only when a server is connected. Recalled memory does NOT
+live here; it rides in the message as a <system-reminder> (section 9), so it
+never touches the system-prompt cache.
+
+Caching: within a conversation the system prompt is stable, so the demo enables
+automatic caching, one top-level cache_control that caches the whole prompt plus
+the growing messages and advances as the conversation grows (see demo.py).
+Mirrors Claude Code's getSystemPrompt + resolveSystemPromptSections.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+
+@dataclass
+class Section:
+    name: str
+    compute: Callable    # (state) -> str | None ; static sections ignore state, returning a constant
+
+
+def static(name, text) -> Section:
+    return Section(name, lambda _state: text)
+
+
+def assemble(sections, state) -> str:
+    """The system prompt for this turn: run every section, drop the Nones, join."""
+    parts = (s.compute(state) for s in sections)
+    return "\n\n".join(p for p in parts if p is not None)
+
+
+# A demonstrative section list, the strip-down's stand-in for Claude Code's
+# getSimpleIntroSection / getUsingYourToolsSection / mcp_instructions / etc.
+DEMO_SECTIONS = [
+    static("intro", "You are a tiny agent. Use the provided tools to answer. Be brief."),
+    static("rules", "Rules: prefer tools over guessing; never invent file contents."),
+    Section("tools", lambda s: "Tools: " + ", ".join(s["tools"]) if s.get("tools") else None),
+    Section("env", lambda s: f"cwd: {s['cwd']}" if s.get("cwd") else None),
+    Section("mcp", lambda s: "MCP servers connected; extra tools may appear." if s.get("mcp") else None),
+]

--- a/sections/21-loop-engineering/src/protocols.py
+++ b/sections/21-loop-engineering/src/protocols.py
@@ -1,0 +1,178 @@
+"""Protocols (section 17): typed request/reply over the section-16 channel.
+Introduced in section 17, then carried forward unchanged.
+
+The channel (section 16) only moves text; text alone has no contract. A protocol
+is the agreed rule on top of it, and it is three small things:
+
+  1. Typed variants. Every message carries a `type` field, so a handler
+     dispatches on it and a reply is never mistaken for an unrelated request.
+  2. A correlation id. `request_id` is set when the request goes out and echoed
+     in the reply, so the sender knows which pending request a reply resolves.
+  3. A small state machine. A request goes pending -> approved or rejected. A
+     reply for an already resolved (or unknown) id is ignored, so duplicates and
+     stray replies are harmless.
+
+Two flows are mirror images of each other. In shutdown the lead requests and the
+teammate confirms; in plan approval the teammate requests and the lead confirms.
+Both ride the same `Protocol` tracker, just in opposite directions. Approval can
+carry the permission mode the work runs under (section 3), so the verdict and the
+mode it runs under travel together.
+
+On top of the tracker, `run_teammate` is section 16's `serve_mailbox` extended
+with the shutdown handshake: a spawned teammate now stops on a lead's request
+instead of dying with its daemon thread. Initiating a stop is the lead's tool call
+(StopTeammate); confirming it is harness-driven, done by the loop itself, not a
+model tool (the reference confirms in the inbox dispatcher the same way).
+
+ponytail: in-process pending dict, one tracker per agent; a cross-restart bus
+would persist pending state, but the resolve logic stays the same.
+"""
+from __future__ import annotations
+
+import time
+
+from mailbox import _fold
+from tools import Tool
+
+PENDING, APPROVED, REJECTED = "pending", "approved", "rejected"
+
+# Which reply variants answer each request, and the verdict each implies.
+# None means a single response variant that carries the verdict in an `approved`
+# field (the plan flow), rather than splitting it across two reply types.
+_REPLIES = {
+    "shutdown_request": {"shutdown_approved": APPROVED, "shutdown_rejected": REJECTED},
+    "plan_approval_request": {"plan_approval_response": None},
+}
+
+
+class Protocol:
+    """Per-agent request tracker over a Team channel (section 16). It records each
+    outgoing request as pending and resolves the matching reply exactly once."""
+
+    def __init__(self, team, me):
+        self.team = team
+        self.me = me
+        self._n = 0
+        self.pending = {}                         # request_id -> {"kind", "state"} (outbound)
+        self.inbound = {}                         # request type -> the message to reply to
+
+    def request(self, to, kind, **fields):
+        """Send a typed request (`kind` is the wire `type` field), record it
+        pending, and return its correlation id."""
+        if kind not in _REPLIES:                  # only known request types have a reply contract
+            raise ValueError(f"unknown request type: {kind!r}")
+        self._n += 1
+        rid = f"{self.me}-{self._n}"              # per-sender id: unique and deterministic
+        self.pending[rid] = {"kind": kind, "state": PENDING}
+        self.team.send(self.me, to, {"type": kind, "request_id": rid, **fields})
+        return rid
+
+    def reply(self, msg, kind, **fields):
+        """Answer an inbound request by echoing its request_id back to the sender,
+        so the reply correlates to exactly what it answers."""
+        req = msg["content"]
+        self.team.send(self.me, msg["from"], {"type": kind, "request_id": req["request_id"], **fields})
+
+    def resolve(self, msg):
+        """Apply an inbound reply to its pending request and return the new state.
+        Returns None (a no-op) if the id is unknown, already resolved, or the reply
+        type does not answer the recorded request. Idempotent on duplicates."""
+        reply = msg["content"]
+        req = self.pending.get(reply.get("request_id"))
+        if not req or req["state"] != PENDING:    # unknown id or already resolved
+            return None
+        verdicts = _REPLIES[req["kind"]]
+        if reply.get("type") not in verdicts:     # type-confusion guard: wrong reply kind
+            return None
+        state = verdicts[reply["type"]]
+        if state is None:                         # single-response flow carries the bool
+            state = APPROVED if reply.get("approved") else REJECTED
+        req["state"] = state
+        return state
+
+    def note_inbound(self, msg):
+        """Record an inbound typed request so a reply tool can answer it without
+        the model passing request_ids around. Keyed by request type, latest wins."""
+        content = msg.get("content")
+        if isinstance(content, dict) and content.get("type") in _REPLIES:
+            self.inbound[content["type"]] = msg
+
+
+def protocol_tools(proto, lead="lead"):
+    """The handshake initiations as tools the model calls, so gating a plan or
+    stopping a teammate is the model's decision, not a script's. The worker submits
+    a plan with ExitPlanMode; the lead answers with ApprovePlan and asks a worker to
+    stop with StopTeammate. Replies correlate by request_id under the hood
+    (note_inbound records the request). Confirming a shutdown is not a tool: the
+    teammate's run_teammate loop replies automatically (harness-driven reception,
+    like Claude Code's inbox dispatcher). Mirrors ExitPlanModeV2Tool and the stop
+    path."""
+    def exit_plan(a):                              # worker -> lead: gate the plan before editing
+        proto.request(lead, "plan_approval_request", plan=a["plan"])
+        return "plan submitted to the lead; awaiting approval before any edits"
+
+    def approve_plan(a):                           # lead -> worker: answer the pending plan
+        req = proto.inbound.get("plan_approval_request")
+        if req is None:
+            return "no plan is awaiting approval"
+        fields = {"approved": bool(a.get("approved", True))}
+        if a.get("permissionMode"):
+            fields["permissionMode"] = a["permissionMode"]   # the verdict carries the mode (section 3)
+        proto.reply(req, "plan_approval_response", **fields)
+        return "plan approved" if fields["approved"] else "plan rejected"
+
+    def stop_teammate(a):                          # lead -> worker: ask for a clean stop
+        proto.request(a["name"], "shutdown_request", reason=a.get("reason", "done"))
+        return f"asked {a['name']} to stop"
+
+    return [
+        Tool("ExitPlanMode", exit_plan, is_read_only=True,
+             description="Submit your plan to the lead and wait for approval before editing.",
+             input_schema={"type": "object", "properties": {"plan": {"type": "string"}},
+                           "required": ["plan"]}),
+        Tool("ApprovePlan", approve_plan, is_read_only=True,
+             description="Approve or reject the plan a teammate submitted for review.",
+             input_schema={"type": "object", "properties": {
+                 "approved": {"type": "boolean"}, "feedback": {"type": "string"},
+                 "permissionMode": {"type": "string"}}}),
+        Tool("StopTeammate", stop_teammate, is_read_only=True,
+             description="Ask a teammate to finish and stop cleanly, by name.",
+             input_schema={"type": "object", "properties": {
+                 "name": {"type": "string"}, "reason": {"type": "string"}},
+                 "required": ["name"]}),
+    ]
+
+
+def _is_shutdown(msg):
+    content = msg["content"]
+    return isinstance(content, dict) and content.get("type") == "shutdown_request"
+
+
+def run_teammate(team, me, lead, work, *, poll=0.05, max_idle_polls=None):
+    """Section 16's serve_mailbox plus the shutdown handshake. Each pass drains the
+    inbox: a shutdown_request is confirmed with shutdown_approved and ends the
+    loop, so a teammate is stopped by a handshake, not by killing its daemon
+    thread; chat messages fold into one prompt and run `work(prompt)`; an empty
+    inbox polls again. The confirm is the loop's own doing, not a model tool call
+    (harness-driven reception, like the reference's inbox dispatcher), and shutdown
+    is checked before chat so peer traffic cannot starve a stop. Returns 'shutdown'
+    when the handshake
+    stops it, 'idle' if a bounded loop gives up first. Section 18 adds claiming
+    board tasks when the inbox is empty."""
+    proto = Protocol(team, me)
+    idle = 0
+    while True:
+        inbox = team.drain(me)
+        shutdown = next((m for m in inbox if _is_shutdown(m)), None)
+        if shutdown is not None:
+            proto.reply(shutdown, "shutdown_approved")      # confirm, then stop
+            return "shutdown"
+        chat = [m for m in inbox if isinstance(m["content"], str)]
+        if chat:
+            idle = 0
+            work(_fold(chat))                               # one inner loop on the folded message
+            continue
+        idle += 1
+        if max_idle_polls is not None and idle >= max_idle_polls:
+            return "idle"
+        time.sleep(poll)

--- a/sections/21-loop-engineering/src/recovery.py
+++ b/sections/21-loop-engineering/src/recovery.py
@@ -1,0 +1,85 @@
+"""Error recovery (section 11): wrap the model call so transient failures retry,
+recoverable ones adapt, and only fatal ones surface.
+
+Introduced in section 11, then carried forward unchanged.
+
+with_retry classifies each failure and takes the matching path:
+  transient (429 / 408 / 409 / 5xx) : exponential backoff + jitter, honor retry-after.
+  overflow  (prompt too long)       : run on_overflow() once (compact, section 8), retry.
+  529 storm                         : after MAX_529_RETRIES, raise FallbackTriggered.
+  fatal     (4xx, unknown)          : raise at once.
+State (consecutive 529s, a one-shot overflow flag) persists across attempts so
+each path is bounded. Mirrors Claude Code's withRetry + getRetryDelay +
+FallbackTriggeredError + the prompt_too_long -> reactive-compact path.
+"""
+from __future__ import annotations
+
+import time
+from random import random
+
+BASE_DELAY = 0.5            # seconds; doubles each attempt
+MAX_DELAY = 32.0
+DEFAULT_MAX_RETRIES = 10
+MAX_529_RETRIES = 3         # consecutive overloads before falling back to another model
+RETRY_STATUS = {408, 409, 429}   # these plus any 5xx are worth retrying
+
+
+class FallbackTriggered(Exception):
+    """Raised after repeated 529s so the caller can retry on `fallback_model`."""
+
+    def __init__(self, fallback_model):
+        super().__init__(f"falling back to {fallback_model}")
+        self.fallback_model = fallback_model
+
+
+def should_retry(status) -> bool:
+    return status in RETRY_STATUS or (status is not None and 500 <= status < 600)
+
+
+def retry_delay(attempt, retry_after=None) -> float:
+    """Exponential backoff with up to 25% jitter; a server retry-after wins."""
+    if retry_after is not None:
+        return float(retry_after)
+    base = min(BASE_DELAY * 2 ** (attempt - 1), MAX_DELAY)
+    return base + base * 0.25 * random()
+
+
+def with_retry(call, on_overflow=None, fallback_model=None,
+               max_retries=DEFAULT_MAX_RETRIES, sleep=time.sleep):
+    """Call `call()`, recovering per error class. Returns its result, or raises
+    once recovery is exhausted so the loop can feed the error back (section 1)."""
+    consecutive_529 = 0
+    overflowed = False
+    for attempt in range(1, max_retries + 2):
+        try:
+            return call()
+        except FallbackTriggered:
+            raise
+        except Exception as e:
+            if _is_overflow(e):
+                if on_overflow is None or overflowed:
+                    raise                       # already compacted once; nothing left to shrink
+                overflowed = True
+                on_overflow()                   # compact (section 8), then retry
+                continue
+            status = _status(e)
+            if status is None:
+                raise                           # not a recognized API error -> fatal
+            if status == 529:
+                consecutive_529 += 1
+                if fallback_model and consecutive_529 >= MAX_529_RETRIES:
+                    raise FallbackTriggered(fallback_model)
+            if attempt > max_retries or not should_retry(status):
+                raise                           # exhausted or non-retryable -> surface it
+            sleep(retry_delay(attempt, getattr(e, "retry_after", None)))
+    raise RuntimeError("with_retry exhausted")  # unreachable: the loop returns or raises first
+
+
+def _status(e):
+    """The HTTP status of an API error, or None. The anthropic SDK exposes
+    status_code; the offline test sets the same attribute."""
+    return getattr(e, "status_code", None)
+
+
+def _is_overflow(e) -> bool:
+    return getattr(e, "overflow", False) or "prompt is too long" in str(e).lower()

--- a/sections/21-loop-engineering/src/scheduler.py
+++ b/sections/21-loop-engineering/src/scheduler.py
@@ -1,0 +1,114 @@
+"""Scheduling (section 14): a clock fires turns on a schedule, no human at the
+keyboard. Introduced in section 14, then carried forward unchanged.
+
+A Scheduler holds entries (each a prompt plus a fire time) and ticks on its own
+daemon thread, independent of whether the loop is running. When a task is due it
+does not call the model: it enqueues the prompt (onFire), and the driver drains
+that queue between turns (section 1), so a fired prompt arrives as a new
+user-style turn. Recurring tasks re-arm to the next interval, one-shots
+auto-delete. Durable tasks persist to JSON and reload on start (section 12), so
+a schedule set today re-arms after a restart.
+
+We model "when" as an absolute fire time plus an optional repeat interval, not a
+5-field cron string. ponytail: timestamp + interval is the mechanism without a
+cron parser; swap in croniter if real cron expressions are needed.
+
+A scheduled run has no human at the keyboard, so its answer needs a route out:
+each task can name a channel, and deliver() sends the turn's answer there
+(Hermes delivers cron output to the job's chat platform). An answer starting
+with [SILENT] delivers nothing, the contract for "checked, nothing to report".
+"""
+from __future__ import annotations
+
+import json
+import queue
+import threading
+import time
+from pathlib import Path
+
+SILENT = "[SILENT]"                              # a fired run may decide nothing is worth sending
+
+
+def deliver(channels, fired, text) -> bool:
+    """Route a fired task's answer to its channel: channels maps a channel name to
+    a send callable (print, Slack, SMS; section 19 wires real ones). No channel or
+    a [SILENT]-prefixed answer delivers nothing; the caller still holds the text
+    (Hermes saves cron output to disk either way)."""
+    if not fired.get("channel") or text.lstrip().startswith(SILENT):
+        return False
+    channels[fired["channel"]](text)
+    return True
+
+
+class Scheduler:
+    """Fires scheduled prompts when the clock catches up to their due time."""
+
+    CHECK_INTERVAL = 1.0                         # tick cadence, like cronScheduler's 1s
+
+    def __init__(self, path=None, clock=time.time):
+        self._next = 0
+        self._tasks: dict[int, dict] = {}        # id -> {id, prompt, due, every, durable}
+        self._pending: queue.Queue = queue.Queue()   # fired prompts waiting for the loop
+        self._clock = clock                      # injectable so tests run on a fake clock
+        self._path = Path(path) if path else None
+        self._stop = threading.Event()
+        if self._path and self._path.exists():
+            self._load()                         # 12 · reload durable tasks on start
+
+    def create(self, prompt, due=None, every=None, durable=False, channel=None):
+        """Schedule a prompt. due: absolute fire time (default now). every:
+        seconds between recurring fires (None = one-shot). durable: persist.
+        channel: where deliver() routes the fired turn's answer (None = nowhere)."""
+        self._next += 1
+        tid = self._next
+        self._tasks[tid] = {"id": tid, "prompt": prompt, "every": every, "durable": durable,
+                            "channel": channel,
+                            "due": due if due is not None else self._clock()}
+        self._save()
+        return tid
+
+    def list(self):
+        return list(self._tasks.values())
+
+    def tick(self):
+        """Fire every task whose due time has passed; re-arm recurring, drop one-shots."""
+        now = self._clock()
+        for tid, t in list(self._tasks.items()):
+            if now >= t["due"]:
+                self._pending.put({"prompt": t["prompt"], "channel": t.get("channel")})
+                # onFire: enqueue, never run the model here; the channel rides along
+                # so the driver knows where the answer goes
+                if t["every"]:
+                    t["due"] = now + t["every"]   # recurring: re-arm past now, so 1s ticks fire once
+                else:
+                    self._tasks.pop(tid, None)    # one-shot: auto-delete after firing
+        self._save()
+
+    def drain(self):
+        """Every fired task waiting so far ({prompt, channel} dicts), oldest first;
+        empties the queue."""
+        out = []
+        while True:
+            try:
+                out.append(self._pending.get_nowait())
+            except queue.Empty:
+                return out
+
+    def run(self):
+        """Start the tick thread (daemon, so it never keeps the process alive)."""
+        def loop():
+            while not self._stop.wait(self.CHECK_INTERVAL):
+                self.tick()
+        threading.Thread(target=loop, daemon=True).start()
+
+    def stop(self):
+        self._stop.set()
+
+    def _save(self):
+        if self._path:                           # only durable tasks survive a restart
+            self._path.write_text(json.dumps([t for t in self._tasks.values() if t["durable"]]))
+
+    def _load(self):
+        for t in json.loads(self._path.read_text()):
+            self._tasks[t["id"]] = t
+            self._next = max(self._next, t["id"])

--- a/sections/21-loop-engineering/src/skills.py
+++ b/sections/21-loop-engineering/src/skills.py
@@ -1,0 +1,150 @@
+"""Skills (section 7): progressive disclosure of a skill into context.
+
+Introduced in section 7, then carried forward unchanged.
+
+A skill reveals itself in three levels, each loaded only when needed:
+  L1 metadata  : name + description (frontmatter), always in the system prompt (cheap).
+  L2 body      : the SKILL.md instructions, read on demand with the normal file tool.
+  L3 resources : files bundled in the skill folder, read with the same file tool.
+
+No skill-specific tool is needed. Once the catalog (name, description, path) sits
+in the system prompt, the agent loads a skill by reading its SKILL.md with the same
+Read tool it uses for any file. L2 (body) and L3 (resources) both go through that
+one tool. load_skills() scans the dir and keeps only L1; catalog_prompt() renders
+the L1 block for the system prompt. Mirrors Claude Code's loadSkillsDir (scans
+.claude/skills) and its system-prompt skill listing. Claude Code wraps body-loading
+in a SkillTool because its skills also fork and scope tools; the plain mechanism
+here does not need one, so a normal path-scoped Read does the job.
+
+The store also evolves (Hermes Agent's skill evolution):
+  use    : reading a SKILL.md bumps a usage record (.usage.json), the way Hermes
+           bumps view/use counts on every skill_view call.
+  write  : WriteSkill lets the agent distill a finished workflow into a new
+           skill, so the next run loads instructions instead of rediscovering them.
+  curate : stale_skills() reports skills unused past a cutoff; Hermes runs a
+           background curator agent on this signal (archive, consolidate, pin).
+"""
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from tools import Tool
+
+MAX_LISTING_DESC_CHARS = 80   # per-entry cap keeps the catalog cheap (Claude Code uses 250)
+USAGE_FILE = ".usage.json"    # per-store usage record; Hermes keeps the same file per skills root
+STALE_AFTER = 30 * 86400      # unused this long (or never used) counts as stale
+
+PATH_SCHEMA = {
+    "type": "object",
+    "properties": {"path": {"type": "string"}},
+    "required": ["path"],
+}
+
+
+@dataclass
+class Skill:
+    name: str
+    description: str       # L1: from frontmatter, shown in the catalog
+    path: Path            # SKILL.md; the body (L2) and bundled files (L3) are read on demand
+
+
+def load_skills(skills_dir) -> list[Skill]:
+    """L1: scan <skills_dir>/<name>/SKILL.md, keeping frontmatter only (cheap)."""
+    skills = []
+    for sub in sorted(Path(skills_dir).iterdir()):
+        md = sub / "SKILL.md"
+        if md.is_file():
+            meta, _body = _split(md.read_text())
+            skills.append(Skill(meta.get("name", sub.name), meta.get("description", ""), md))
+    return skills
+
+
+def catalog_prompt(skills, base_dir) -> str:
+    """L1: the skills block injected into the system prompt at startup, so the model
+    knows which skills exist and where to read each one. Name + description + path
+    only, never the body. The agent reads the path with its normal Read tool."""
+    base = Path(base_dir)
+    lines = [f"- {s.name}: {s.description[:MAX_LISTING_DESC_CHARS]} (read {s.path.relative_to(base)})"
+             for s in skills]
+    return "Available skills (read a skill's path with the Read tool to load it):\n" + "\n".join(lines)
+
+
+def read_tool(base_dir) -> Tool:
+    """The normal file tool. Loads a skill body (L2) or a bundled resource (L3) by
+    path. Scoped to base_dir so a skill name can never escape into the filesystem."""
+    base = Path(base_dir).resolve()
+
+    def read(a):
+        target = (base / a["path"]).resolve()
+        if not target.is_relative_to(base):          # reject path traversal (../../etc/passwd)
+            raise ValueError(f"path {a['path']!r} escapes the skills dir")
+        if target.name == "SKILL.md":                # loading a skill counts as use (Hermes bumps
+            record_use(base, target.parent.name)     # .usage.json on every skill_view)
+        return target.read_text()                     # tool result -> enters messages[]
+
+    return Tool("Read", read, description="Read a file by its path.",
+                input_schema=PATH_SCHEMA, is_read_only=True)
+
+
+def record_use(skills_dir, name, now=None) -> dict:
+    """Bump `name`'s usage record: uses count plus last_used_at. The curator's
+    stale timer keys off last_used_at (Hermes: agent/curator.py)."""
+    path = Path(skills_dir) / USAGE_FILE
+    usage = json.loads(path.read_text()) if path.exists() else {}
+    entry = usage.setdefault(name, {"uses": 0})
+    entry["uses"] += 1
+    entry["last_used_at"] = now if now is not None else time.time()
+    path.write_text(json.dumps(usage))
+    return entry
+
+
+def stale_skills(skills_dir, skills, now=None, stale_after=STALE_AFTER) -> list[str]:
+    """The curator's input: names unused for stale_after (never used counts too).
+    ponytail: a report, not an action; Hermes archives these via a background
+    curator agent, with pins protecting skills from auto-archive."""
+    path = Path(skills_dir) / USAGE_FILE
+    usage = json.loads(path.read_text()) if path.exists() else {}
+    now = now if now is not None else time.time()
+    return [s.name for s in skills
+            if now - usage.get(s.name, {}).get("last_used_at", 0) >= stale_after]
+
+
+def write_skill(skills_dir, name, description, body) -> Path:
+    """The agent distills a finished workflow into a new skill on disk. The next
+    load_skills() scan catalogs it, so the store grows from the agent's own work."""
+    base = Path(skills_dir).resolve()
+    target = (base / name / "SKILL.md").resolve()
+    if not target.is_relative_to(base):              # a name can never escape the skills dir
+        raise ValueError(f"skill name {name!r} escapes the skills dir")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(f"---\nname: {name}\ndescription: {description}\n---\n{body}\n")
+    return target
+
+
+def write_tool(base_dir) -> Tool:
+    """WriteSkill: the model-facing handle for write_skill. A side effect, so the
+    gate (section 3) asks unless a rule pre-approves it. Hermes goes further and
+    can stage skill writes for async human approval (write_approval.py)."""
+    def write(a):
+        write_skill(base_dir, a["name"], a["description"], a["body"])
+        return f"skill {a['name']!r} saved; the next catalog scan lists it"
+
+    return Tool("WriteSkill", write,
+                description="Save a reusable skill (name, description, body) for future runs.",
+                input_schema={"type": "object",
+                              "properties": {"name": {"type": "string"},
+                                             "description": {"type": "string"},
+                                             "body": {"type": "string"}},
+                              "required": ["name", "description", "body"]})
+
+
+def _split(text):
+    """Minimal SKILL.md parse into (frontmatter dict, body). ponytail: assumes a
+    well-formed '---\\n<key: value>...\\n---\\n<body>' header (real CC uses YAML)."""
+    _, frontmatter, body = text.split("---", 2)
+    meta = {k.strip(): v.strip() for k, v in
+            (line.split(":", 1) for line in frontmatter.strip().splitlines() if ":" in line)}
+    return meta, body.strip()

--- a/sections/21-loop-engineering/src/skills/pdf-fill/SKILL.md
+++ b/sections/21-loop-engineering/src/skills/pdf-fill/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: pdf-fill
+description: Fill PDF form fields from a data dict.
+---
+PDF FILL STEPS:
+1. open the form
+2. map each value to its form field. The field map is in the bundled file
+   reference.md; read that file when you need an exact field name.
+3. write values
+4. flatten

--- a/sections/21-loop-engineering/src/skills/pdf-fill/reference.md
+++ b/sections/21-loop-engineering/src/skills/pdf-fill/reference.md
@@ -1,0 +1,4 @@
+PDF FIELD MAP:
+- applicant email -> form field "email_addr"
+- applicant name  -> form field "full_name"
+- submission date -> form field "date_iso"

--- a/sections/21-loop-engineering/src/skills/sql-style/SKILL.md
+++ b/sections/21-loop-engineering/src/skills/sql-style/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: sql-style
+description: Apply the house SQL style guide.
+---
+SQL STYLE:
+lowercase keywords, trailing commas, CTEs over subqueries.

--- a/sections/21-loop-engineering/src/subagents.py
+++ b/sections/21-loop-engineering/src/subagents.py
@@ -1,0 +1,35 @@
+"""Subagents (section 6): spawn the agent loop again inside a tool call.
+
+Introduced in section 6, then carried forward unchanged.
+
+A subagent is `run()` (loop.py) invoked with a FRESH messages[]: the child
+explores in its own context and only its final text returns to the parent. The
+child's own tool calls still pass the gate (section 3), so isolating context
+does not isolate authority. Recursion is fenced by curating the child's tools:
+the child registry omits the Agent tool, so a child cannot spawn another.
+Mirrors Claude Code's AgentTool + runAgent.ts (fresh initialMessages,
+extractTextContent of the last message).
+"""
+from __future__ import annotations
+
+from loop import Session, run_turn
+from tools import Tool
+
+DESCRIPTION_SCHEMA = {
+    "type": "object",
+    "properties": {"description": {"type": "string"}},
+    "required": ["description"],
+}
+
+
+def agent_tool(model, child_registry, parent_session, max_steps=20) -> Tool:
+    """Agent: run a child loop on `description`, return only its final text."""
+    def spawn(a):
+        child = Session(mode=parent_session.mode,
+                        allow_rules=set(parent_session.allow_rules))  # fresh context, inherited authority
+        return run_turn([{"role": "user", "content": a["description"]}], model, child_registry, child, max_steps=max_steps)
+
+    # spawning is read-only itself; the child's individual calls are what the gate sees
+    return Tool("Agent", spawn,
+                description="Delegate a subtask to a fresh subagent; returns only its final answer.",
+                input_schema=DESCRIPTION_SCHEMA, is_read_only=True)

--- a/sections/21-loop-engineering/src/tasks.py
+++ b/sections/21-loop-engineering/src/tasks.py
@@ -1,0 +1,138 @@
+"""Task system (section 12): durable work records on disk, with a status state
+machine, blockedBy/blocks dependency edges, and a lock-serialized claim.
+
+Introduced in section 12, then carried forward unchanged.
+
+Each task is one JSON file under a task dir. create/get/update/list are CRUD;
+claim() refuses a task whose blockers are not all completed, and takes an
+exclusive file lock so two agents (section 16) cannot both win the same task.
+IDs are sequential, tracked in .highwatermark so a deleted id is never reused.
+Mirrors Claude Code's utils/tasks.ts (TaskSchema, createTask/claimTask,
+getTaskPath, .highwatermark, proper-lockfile).
+"""
+from __future__ import annotations
+
+import fcntl
+import json
+from contextlib import contextmanager
+from pathlib import Path
+
+from tools import Tool
+
+
+class TaskStore:
+    """The durable task graph: one JSON file per task under `root`."""
+
+    def __init__(self, root):
+        self.root = Path(root)
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def create(self, subject, blocked_by=()):
+        tid = self._next_id()
+        task = {"id": tid, "subject": subject, "status": "pending",
+                "owner": None, "blockedBy": list(blocked_by), "blocks": []}
+        self._write(task)
+        for b in blocked_by:                           # keep the reverse edge in sync
+            dep = self.get(b)
+            if dep is not None:
+                dep["blocks"].append(tid)
+                self._write(dep)
+        return task
+
+    def update(self, tid, status=None):
+        task = self.get(tid)
+        if task is None:
+            return None
+        if status is not None:
+            task["status"] = status                    # soft: any transition the caller asks for
+        self._write(task)
+        return task
+
+    def claim(self, tid, owner):
+        """Claim a task for `owner` iff it is unowned and every blocker is
+        completed. Serialized by an exclusive lock so a claim race has one winner."""
+        with self._lock():
+            task = self.get(tid)
+            if task is None:
+                return {"ok": False, "reason": "not_found"}
+            if task["owner"] is not None:
+                return {"ok": False, "reason": "already_claimed"}
+            unmet = [b for b in task["blockedBy"]
+                     if (self.get(b) or {}).get("status") != "completed"]
+            if unmet:
+                return {"ok": False, "reason": "blocked"}
+            task["owner"], task["status"] = owner, "in_progress"
+            self._write(task)
+            return {"ok": True, "task": task}
+
+    def get(self, tid):
+        return self._read(self._path(tid))
+
+    def list(self):
+        tasks = (self._read(p) for p in self.root.glob("*.json"))
+        return sorted((t for t in tasks if t is not None), key=lambda t: t["id"])
+
+    # --- disk plumbing ---
+    def _path(self, tid):
+        return self.root / f"{tid}.json"
+
+    def _write(self, task):
+        self._path(task["id"]).write_text(json.dumps(task))
+
+    def _read(self, path):
+        try:
+            return json.loads(Path(path).read_text())
+        except (OSError, ValueError):                   # missing or hand-corrupted: skip, don't crash
+            return None
+
+    def _next_id(self):
+        hwm = self.root / ".highwatermark"
+        n = (int(hwm.read_text()) + 1) if hwm.exists() else 1
+        hwm.write_text(str(n))                          # ponytail: single-writer creates; claim() is the locked path
+        return n
+
+    @contextmanager
+    def _lock(self):
+        f = open(self.root / ".lock", "w")
+        try:
+            fcntl.flock(f, fcntl.LOCK_EX)               # blocks until the other claimer releases
+            yield
+        finally:
+            fcntl.flock(f, fcntl.LOCK_UN)
+            f.close()
+
+
+def task_tools(store: TaskStore):
+    """The four LLM-facing tools, thin wrappers over the store (Claude Code's
+    TaskCreate / TaskUpdate / TaskGet / TaskList)."""
+    def create(a):
+        t = store.create(a["subject"], a.get("blockedBy", []))
+        return f"created task {t['id']}"
+
+    def update(a):
+        t = store.update(a["id"], status=a.get("status"))
+        return f"task {a['id']} -> {t['status']}" if t else "no such task"
+
+    def get(a):
+        t = store.get(a["id"])
+        return json.dumps(t) if t else "no such task"
+
+    def lst(_a):
+        return json.dumps([{"id": t["id"], "subject": t["subject"], "status": t["status"]}
+                           for t in store.list()])
+
+    return [
+        Tool("TaskCreate", create, description="Create a durable task. May depend on others.",
+             input_schema={"type": "object", "properties": {
+                 "subject": {"type": "string"},
+                 "blockedBy": {"type": "array", "items": {"type": "integer"}}},
+                 "required": ["subject"]}),
+        Tool("TaskUpdate", update, description="Set a task's status (pending|in_progress|completed).",
+             input_schema={"type": "object", "properties": {
+                 "id": {"type": "integer"}, "status": {"type": "string"}},
+                 "required": ["id", "status"]}),
+        Tool("TaskGet", get, description="Read one task by id.", is_read_only=True,
+             input_schema={"type": "object", "properties": {"id": {"type": "integer"}},
+                           "required": ["id"]}),
+        Tool("TaskList", lst, description="List all tasks.", is_read_only=True),
+    ]

--- a/sections/21-loop-engineering/src/telemetry.py
+++ b/sections/21-loop-engineering/src/telemetry.py
@@ -1,0 +1,103 @@
+"""Observability & evaluation (section 20): watch it and measure it.
+
+Two separable pipelines, neither of which touches the loop's control flow.
+
+Telemetry runs inline. emit() is fire-and-forget: events queue until a sink
+attaches (the loop can log before telemetry is ready), then each event is
+sampled, scrubbed of sensitive fields, and fanned out to every sink. It never
+blocks and never raises, so a logging fault cannot stall or crash the loop
+(section 1).
+
+CostTracker accumulates per-model token usage into a running USD total, the
+number surfaced live and on exit.
+
+run_eval() runs off the hot path: replay a fixed task set against a candidate
+build and grade each output, so a quiet quality regression is caught before
+users hit it. Telemetry says what happened; only eval says whether it was good.
+
+Mirrors Claude Code services/analytics/: index.ts queues logEvent then drains
+on attachAnalyticsSink, shouldSampleEvent drops by rate, the
+_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS marker guards sensitive fields, and
+cost-tracker.ts / modelCost.ts roll per-model token cost into a session total.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+# Fields safe to send to a general-access backend. Anything else is dropped
+# before fan-out, so code, file paths, and prompts never leak (the
+# _I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS allowlist).
+SAFE_FIELDS = {"event", "tool", "model", "duration_ms", "ok", "tokens", "cost_usd"}
+
+# Per-model price per token (input, output) in USD; illustrative, not current.
+PRICES = {
+    "claude-opus-4-8":   (15e-6, 75e-6),
+    "claude-sonnet-5":   (3e-6, 15e-6),
+    "claude-sonnet-4-6": (3e-6, 15e-6),
+    "claude-haiku-4-5":  (0.8e-6, 4e-6),
+}
+
+
+def scrub(meta: dict) -> dict:
+    """Keep only allowlisted fields (stripProtoFields): a value not known safe
+    never reaches a backend."""
+    return {k: v for k, v in meta.items() if k in SAFE_FIELDS}
+
+
+class Telemetry:
+    """Inline event logger. Fire-and-forget: emit() never blocks and never
+    raises, so a logging fault cannot stall the loop (section 1)."""
+
+    def __init__(self, sample=None):
+        self.sinks: list = []
+        self._queue: list = []                        # events emitted before any sink attached
+        self.sample = sample or (lambda name: True)   # shouldSampleEvent: keep or drop
+
+    def attach(self, sink) -> None:
+        """Register a sink and drain the pre-sink buffer through it."""
+        self.sinks.append(sink)
+        pending, self._queue = self._queue, []
+        for name, meta in pending:
+            self._deliver(name, meta)
+
+    def emit(self, name: str, **meta) -> None:
+        if not self.sinks:
+            self._queue.append((name, meta))          # buffer until a sink is ready
+            return
+        self._deliver(name, meta)
+
+    def _deliver(self, name, meta) -> None:
+        if not self.sample(name):                     # dropped by sampling rate
+            return
+        clean = scrub(meta)                            # allowlist before any backend sees it
+        for sink in self.sinks:
+            try:
+                sink(name, clean)
+            except Exception:                          # ponytail: one bad sink never breaks the loop
+                pass
+
+
+@dataclass
+class CostTracker:
+    """Accumulate per-model token usage into a running USD total (cost-tracker.ts)."""
+    by_model: dict = field(default_factory=dict)      # model -> (input_tokens, output_tokens)
+    cost_usd: float = 0.0
+
+    def add(self, model: str, input_tokens: int, output_tokens: int) -> float:
+        i, o = self.by_model.get(model, (0, 0))
+        self.by_model[model] = (i + input_tokens, o + output_tokens)
+        pi, po = PRICES.get(model, (0.0, 0.0))         # modelCost.ts pricing tiers
+        self.cost_usd += input_tokens * pi + output_tokens * po
+        return self.cost_usd
+
+
+def run_eval(build, tasks) -> dict:
+    """Replay a fixed task set against a candidate build and grade each output.
+
+    build(task_input) -> output; each task is (input, grade) where grade(output)
+    -> bool. Off the hot path: this is how a quality regression is caught before
+    a release ships. Returns the pass rate and the per-task verdicts."""
+    verdicts = [bool(grade(build(inp))) for inp, grade in tasks]
+    passed = sum(verdicts)
+    return {"passed": passed, "total": len(tasks),
+            "rate": passed / len(tasks) if tasks else 1.0, "verdicts": verdicts}

--- a/sections/21-loop-engineering/src/test.py
+++ b/sections/21-loop-engineering/src/test.py
@@ -1,0 +1,91 @@
+"""Section 21 offline checks, no key, no network.
+
+test_pass_first_try(): a passing candidate returns after one attempt.
+
+test_feedback_retry(): a failed verdict rides into the retry as feedback, and
+attempt two passes because it saw why attempt one failed.
+
+test_budget_escalate(): a worker that never passes stops at the budget with
+ok=False. The ceiling is the harness's range(), not the model's judgment.
+
+test_agent_checker(): the checker runs the inner loop on a fresh messages[]
+and parses the first-word PASS/FAIL verdict contract.
+
+    python sections/21-loop-engineering/src/test.py
+"""
+from verify import agent_checker, verified_run
+
+
+def test_pass_first_try():
+    checker = lambda task, out: {"passed": out == "42", "reason": "must be 42"}
+    r = verified_run("add 27 and 15", lambda p: "42", checker, budget=3)
+    assert r["ok"] and r["output"] == "42" and len(r["attempts"]) == 1
+
+    print("21 loop-eng: pass-first-try ok")
+
+
+def test_feedback_retry():
+    prompts = []
+
+    def worker(prompt):
+        prompts.append(prompt)
+        return "42" if "prior attempt" in prompt.lower() else "41"   # attempt two reads the feedback
+
+    checker = lambda task, out: {"passed": out == "42", "reason": "off by one"}
+    r = verified_run("add 27 and 15", worker, checker, budget=3)
+    assert r["ok"] and len(r["attempts"]) == 2
+    assert r["attempts"][0]["passed"] is False
+    assert "prior" not in prompts[0].lower()       # attempt one saw only the task
+    assert "off by one" in prompts[1]              # the verdict reached attempt two as data
+
+    print("21 loop-eng: feedback-retry ok")
+
+
+def test_budget_escalate():
+    calls = []
+    worker = lambda p: (calls.append(p), "wrong")[1]
+    checker = lambda task, out: {"passed": False, "reason": "still wrong"}
+    r = verified_run("impossible", worker, checker, budget=2)
+    assert r["ok"] is False and r["output"] is None
+    assert len(calls) == 2 and len(r["attempts"]) == 2   # stopped at the ceiling, no attempt 3
+
+    print("21 loop-eng: budget-escalate ok")
+
+
+class _Text:                                       # a stand-in Anthropic text block
+    type = "text"
+
+    def __init__(self, text):
+        self.text = text
+
+
+class _Msg:                                        # a stand-in Anthropic Message
+    def __init__(self, text):
+        self.content = [_Text(text)]
+        self.stop_reason = "end_turn"
+
+
+def test_agent_checker():
+    seen = []
+
+    def model(messages, registry, system):
+        seen.append(list(messages))
+        return _Msg("FAIL the output is prose, not a number")
+
+    check = agent_checker("output is exactly one number", model)
+    v = check("add 27 and 15", "the answer is forty-two")
+    assert v["passed"] is False and "prose" in v["reason"]
+    assert len(seen[0]) == 1                       # a fresh messages[] per grade (section 6)
+
+    passing = agent_checker("output is exactly one number",
+                            lambda m, r, s: _Msg("PASS exactly one number"))
+    assert passing("add 27 and 15", "42")["passed"] is True
+
+    print("21 loop-eng: agent-checker ok")
+
+
+if __name__ == "__main__":
+    test_pass_first_try()
+    test_feedback_retry()
+    test_budget_escalate()
+    test_agent_checker()

--- a/sections/21-loop-engineering/src/tools.py
+++ b/sections/21-loop-engineering/src/tools.py
@@ -1,0 +1,73 @@
+"""Tool runtime (section 2): the Tool contract, a registry, dispatch, and
+parallel execution of concurrency-safe calls. Introduced in section 2, then
+carried forward unchanged.
+
+A Tool carries the Anthropic input_schema it advertises plus the handler that
+runs it; the Registry emits the tools list for the model. Mirrors Claude Code's
+Tool.ts (name, isReadOnly, isConcurrencySafe) and the partition-then-run step.
+"""
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+NO_INPUT = {"type": "object", "properties": {}}   # schema for a tool that takes no arguments
+
+
+@dataclass
+class Tool:
+    name: str
+    run: Callable[[dict], Any]
+    description: str = ""
+    input_schema: dict = field(default_factory=lambda: dict(NO_INPUT))
+    is_read_only: bool = False
+    is_concurrency_safe: bool = False   # may share a parallel batch
+    is_edit: bool = False               # a file edit; read by the permission gate (section 3)
+
+
+class Registry:
+    """Name to Tool. Adding a tool is registering one handler."""
+
+    def __init__(self):
+        self._tools: dict[str, Tool] = {}
+
+    def register(self, tool: Tool) -> None:
+        self._tools[tool.name] = tool
+
+    def get(self, name: str) -> Tool | None:
+        return self._tools.get(name)
+
+    def schemas(self) -> list[dict]:
+        """The tools list advertised to the model (Anthropic format)."""
+        return [{"name": t.name, "description": t.description, "input_schema": t.input_schema}
+                for t in self._tools.values()]
+
+
+def run_tool(tool: Tool, tool_input: dict) -> str:
+    """Execute one tool, turning any failure into a string result (never raises)."""
+    try:
+        return str(tool.run(tool_input))
+    except Exception as e:  # ponytail: failure is a result fed back, not a crashed loop
+        return f"error: {type(e).__name__}: {e}"
+
+
+def run_concurrently(registry: Registry, calls: list[dict]) -> list[str]:
+    """Dispatch a turn's tool calls; concurrency-safe ones share one parallel
+    batch. Output order matches input. The loop dispatches sequentially for
+    readability; this is the batching primitive the real runtime applies. Each
+    call is {"name": ..., "input": ...}."""
+    tools = [registry.get(c["name"]) for c in calls]
+    out: dict[int, str] = {}
+
+    safe = [i for i, t in enumerate(tools) if t and t.is_concurrency_safe]
+    if safe:
+        with ThreadPoolExecutor(max_workers=len(safe)) as pool:
+            for i, res in zip(safe, pool.map(lambda i: run_tool(tools[i], calls[i].get("input", {})), safe)):
+                out[i] = res
+
+    for i, t in enumerate(tools):
+        if i not in out:
+            out[i] = f"error: no tool {calls[i]['name']!r}" if t is None else run_tool(t, calls[i].get("input", {}))
+
+    return [out[i] for i in range(len(calls))]

--- a/sections/21-loop-engineering/src/verify.py
+++ b/sections/21-loop-engineering/src/verify.py
@@ -1,0 +1,61 @@
+"""Loop engineering (section 21): the verification loop.
+
+The inner loop (section 1) stops when the model says it is done. verified_run
+makes "done" a checked claim: a separate checker grades each candidate against
+a rubric, a failed verdict rides into the retry as feedback, and a harness-side
+budget caps the attempts. Budget spent means escalate (return the record with
+ok=False), not retry forever.
+
+The maker and checker split is section 6: agent_checker grades on a FRESH
+messages[] each time, so the worker never grades its own output. The rubric is
+fixed outside the loop; the model can satisfy it, not rewrite it.
+
+Mirrors the verification loop named by the loop-engineering sources
+(grade-and-retry, maker/checker) and Claude Code's Workflow verify stages
+(adversarial verify, judge panel).
+"""
+from __future__ import annotations
+
+from loop import Session, run_turn
+from permissions import DEFAULT
+from tools import Registry
+
+
+def verified_run(task, worker, checker, budget=2):
+    """Run worker(prompt) until checker passes it or the budget is spent.
+
+    worker(prompt) -> output text (typically run_turn on the inner loop).
+    checker(task, output) -> {"passed": bool, "reason": str}, a separate agent.
+    Returns {"ok", "output", "attempts"}; ok=False means escalate to a human.
+    The range() is the ceiling. The harness enforces it, not the model."""
+    feedback = ""
+    attempts = []
+    for n in range(1, budget + 1):
+        out = worker(task + feedback)                 # the inner loop (section 1)
+        verdict = checker(task, out)                  # a separate checker (section 6)
+        attempts.append({"attempt": n, "passed": verdict["passed"], "reason": verdict["reason"]})
+        if verdict["passed"]:
+            return {"ok": True, "output": out, "attempts": attempts}
+        feedback = (f"\n\nA prior attempt was rejected by review.\nAttempt:\n{out}\n"
+                    f"Why it failed: {verdict['reason']}\nFix that and answer again.")
+    return {"ok": False, "output": None, "attempts": attempts}   # budget spent: escalate
+
+
+def agent_checker(rubric, model, registry=None):
+    """A fresh checker agent (section 6): grades against the rubric, never edits.
+
+    Each grade runs the inner loop on a NEW messages[] and a new Session, so
+    the checker shares no context with the worker. The verdict contract is the
+    first word, PASS or FAIL, then one short reason."""
+    registry = registry or Registry()                 # a grader needs no tools by default
+
+    def check(task, output):
+        prompt = ("You are a reviewer. Grade the output against the rubric. Do not fix it.\n"
+                  f"Rubric: {rubric}\nTask: {task}\nOutput:\n{output}\n"
+                  "Reply with PASS or FAIL as the first word, then one short reason.")
+        text = run_turn([{"role": "user", "content": prompt}], model, registry,
+                        Session(mode=DEFAULT)).strip()
+        word, _, reason = text.partition(" ")
+        return {"passed": word.upper().startswith("PASS"), "reason": reason.strip() or text}
+
+    return check

--- a/sections/21-loop-engineering/src/worktree.py
+++ b/sections/21-loop-engineering/src/worktree.py
@@ -1,0 +1,85 @@
+"""Worktree isolation (section 15): each unit of parallel work gets its own
+checkout of the repo on its own branch, so concurrent agents cannot clobber a
+shared tree. Introduced in section 15, then carried forward unchanged.
+
+A git worktree is a second checkout of the same repo on its own branch. We bind
+each unit of work to one by scoping its working directory through a contextvar,
+the synchronous analog of Claude Code's AsyncLocalStorage runWithCwdOverride:
+every tool that reads get_cwd() inside that scope resolves paths in its own
+worktree, so siblings running concurrently never touch the same files (no global
+chdir to corrupt a neighbour). On teardown a change count decides: a clean
+worktree is removed, a dirty one is kept for review so work is never silently
+discarded.
+
+ponytail: change count is `git status --porcelain` (uncommitted files); add
+`git log <base>..HEAD` to also keep worktrees that carry unmerged commits.
+"""
+from __future__ import annotations
+
+import contextlib
+import contextvars
+import re
+import subprocess
+from pathlib import Path
+
+_cwd: contextvars.ContextVar = contextvars.ContextVar("cwd", default=None)
+SLUG_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def get_cwd():
+    """The working directory bound to this context, or None for the process cwd.
+    A tool passes this to subprocess so each agent resolves paths in its worktree."""
+    return _cwd.get()
+
+
+@contextlib.contextmanager
+def cwd_override(path):
+    """Bind get_cwd() to `path` for this context (and its descendants). Scoped by
+    a contextvar, not os.chdir, so concurrent agents never corrupt each other."""
+    token = _cwd.set(str(path))
+    try:
+        yield
+    finally:
+        _cwd.reset(token)
+
+
+def validate_slug(slug):
+    """Reject path traversal before any git command or path join: '../target'
+    would escape .claude/worktrees once normalized. Runs at the trust boundary."""
+    if slug in (".", "..") or not SLUG_RE.match(slug or ""):
+        raise ValueError(f"bad worktree slug: {slug!r}")
+    return slug
+
+
+def _path(repo_root, slug):
+    return Path(repo_root) / ".claude" / "worktrees" / validate_slug(slug)
+
+
+def create(repo_root, slug, base="HEAD"):
+    """git worktree add a fresh checkout at .claude/worktrees/<slug> on branch
+    worktree-<slug>; returns its path. The slug is validated first (boundary)."""
+    path = _path(repo_root, slug)
+    _git(repo_root, "worktree", "add", "-B", f"worktree-{slug}", str(path), base)
+    return path
+
+
+def changes(path):
+    """Lines git considers dirty in the worktree (uncommitted files). Zero means
+    nothing was written, so the worktree is safe to auto-remove."""
+    return len([l for l in _git(path, "status", "--porcelain").splitlines() if l.strip()])
+
+
+def remove(repo_root, slug, force=False):
+    """Tear down a worktree iff it is clean, unless force. A dirty worktree is
+    kept for review so parallel work is never silently lost; returns True if removed."""
+    path = _path(repo_root, slug)
+    if not force and changes(path):
+        return False                                    # keep-for-review
+    _git(repo_root, "worktree", "remove", "--force", str(path))
+    _git(repo_root, "branch", "-D", f"worktree-{slug}")
+    return True
+
+
+def _git(cwd, *args):
+    return subprocess.run(["git", *args], cwd=str(cwd), capture_output=True,
+                          text=True, check=True).stdout.strip()


### PR DESCRIPTION
## Summary

- New capstone section `21-loop-engineering` under a new `Layer 7 · Composition`: the shift from prompting turn by turn to designing the outer loops that run the agent (verification, event, improvement), with budgets, maturity levels (L1 report / L2 assisted / L3 unattended), and failure modes.
- Runnable `src/` carries section 20 forward and adds one mechanism: `verify.py` (`verified_run` grade-and-retry with a harness-enforced budget, `agent_checker` as a fresh maker/checker grader per section 6).
- Per-system coverage: Claude Code (`/loop`, `ScheduleWakeup`, `Workflow` budget and verify patterns) and Hermes Agent (`iteration_budget.py`, cron toolsets, skill curator as improvement loop).
- zh-TW and zh-CN translations of the section; all three root READMEs wired (badge, Systems rows, Sections table, structure counts).
- Sources: cobusgreyling/loop-engineering, LangChain, Addy Osmani, MindStudio, and Lilian Weng's harness self-improvement post.

## Test plan

- `python sections/21-loop-engineering/src/test.py` (offline, no key): 4 checks pass.
- `uv run python -c "import demo, verify"` from the src path: imports clean.
- Style checks: no lines over 180 chars in edited English READMEs, no em/en dashes, src diff vs section 20 is exactly `verify.py` + section-local `demo.py`/`test.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)