### PR TITLE
Clarify relevant memory recall behavior

### DIFF
--- a/sections/09-memory/README.zh-TW.md
+++ b/sections/09-memory/README.zh-TW.md
@@ -66,6 +66,12 @@ def recall(mems, query, k=RECALL_K, selector=None) -> list[Memory]:
     return [m for _score, m in hits[:k]]
 ```
 
+這裡的「相關」不是先讀完所有記憶內文。`load_index` 只讀 frontmatter，`manifest` 把每個記憶壓成一行 `name / type / description`，接著才做相關性判斷：
+
+- 如果 `Store(selector=...)` 有傳入 selector，selector 讀 manifest 和 query，回傳要注入的記憶名稱。live 版通常由 LLM 做這個選擇；只有被選中的檔案才會在 `recall_block` 讀出 body。
+- 如果沒有 selector，就走離線 fallback：`_overlap(query, mem)` 把 query 和 `mem.name + mem.description` 經 `_words` 切詞後做交集，分數大於 0 的項目排序後取前 `k`。這不是 embedding，也不是 SQLite 搜尋。
+- `SessionSearch` 是另一條路：它查的是原始 session log，用 SQLite FTS5 的 `MATCH ... ORDER BY rank` 搜過去訊息。搜尋本身沒有模型呼叫；模型只是在 turn 中決定要不要呼叫這個 tool。
+
 Extraction 是唯一會讓儲存區成長的操作：
 
 ```python

--- a/sections/09-memory/README.zh-TW.md
+++ b/sections/09-memory/README.zh-TW.md
@@ -36,6 +36,61 @@ loop 不會讀取整個儲存區。它先讀一份便宜的索引，然後只載
 
 Recall 只讀取。Extraction 只寫入。把這兩個方向分開，可以避免儲存區意外膨脹。
 
+```mermaid
+flowchart TB
+    user["User turn"]
+    loop["run_turn"]
+    store["Store"]
+    model["Model"]
+    tools["Tools"]
+    final["Final answer"]
+
+    subgraph durable["Durable memory store"]
+        md["*.md memory files"]
+        fm["frontmatter index<br/>name / type / description"]
+        body["selected memory bodies"]
+    end
+
+    subgraph recall["Recall before the model call"]
+        load["load_index<br/>read frontmatter only"]
+        manifest["manifest<br/>one cheap line per memory"]
+        relevant{"Relevant selector?"}
+        llm["selector<br/>usually an LLM in live mode"]
+        overlap["_overlap fallback<br/>word overlap, offline"]
+        chosen["chosen memory names<br/>max RECALL_K"]
+        reminder["system-reminder injection"]
+    end
+
+    subgraph rawlog["Raw session history"]
+        sqlite["state.db<br/>SQLite FTS5 session_log"]
+        search["search_sessions<br/>MATCH query ORDER BY rank"]
+        sessiontool["SessionSearch tool"]
+    end
+
+    subgraph writeback["Run-end write paths"]
+        logrun["log_run<br/>append transcript text"]
+        extractor["extractor<br/>usually an LLM in live mode"]
+        newmem["new *.md memory files"]
+        consolidate["Consolidation<br/>rare background cleanup"]
+    end
+
+    user --> loop --> store
+    store --> load --> fm --> manifest --> relevant
+    md --> load
+    relevant -- selector provided --> llm --> chosen
+    relevant -- no selector --> overlap --> chosen
+    chosen --> body --> reminder --> model
+    loop --> model
+    model --> tools --> model
+    model -- may call --> sessiontool --> search --> sqlite
+    model --> final
+    final --> store
+    store --> logrun --> sqlite
+    store --> extractor --> newmem --> md
+    md -. occasionally .-> consolidate
+    consolidate -. prune or merge .-> md
+```
+
 ### New: index、recall、extraction 與 store
 
 儲存區是一個放 `.md` 檔案的目錄。`load_index` 只讀取 frontmatter：


### PR DESCRIPTION
## Summary

- Clarify what the relevant/recall step actually evaluates in the memory chapter
- Document the two paths: LLM-backed selector versus offline word-overlap fallback
- Distinguish memory recall from SQLite FTS-backed SessionSearch

## Validation

- `python sections\09-memory\src\test.py`