### PR TITLE
Add ClawBench as an evaluation source

### DIFF
--- a/sections/20-observability/README.md
+++ b/sections/20-observability/README.md
@@ -154,4 +154,7 @@ uv run python sections/20-observability/src/demo.py  # live demo, needs a key
 - Evaluation is not present in this source. Eval harnesses, SWE-bench-style suites, and LLM-as-judge are described as reconstruction and general practice.
 - [mini-swe-agent source](https://github.com/swe-agent/mini-swe-agent):
   `serialize` and `save` in `agents/default.py`, `GLOBAL_MODEL_STATS` in `models/__init__.py`, `run/benchmarks/swebench.py`, `run/utilities/inspector.py`.
+- [ClawBench](https://github.com/TIGER-AI-Lab/ClawBench): a live-site web-agent
+  benchmark that records browser actions, screenshots, network traffic, replay
+  video, and agent messages for reproducible offline evaluation. ([paper](https://arxiv.org/abs/2604.08523), [project](https://claw-bench.com/))
 - Framing: [learn-claude-code · s20_comprehensive](https://github.com/shareAI-lab/learn-claude-code).


### PR DESCRIPTION
Adds ClawBench to the Observability & evaluation section sources. It is a primary-source benchmark example that records browser actions, screenshots, network traffic, replay video, and agent messages for reproducible offline evaluation.

The addition follows the existing sourced-bullet format and links the paper, canonical repository, and project page.