### PR TITLE
Add ClawBench evaluator example

### DIFF
--- a/sections/20-observability/README.md
+++ b/sections/20-observability/README.md
@@ -128,6 +128,8 @@ How each agent emits telemetry, tracks spend, and measures quality.
 
 ---
 
+For a complementary live-web example, [ClawBench](https://github.com/reacher-z/ClawBench) evaluates computer-using agents on isolated multi-step tasks and records replayable execution traces, request interception, and browser actions. Its task-level evidence model illustrates how an offline evaluator can retain enough context to diagnose regressions rather than expose only an aggregate score. See the [paper](https://arxiv.org/abs/2604.08523) and [project site](https://claw-bench.com/).
+
 ## Runnable
 
 [`src/`](src/) carries 19 forward and adds:


### PR DESCRIPTION
Adds ClawBench as a complementary live-web evaluator example in the observability and evaluation section. The entry links the paper, code, and project site and describes its traceable task-level evidence.

Disclosure: I help maintain ClawBench.