### PR TITLE
docs: link learn-agent-memory production memory track

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ __pycache__/
 # Claude Code local settings
 .claude
 CLAUDE.md
+
+docs

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 </p>
 
 <p align="center">
-  <a href="#sections"><img src="https://img.shields.io/badge/Focus-Harness_Engineering-6e40c9?style=for-the-badge" alt="Focus: Harness Engineering"></a>
-  <a href="#systems-under-study"><img src="https://img.shields.io/badge/Systems-3+-0a7bbb?style=for-the-badge" alt="Systems"></a>
-  <a href="#sections"><img src="https://img.shields.io/badge/Sections-22-green?style=for-the-badge" alt="Sections"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow?style=for-the-badge" alt="License"></a>
+  <a href="#sections"><img src="https://img.shields.io/badge/Focus-Harness_Engineering-8250df" alt="Focus: Harness Engineering"></a>
+  <a href="#systems-under-study"><img src="https://img.shields.io/badge/Systems-3+-0969da" alt="Systems"></a>
+  <a href="#sections"><img src="https://img.shields.io/badge/Sections-22-2da44e" alt="Sections"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-d29922" alt="License"></a>
 </p>
 
 <p align="center">
@@ -69,12 +69,15 @@ Each system is a worked example for the sections below.
 | *(more soon)*        |                                                                                 |                                    |                      |                 |
 
 > More systems can be added later, including OpenClaw and aider.
+> The memory layer also has a companion repo: [learn-agent-memory](https://github.com/hardness1020/learn-agent-memory).
 
 ---
 
 ## Sections
 
 Eight layers, from the basic loop to a harness that runs itself. Each row links to one self-contained writeup.
+
+> Section 9 continues in [learn-agent-memory](https://github.com/hardness1020/learn-agent-memory): ten more stages that scale its memory loop to production.
 
 ![The learning path](assets/learning-path.png)
 
@@ -132,6 +135,9 @@ Each section folder is `NN-name/` and contains a `README.md`.
 
 Sections 1 to 21 also carry a runnable `src/`. The code accumulates section by section.
 Each section adds one mechanism and evolves `loop.py`, so a diff between adjacent sections shows what changed.
+
+Deep dives that outgrow one section live in their own repos.
+[learn-agent-memory](https://github.com/hardness1020/learn-agent-memory) is the first: it scales the section 9 loop into a full memory subsystem.
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -5,10 +5,10 @@
 </p>
 
 <p align="center">
-  <a href="#研究的系统"><img src="https://img.shields.io/badge/Focus-Harness_Engineering-6e40c9?style=for-the-badge" alt="Focus: Harness Engineering"></a>
-  <a href="#研究的系统"><img src="https://img.shields.io/badge/Systems-3+-0a7bbb?style=for-the-badge" alt="Systems"></a>
-  <a href="#各章节"><img src="https://img.shields.io/badge/Sections-22-green?style=for-the-badge" alt="Sections"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow?style=for-the-badge" alt="License"></a>
+  <a href="#研究的系统"><img src="https://img.shields.io/badge/Focus-Harness_Engineering-8250df" alt="Focus: Harness Engineering"></a>
+  <a href="#研究的系统"><img src="https://img.shields.io/badge/Systems-3+-0969da" alt="Systems"></a>
+  <a href="#各章节"><img src="https://img.shields.io/badge/Sections-22-2da44e" alt="Sections"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-d29922" alt="License"></a>
 </p>
 
 <p align="center">
@@ -69,12 +69,15 @@
 | *(更多陆续加入)*       |                                                                       |                                       |                           |           |
 
 > 之后可以再加入更多系统，例如 OpenClaw 和 aider。
+> memory 这一层另外有一个专门的 repo：[learn-agent-memory](https://github.com/hardness1020/learn-agent-memory)。
 
 ---
 
 ## 各章节
 
 八层，从最基本的 loop 一路到能自己运转的 harness。每一行都链接到一篇可独立阅读的说明。
+
+> 第 9 章在 [learn-agent-memory](https://github.com/hardness1020/learn-agent-memory) 继续往下走：再用十个阶段，把它的 memory loop 放大到 production 规模。
 
 ![The learning path](assets/learning-path.png)
 
@@ -132,6 +135,9 @@ awesome-agent-architecture/
 
 第 1 到 21 章还带有可执行的 `src/`。代码一章一章累积上去。
 每一章新增一个机制，并让 `loop.py` 演进，所以对比相邻两章的 diff，就能看出改了什么。
+
+超出单一章节篇幅的深入主题，会独立成自己的 repo。
+第一个是 [learn-agent-memory](https://github.com/hardness1020/learn-agent-memory)，把第 9 章的 memory loop 放大成完整的子系统。
 
 ---
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -5,10 +5,10 @@
 </p>
 
 <p align="center">
-  <a href="#研究的系統"><img src="https://img.shields.io/badge/Focus-Harness_Engineering-6e40c9?style=for-the-badge" alt="Focus: Harness Engineering"></a>
-  <a href="#研究的系統"><img src="https://img.shields.io/badge/Systems-3+-0a7bbb?style=for-the-badge" alt="Systems"></a>
-  <a href="#各章節"><img src="https://img.shields.io/badge/Sections-22-green?style=for-the-badge" alt="Sections"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow?style=for-the-badge" alt="License"></a>
+  <a href="#研究的系統"><img src="https://img.shields.io/badge/Focus-Harness_Engineering-8250df" alt="Focus: Harness Engineering"></a>
+  <a href="#研究的系統"><img src="https://img.shields.io/badge/Systems-3+-0969da" alt="Systems"></a>
+  <a href="#各章節"><img src="https://img.shields.io/badge/Sections-22-2da44e" alt="Sections"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-d29922" alt="License"></a>
 </p>
 
 <p align="center">
@@ -69,12 +69,15 @@
 | *(更多陸續加入)*       |                                                                       |                                       |                           |           |
 
 > 之後可以再加入更多系統，例如 OpenClaw 和 aider。
+> memory 這一層另外有一個專門的 repo：[learn-agent-memory](https://github.com/hardness1020/learn-agent-memory)。
 
 ---
 
 ## 各章節
 
 八層，從最基本的 loop 一路到能自己運轉的 harness。每一列都連到一篇可獨立閱讀的說明。
+
+> 第 9 章在 [learn-agent-memory](https://github.com/hardness1020/learn-agent-memory) 繼續往下走：再用十個階段，把它的 memory loop 放大到 production 規模。
 
 ![The learning path](assets/learning-path.png)
 
@@ -132,6 +135,9 @@ awesome-agent-architecture/
 
 第 1 到 21 章還帶有可執行的 `src/`。程式碼一章一章累積上去。
 每一章新增一個機制，並讓 `loop.py` 演進，所以對比相鄰兩章的 diff，就能看出改了什麼。
+
+超出單一章節份量的深入主題，會獨立成自己的 repo。
+第一個是 [learn-agent-memory](https://github.com/hardness1020/learn-agent-memory)，把第 9 章的 memory loop 放大成完整的子系統。
 
 ---
 

--- a/sections/09-memory/README.md
+++ b/sections/09-memory/README.md
@@ -17,6 +17,9 @@ Memory must:
 
 Without memory, the agent repeats questions and forgets user preferences between sessions. If it saves everything, recall gets noisy and stale.
 
+This section builds the minimum loop. At production scale, memory grows into a subsystem of its own,
+with event logs, typed records, temporal facts, and hybrid retrieval. The [learn-agent-memory](https://github.com/hardness1020/learn-agent-memory) repo covers that.
+
 ---
 
 ## Mechanism

--- a/sections/09-memory/README.zh-CN.md
+++ b/sections/09-memory/README.zh-CN.md
@@ -17,6 +17,9 @@
 
 没有记忆，agent 会重复提问，并在不同 session 之间忘记用户的偏好。如果它什么都存，回想就会变得杂乱又过时。
 
+这一章先把最小可行的 loop 做出来。到了 production 规模，memory 会变成一个独立的子系统，
+有 event log、typed record、temporal facts 和 hybrid retrieval，细节收在 [learn-agent-memory](https://github.com/hardness1020/learn-agent-memory) 这个 repo。
+
 ---
 
 ## 机制

--- a/sections/09-memory/README.zh-TW.md
+++ b/sections/09-memory/README.zh-TW.md
@@ -17,6 +17,9 @@
 
 沒有記憶，agent 會重複提問，並在不同 session 之間忘記使用者的偏好。如果它什麼都存，回想就會變得雜亂又過時。
 
+這一章先把最小可行的 loop 做出來。到了 production 規模，memory 會變成一個獨立的子系統，
+有 event log、typed record、temporal facts 和 hybrid retrieval，細節收在 [learn-agent-memory](https://github.com/hardness1020/learn-agent-memory) 這個 repo。
+
 ---
 
 ## 機制


### PR DESCRIPTION
- Reference the standalone [learn-agent-memory](https://github.com/hardness1020/learn-agent-memory) repo from the systems table and section 9, in all three languages.
- Restyle README badges.
- Ignore the local docs directory.