### PR TITLE
docs: update section 19 for MCP spec 2026-07-28

### DIFF
--- a/sections/19-mcp-plugins-channels/README.md
+++ b/sections/19-mcp-plugins-channels/README.md
@@ -9,6 +9,7 @@ A harness can only do what its tools let it do, and every built-in tool is prede
 That does not scale to the services a user wants: issue trackers, deploy systems, knowledge bases. You cannot hand write a tool for each, in each language it uses.
 
 MCP (Model Context Protocol) is the open contract that closes the gap. An external service declares its tools, and the agent calls them blind, not knowing who wrote them or how.
+In MCP terms the service is the server, and the harness that connects and calls is the client.
 
 So the agent gains a Jira tool or a deploy tool without anyone editing the harness. Leave MCP out and capability is frozen at whatever shipped in the binary.
 
@@ -28,6 +29,29 @@ Names are namespaced `mcp__<server>__<tool>` so two servers never collide. The l
 - The name is namespaced and normalized, so it is unique and matches the API's name pattern.
 - Each tool's MCP annotations (`readOnlyHint`, `destructiveHint`) become the permission hints the gate reads (section 3).
 - Merged into the one `Registry`, the model sees MCP tools and built-ins in the same list.
+
+### The wire protocol under it
+
+The 2026-07-28 spec revision made the wire stateless. Every request now stands alone, so any server replica can answer it.
+The harness side above (discover, wrap, merge) does not change. What changed on the wire:
+
+- **No more handshake.** Before, a client called `initialize` and waited before doing anything else.
+  Now any request can go first; each one carries its own protocol version and capabilities in `_meta`.
+  A client that wants to check versions up front calls `server/discover`.
+- **No more sessions.** Before, the server kept per-connection state behind a session header.
+  Now a server that needs state across calls returns a handle, and the client passes it back as a normal tool argument.
+- **One notification stream.** Before, a client held a long GET connection open to hear about changes.
+  Now it opens one `subscriptions/listen` stream and names the events it wants (a changed tool list, a changed resource).
+  List results also carry a `ttlMs` field that says how long the client may cache them.
+- **The server asks by replying, not by calling back.** Before, a server could send its own request to the client
+  mid-tool-call (ask the user a question, ask the model to sample). Now it returns an interim result marked
+  `input_required`, and the client retries the same request with the answer attached.
+- **Fewer features.** Roots, Sampling, Logging, and the old HTTP+SSE transport are deprecated.
+  Two transports remain official: stdio for local servers, Streamable HTTP for remote ones.
+
+For someone using an agent, nothing changes on screen: old servers keep working, and v1 SDKs stay maintained.
+The gains land underneath: remote servers scale behind a load balancer, the first call skips a round trip, and a cached tool list saves tokens.
+Servers on a deprecated feature get a twelve-month window to migrate. That work falls on the server author, not the user.
 
 ### New: wrapping a discovered tool
 
@@ -145,8 +169,10 @@ How the harness reaches outside itself.
 
 - **Name collisions.** Two servers both expose `search`. The `mcp__server__tool` namespace prevents clashes; a server name with `__` still parses wrong, so keep names simple.
 - **Tool-list bloat.** Many servers make a large tool list that costs tokens and confuses selection (section 2). Mitigation: truncate descriptions and defer loading.
-- **Stale pool after connect.** A server added mid-session is not in the cached tool list, so the model never sees it. Mitigation: rebuild pool and prompt on change (section 8).
+- **Stale pool after connect.** A server added mid-session is not in the cached tool list, so the model never sees it.
+  Mitigation: rebuild pool and prompt on change (section 8); the 2026-07-28 spec adds `toolsListChanged` over `subscriptions/listen` and `ttlMs` hints for this.
 - **Connection churn.** A flaky server times out, resets, or expires its token. Mitigation: reconnect after repeated failures, re-auth on `401`, time out each call (section 11).
+  The stateless revision drops stream resumability, so a broken in-flight request is re-issued as a new one, not resumed.
 - **Over-trusted side effects.** A server marks a destructive tool `readOnlyHint: true` to skip the prompt. Mitigation: a rule on the qualified name gates it anyway (section 3).
 
 ---
@@ -177,4 +203,8 @@ uv run python sections/19-mcp-plugins-channels/src/demo.py  # live demo, needs a
 - [Claude Code plugins](https://github.com/yasasbanukaofficial/claude-code): `plugins/builtinPlugins.ts`, `plugins/bundled/`, `types/plugin.ts`, plus `remote/` and `bridge/`.
 - [Hermes Agent source](https://github.com/NousResearch/hermes-agent):
   `mcp_serve.py`, `hermes_cli/plugins.py` (`PluginManager`, `VALID_HOOKS`), `gateway/platforms/`, `gateway/platform_registry.py`, `plugins/platforms/`.
+- [MCP specification 2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28) and its
+  [changelog](https://modelcontextprotocol.io/specification/2026-07-28/changelog): stateless protocol, `server/discover`, `subscriptions/listen`, MRTR, deprecations.
+- MCP blog: [the future of transports](https://blog.modelcontextprotocol.io/posts/2025-12-19-mcp-transport-future/) (why the protocol went stateless),
+  [SDK betas for 2026-07-28](https://blog.modelcontextprotocol.io/posts/sdk-betas-2026-07-28/) (v2 SDKs, backward compatibility).
 - Framing: [learn-claude-code · s19_mcp_plugin](https://github.com/shareAI-lab/learn-claude-code).

--- a/sections/19-mcp-plugins-channels/README.zh-CN.md
+++ b/sections/19-mcp-plugins-channels/README.zh-CN.md
@@ -9,6 +9,7 @@
 这无法扩展到用户想要的各种服务：issue tracker、部署系统、知识库。你没办法为每一个服务、用它各自的语言，都写一个专属工具。
 
 MCP（Model Context Protocol）就是填补这道缺口的开放标准。一个外部服务宣告它的工具，agent 则盲调用它们，不需要知道是谁写的、怎么写的。
+用 MCP 的说法，提供工具的那个服务就是 server，负责连接和调用的 harness 就是 client。
 
 于是 agent 不需要任何人动 harness，就得到了 Jira 工具或部署工具。少了 MCP，agent 的能力就停在安装当下内建的那一套，之后加不了新的。
 
@@ -28,6 +29,29 @@ MCP 之外，这一章还讲两个搭在它上面的机制：plugin 把 server �
 - 名称加了命名空间并经过正规化，所以它是唯一的，也符合 API 的名称样式。
 - 每个工具的 MCP annotation（`readOnlyHint`、`destructiveHint`）成为 gate 读取的权限提示（第 3 章）。
 - 合并进那一个 `Registry` 之后，模型会在同一份清单里看到 MCP 工具与内建工具。
+
+### 底层的 wire protocol
+
+2026-07-28 版的 spec 把 protocol 本身改成了 stateless：每个 request 都是独立的，哪台 server 副本都能接。
+上面 harness 端做的事（探索、包装、合并）都不变。变的是 client 和 server 之间实际往来的消息：
+
+- **不用握手了。** 以前 client 得先调用 `initialize`、等 server 响应，才能做别的事。
+  现在任何 request 都能直接发，每个 request 自己在 `_meta` 里带上 protocol 版本和能力。
+  想先确认版本，就调用 `server/discover` 问 server。
+- **没有 session 了。** 以前 server 靠一个 session header 帮每条连接记状态。
+  现在 server 若需要跨调用记东西，就返回一个 handle，client 之后当成普通的工具参数带回来。
+- **通知走一条 stream。** 以前 client 得挂着一条 GET 连接听变动。
+  现在它开一条 `subscriptions/listen` stream，指名要听哪些事件（工具清单变了、resource 变了）。
+  list 的结果也多了 `ttlMs` 字段，告诉 client 可以 cache 多久。
+- **server 用回复提问，不再回头调用。** 以前 server 可以在工具跑到一半时，反过来对 client 发 request
+  （问用户一个问题、请模型 sample）。现在它返回一个标着 `input_required` 的中间结果，
+  client 把答案附上，重发同一个 request。
+- **功能变少了。** Roots、Sampling、Logging 和旧的 HTTP+SSE transport 都列为 deprecated。
+  官方 transport 剩两种：本地用 stdio，远程用 Streamable HTTP。
+
+对用 agent 的人来说，界面上什么都没变：旧 server 照常运作，v1 SDK 也继续维护。
+好处都出现在用户看不到的地方：远程 server 能挂在 load balancer 后面扩展，第一次调用少一趟来回，cache 住的工具清单也省 token。
+用到 deprecated 功能的 server 有十二个月的窗口可以迁移。那是 server 作者要做的事，不是用户的事。
 
 ### New: 包装探索到的工具
 
@@ -143,8 +167,10 @@ harness 如何伸手触及自身之外。
 
 - **撞名（Name collisions）：**两个 server 都公开 `search`。`mcp__server__tool` 命名空间避免了冲突；但一个名称含 `__` 的 server 仍会被解析错误，所以名称要保持简单。
 - **工具清单膨胀（Tool-list bloat）：**太多 server 会造成庞大的工具清单，既花 token 又干扰选择（第 2 章）。缓解：截断描述并延后载入。
-- **connect 之后池过时：**一个在 session 中途加入的 server 不在 cache 的工具清单里，于是模型永远看不到它。缓解：变动时重建池并重建 prompt（第 8 章）。
+- **connect 之后池过时：**一个在 session 中途加入的 server 不在 cache 的工具清单里，于是模型永远看不到它。缓解：变动时重建池并重建 prompt（第 8 章）；
+  2026-07-28 版的 spec 为此加了走 `subscriptions/listen` 的 `toolsListChanged` 通知和 `ttlMs` 提示。
 - **连接抖动（Connection churn）：**一个不稳的 server 会超时、重置，或 token 过期。缓解：反复失败后重连、`401` 时重新验证、为每次调用设超时（第 11 章）。
+  stateless 版拿掉了 stream 续传，所以中断的 request 要当成一个新 request 重发，不是接着传。
 - **被过度信任的副作用：**一个 server 把具破坏性的工具标成 `readOnlyHint: true` 以跳过提示。缓解：以完整名称设一条规则照样 gate 它（第 3 章）。
 
 ---
@@ -172,4 +198,8 @@ uv run python sections/19-mcp-plugins-channels/src/demo.py  # live demo, needs a
 - [Claude Code MCP config and channels](https://github.com/yasasbanukaofficial/claude-code)：`config.ts`（precedence）、`channelNotification.ts`（`CHANNEL_TAG`），加上 `McpAuthTool`、`ListMcpResourcesTool`、`ReadMcpResourceTool`。
 - [Claude Code plugins](https://github.com/yasasbanukaofficial/claude-code)：`plugins/builtinPlugins.ts`、`plugins/bundled/`、`types/plugin.ts`，加上 `remote/` 与 `bridge/`。
 - [Hermes Agent 源码](https://github.com/NousResearch/hermes-agent)：`mcp_serve.py`、`hermes_cli/plugins.py`（`PluginManager`、`VALID_HOOKS`）、`gateway/platforms/`、`gateway/platform_registry.py`、`plugins/platforms/`。
+- [MCP specification 2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28) 与它的
+  [changelog](https://modelcontextprotocol.io/specification/2026-07-28/changelog)：stateless protocol、`server/discover`、`subscriptions/listen`、MRTR、deprecation 清单。
+- MCP blog：[the future of transports](https://blog.modelcontextprotocol.io/posts/2025-12-19-mcp-transport-future/)（protocol 为什么走向 stateless）、
+  [SDK betas for 2026-07-28](https://blog.modelcontextprotocol.io/posts/sdk-betas-2026-07-28/)（v2 SDK 与向后兼容）。
 - 章节定位：[learn-claude-code · s19_mcp_plugin](https://github.com/shareAI-lab/learn-claude-code)。

--- a/sections/19-mcp-plugins-channels/README.zh-TW.md
+++ b/sections/19-mcp-plugins-channels/README.zh-TW.md
@@ -9,6 +9,7 @@
 這無法擴展到使用者想要的各種服務：issue tracker、部署系統、知識庫。你沒辦法為每一個服務、用它各自的語言，都寫一個專屬工具。
 
 MCP（Model Context Protocol）就是填補這道缺口的開放標準。一個外部服務宣告它的工具，agent 則盲呼叫它們，不需要知道是誰寫的、怎麼寫的。
+用 MCP 的說法，提供工具的那個服務就是 server，負責連線和呼叫的 harness 就是 client。
 
 於是 agent 不需要任何人動 harness，就得到了 Jira 工具或部署工具。少了 MCP，agent 的能力就停在安裝當下內建的那一套，之後加不了新的。
 
@@ -28,6 +29,29 @@ MCP 之外，這一章還講兩個搭在它上面的機制：plugin 把 server �
 - 名稱加了命名空間並經過正規化，所以它是唯一的，也符合 API 的名稱樣式。
 - 每個工具的 MCP annotation（`readOnlyHint`、`destructiveHint`）成為 gate 讀取的權限提示（第 3 章）。
 - 合併進那一個 `Registry` 之後，模型會在同一份清單裡看到 MCP 工具與內建工具。
+
+### 底層的 wire protocol
+
+2026-07-28 版的 spec 把 protocol 本身改成了 stateless：每個 request 都是獨立的，哪台 server 副本都能接。
+上面 harness 端做的事（探索、包裝、合併）都不變。變的是 client 跟 server 之間實際往來的訊息：
+
+- **不用握手了。** 以前 client 得先呼叫 `initialize`、等 server 回應，才能做別的事。
+  現在任何 request 都能直接發，每個 request 自己在 `_meta` 裡帶上 protocol 版本和能力。
+  想先確認版本，就呼叫 `server/discover` 問 server。
+- **沒有 session 了。** 以前 server 靠一個 session header 幫每條連線記狀態。
+  現在 server 若需要跨呼叫記東西，就回傳一個 handle，client 之後當成普通的工具參數帶回來。
+- **通知走一條 stream。** 以前 client 得掛著一條 GET 連線聽變動。
+  現在它開一條 `subscriptions/listen` stream，指名要聽哪些事件（工具清單變了、resource 變了）。
+  list 的結果也多了 `ttlMs` 欄位，告訴 client 可以 cache 多久。
+- **server 用回覆提問，不再回頭呼叫。** 以前 server 可以在工具跑到一半時，反過來對 client 發 request
+  （問使用者一個問題、請模型 sample）。現在它回傳一個標著 `input_required` 的中間結果，
+  client 把答案附上，重發同一個 request。
+- **功能變少了。** Roots、Sampling、Logging 和舊的 HTTP+SSE transport 都列為 deprecated。
+  官方 transport 剩兩種：本地用 stdio，遠端用 Streamable HTTP。
+
+對用 agent 的人來說，畫面上什麼都沒變：舊 server 照常運作，v1 SDK 也繼續維護。
+好處都出現在使用者看不到的地方：遠端 server 能掛在 load balancer 後面擴展，第一次呼叫少一趟來回，cache 住的工具清單也省 token。
+用到 deprecated 功能的 server 有十二個月的窗口可以遷移。那是 server 作者要做的事，不是使用者的事。
 
 ### New: 包裝探索到的工具
 
@@ -143,8 +167,10 @@ harness 如何伸手觸及自身之外。
 
 - **撞名（Name collisions）：**兩個 server 都公開 `search`。`mcp__server__tool` 命名空間避免了衝突；但一個名稱含 `__` 的 server 仍會被解析錯誤，所以名稱要保持簡單。
 - **工具清單膨脹（Tool-list bloat）：**太多 server 會造成龐大的工具清單，既花 token 又干擾選擇（第 2 章）。緩解：截斷描述並延後載入。
-- **connect 之後池過時：**一個在 session 中途加入的 server 不在 cache 的工具清單裡，於是模型永遠看不到它。緩解：變動時重建池並重建 prompt（第 8 章）。
+- **connect 之後池過時：**一個在 session 中途加入的 server 不在 cache 的工具清單裡，於是模型永遠看不到它。緩解：變動時重建池並重建 prompt（第 8 章）；
+  2026-07-28 版的 spec 為此加了走 `subscriptions/listen` 的 `toolsListChanged` 通知和 `ttlMs` 提示。
 - **連線抖動（Connection churn）：**一個不穩的 server 會逾時、重置，或 token 過期。緩解：反覆失敗後重連、`401` 時重新驗證、為每次呼叫設逾時（第 11 章）。
+  stateless 版拿掉了 stream 續傳，所以中斷的 request 要當成一個新 request 重發，不是接著傳。
 - **被過度信任的副作用：**一個 server 把具破壞性的工具標成 `readOnlyHint: true` 以跳過提示。緩解：以完整名稱設一條規則照樣 gate 它（第 3 章）。
 
 ---
@@ -172,4 +198,8 @@ uv run python sections/19-mcp-plugins-channels/src/demo.py  # live demo, needs a
 - [Claude Code MCP config and channels](https://github.com/yasasbanukaofficial/claude-code)：`config.ts`（precedence）、`channelNotification.ts`（`CHANNEL_TAG`），加上 `McpAuthTool`、`ListMcpResourcesTool`、`ReadMcpResourceTool`。
 - [Claude Code plugins](https://github.com/yasasbanukaofficial/claude-code)：`plugins/builtinPlugins.ts`、`plugins/bundled/`、`types/plugin.ts`，加上 `remote/` 與 `bridge/`。
 - [Hermes Agent 原始碼](https://github.com/NousResearch/hermes-agent)：`mcp_serve.py`、`hermes_cli/plugins.py`（`PluginManager`、`VALID_HOOKS`）、`gateway/platforms/`、`gateway/platform_registry.py`、`plugins/platforms/`。
+- [MCP specification 2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28) 與它的
+  [changelog](https://modelcontextprotocol.io/specification/2026-07-28/changelog)：stateless protocol、`server/discover`、`subscriptions/listen`、MRTR、deprecation 清單。
+- MCP blog：[the future of transports](https://blog.modelcontextprotocol.io/posts/2025-12-19-mcp-transport-future/)（protocol 為什麼走向 stateless）、
+  [SDK betas for 2026-07-28](https://blog.modelcontextprotocol.io/posts/sdk-betas-2026-07-28/)（v2 SDK 與向後相容）。
 - 章節定位：[learn-claude-code · s19_mcp_plugin](https://github.com/shareAI-lab/learn-claude-code)。


### PR DESCRIPTION
Updates section 19 for the stable 2026-07-28 MCP spec revision.

- Add a wire protocol subsection: stateless design, `server/discover`, `subscriptions/listen`, multi round-trip requests, deprecations, and what changes for users.
- Define the MCP server and client roles at first mention.
- Extend the stale-pool and connection-churn mitigations with the new spec mechanisms.
- Add the spec, changelog, and MCP blog posts to sources.
- Mirror all edits in zh-TW and zh-CN.