### PR TITLE
docs: add CONTRIBUTING.md with PR checklist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing
+
+Thanks for contributing. This repo is a set of educational reconstructions.
+Every claim should trace back to source code, docs, or observed behavior.
+This checklist is what reviewers check on every PR.
+
+## Before you open a PR
+
+- Check open PRs and issues for overlap. One topic per PR.
+- Read the section you want to change. Each section follows a fixed shape:
+  Opening, Mechanism, Per system, Failure modes, Runnable, Sources.
+- If you maintain or are affiliated with a project you are adding, say so in the PR description.
+
+## Where content goes
+
+- Source links belong in the `## Sources` block of the section they ground.
+  A source should back a claim the section text makes.
+- Nothing goes after the per-system table except its closing rule.
+- Benchmarks go in the section they evaluate. General agent and harness evaluation
+  belongs in section 20. Memory benchmarks belong in section 9 and the
+  production-memory track. Group entries by purpose, one line each on what it measures,
+  with paper and canonical repo links.
+
+## Writing rules
+
+- Short sentences. One idea per sentence.
+- No em or en dashes. Use periods, commas, parentheses, or `·`.
+- No line over 180 characters. Check: `awk 'length($0)>180' <file>` returns nothing.
+- Prefer named, verifiable mechanisms over speculation. Cite sources.
+
+## Translations
+
+Every `README.md` ships with `README.zh-TW.md` and `README.zh-CN.md`.
+If you edit one, update all three in the same commit.
+Write natural spoken Chinese. Keep technical terms in English
+(`stop_reason`, `PreToolUse`, hook, harness, loop, prompt, token).
+
+## Commits
+
+- Conventional commits (`docs:`, `fix:`, `feat:`).
+- Keep messages under 50 words.
+
+## Review expectations
+
+- PRs that add a single external link with no surrounding claim are usually too thin.
+  Tie the addition to the section text, or expand it into an organized set.
+- Reviewers may ask you to consolidate overlapping PRs into one.

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ uv run python sections/01-agent-loop/src/demo.py  # live
 - **Correct the record.** These are reconstructions from source, docs, and behavior. Sourced corrections are welcome.
 
 Favor named, verifiable mechanisms over speculation. Cite sources.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full PR checklist.
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -170,6 +170,7 @@ uv run python sections/01-agent-loop/src/demo.py  # 实时
 - **修正内容。** 这些都是从源码、文档和实际行为重建出来的。欢迎附上出处的修正。
 
 请优先采用有名字、可查证的机制，而不是臆测。记得引用出处。
+完整的 PR 检查清单见 [CONTRIBUTING.md](CONTRIBUTING.md)。
 
 ---
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -170,6 +170,7 @@ uv run python sections/01-agent-loop/src/demo.py  # 即時
 - **修正內容。** 這些都是從原始碼、文件和實際行為重建出來的。歡迎附上出處的修正。
 
 請優先採用有名字、可查證的機制，而不是臆測。記得引用出處。
+完整的 PR 檢查清單見 [CONTRIBUTING.md](CONTRIBUTING.md)。
 
 ---
 


### PR DESCRIPTION
Adds a contributor-facing checklist distilled from CLAUDE.md: section shape, where sources and benchmarks go, writing rules, the trilingual README requirement, commit style, and affiliation disclosure. Links it from the Contributing section of all three root READMEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)