### PR TITLE
docs: add section 23 evaluation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ This checklist is what reviewers check on every PR.
   A source should back a claim the section text makes.
 - Nothing goes after the per-system table except its closing rule.
 - Benchmarks go in the section they evaluate. General agent and harness evaluation
-  belongs in section 20. Memory benchmarks belong in section 9 and the
+  belongs in section 23. Memory benchmarks belong in section 9 and the
   production-memory track. Group entries by purpose, one line each on what it measures,
   with paper and canonical repo links.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center">
   <a href="#sections"><img src="https://img.shields.io/badge/Focus-Harness_Engineering-8250df" alt="Focus: Harness Engineering"></a>
   <a href="#systems-under-study"><img src="https://img.shields.io/badge/Systems-3+-0969da" alt="Systems"></a>
-  <a href="#sections"><img src="https://img.shields.io/badge/Sections-23-2da44e" alt="Sections"></a>
+  <a href="#sections"><img src="https://img.shields.io/badge/Sections-24-2da44e" alt="Sections"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-d29922" alt="License"></a>
 </p>
 
@@ -63,9 +63,9 @@ Each system is a worked example for the sections below.
 
 | System                 | Why people use it                                                               | Read it for                        | Sections             | Version studied |
 | ---------------------- | ------------------------------------------------------------------------------- | ---------------------------------- | -------------------- | --------------- |
-| **Claude Code**  | Frontier coding agent: edits files, runs commands, ships changes in real repos. | The full harness, start here       | 0 to 22 (all)        | v2.1.88         |
+| **Claude Code**  | Frontier coding agent: edits files, runs commands, ships changes in real repos. | The full harness, start here       | 0 to 23 (all)        | v2.1.88         |
 | **Hermes Agent** | Long-term assistant: remembers you, learns workflows, runs anywhere. | Memory, skills, always-on channels | 7, 9, 14, 16, 19, 21, 22 | v2026.7.1 |
-| **mini-swe-agent** | Research baseline: one bash tool, about 150 lines. | The smallest complete loop, budgets, eval harness | 0 to 3, 8, 10, 11, 20 to 22 | v2.4.5 |
+| **mini-swe-agent** | Research baseline: one bash tool, about 150 lines. | The smallest complete loop, budgets, eval harness | 0 to 3, 8, 10, 11, 20 to 23 | v2.4.5 |
 | *(more soon)*        |                                                                                 |                                    |                      |                 |
 
 > More systems can be added later, including OpenClaw and aider.
@@ -111,6 +111,7 @@ Eight layers, from the basic loop to a harness that runs itself. Each row links 
 |    | **Layer 6 · Extension & Integration**                 |                                                    |                                                       |
 | 19 | [MCP / plugins / channels](sections/19-mcp-plugins-channels/) | How does the harness reach the world?              | Transports, channels, tool pool assembly              |
 | 20 | [Observability &amp; evaluation](sections/20-observability/)  | How do we know it works?                           | Tracing, metrics, evals, failure analysis             |
+| 23 | [Evaluation](sections/23-evaluation/)                         | How do we know a change made it better?            | Eval environments, resets, judges, Pass^k             |
 |    | **Layer 7 · Composition**                             |                                                    |                                                       |
 | 21 | [Loop engineering](sections/21-loop-engineering/)             | How do loops stack into a system that runs itself? | Verification loop, triggers, budgets, maturity levels |
 | 22 | [Graph engineering](sections/22-graph-engineering/)           | When does control flow move from the model to code? | Nodes, coded edges, cycles, agents as nodes           |
@@ -119,7 +120,7 @@ Eight layers, from the basic loop to a harness that runs itself. Each row links 
 
 ## Repository Structure
 
-All 23 section writeups are present, from `00-harness-thesis/` through `22-graph-engineering/`.
+All 24 section writeups are present, from `00-harness-thesis/` through `23-evaluation/`.
 
 ```text
 awesome-agent-architecture/
@@ -128,13 +129,13 @@ awesome-agent-architecture/
 │   ├── 00-harness-thesis/     # README.md per section
 │   ├── 01-agent-loop/src/     # runnable chain starts here
 │   ├── ...
-│   └── 22-graph-engineering/
+│   └── 23-evaluation/
 └── references/                # primary sources and prior art
 ```
 
 Each section folder is `NN-name/` and contains a `README.md`.
 
-Sections 1 to 22 also carry a runnable `src/`. The code accumulates section by section.
+Sections 1 to 23 also carry a runnable `src/`. The code accumulates section by section.
 Each section adds one mechanism and evolves `loop.py`, so a diff between adjacent sections shows what changed.
 
 Deep dives that outgrow one section live in their own repos.
@@ -144,7 +145,7 @@ Deep dives that outgrow one section live in their own repos.
 
 ## Running the Demos
 
-Sections 1 to 22 ship runnable demos. Set up once from the repo root:
+Sections 1 to 23 ship runnable demos. Set up once from the repo root:
 
 ```bash
 uv venv
@@ -197,3 +198,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full PR checklist.
 - [LangChain · 3 years of graph engineering](https://www.langchain.com/blog/3-years-of-graph-engineering-with-langgraph): Nodes, edges, cycles, and agents as nodes.
 - [Anthropic · Building effective agents](https://www.anthropic.com/engineering/building-effective-agents): Workflows vs agents and the five workflow shapes.
 - [Google · Why we built ADK 2.0](https://developers.googleblog.com/en/why-we-built-adk-20/): Routing in code and context isolation between nodes.
+- [ai-agent-book](https://github.com/bojieli/ai-agent-book): 《深入理解 AI Agent》 by 李博杰 (Apache-2.0). Chapter 6 grounds the evaluation section.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -7,7 +7,7 @@
 <p align="center">
   <a href="#研究的系统"><img src="https://img.shields.io/badge/Focus-Harness_Engineering-8250df" alt="Focus: Harness Engineering"></a>
   <a href="#研究的系统"><img src="https://img.shields.io/badge/Systems-3+-0969da" alt="Systems"></a>
-  <a href="#各章节"><img src="https://img.shields.io/badge/Sections-23-2da44e" alt="Sections"></a>
+  <a href="#各章节"><img src="https://img.shields.io/badge/Sections-24-2da44e" alt="Sections"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-d29922" alt="License"></a>
 </p>
 
@@ -63,9 +63,9 @@
 
 | 系统                     | 大家为什么用它                                                        | 值得看的地方                          | 覆盖章节                  | 研究版本  |
 | ------------------------ | --------------------------------------------------------------------- | ------------------------------------- | ------------------------- | --------- |
-| **Claude Code**    | 目前最强的 coding agent：改文件、跑命令，直接在真实 repo 里完成改动。 | 完整 harness 架构，从这里读起         | 0 到 22（全部）           | v2.1.88   |
+| **Claude Code**    | 目前最强的 coding agent：改文件、跑命令，直接在真实 repo 里完成改动。 | 完整 harness 架构，从这里读起         | 0 到 23（全部）           | v2.1.88   |
 | **Hermes Agent**   | 长期助理：记得你、学会你的工作流程，还能跨平台跑任务。                | Memory、skills、always-on channels    | 7、9、14、16、19、21、22  | v2026.7.1 |
-| **mini-swe-agent** | 研究基准：一个 bash 工具，约 150 行。                                 | 最小的完整 loop、budget、eval harness | 0 到 3、8、10、11、20 到 22 | v2.4.5    |
+| **mini-swe-agent** | 研究基准：一个 bash 工具，约 150 行。                                 | 最小的完整 loop、budget、eval harness | 0 到 3、8、10、11、20 到 23 | v2.4.5    |
 | *(更多陆续加入)*       |                                                                       |                                       |                           |           |
 
 > 之后可以再加入更多系统，例如 OpenClaw 和 aider。
@@ -111,6 +111,7 @@
 |    | **第 6 层 · 扩展与集成**                                             |                                     |                                                       |
 | 19 | [MCP / plugins / channels](sections/19-mcp-plugins-channels/README.zh-CN.md) | harness 怎么连到外面的世界？        | Transports, channels, tool pool assembly              |
 | 20 | [Observability &amp; evaluation](sections/20-observability/README.zh-CN.md)  | 我们怎么知道它有效？                | Tracing, metrics, evals, failure analysis             |
+| 23 | [Evaluation](sections/23-evaluation/README.zh-CN.md)                         | 怎么知道这次改动有没有让它变好？    | Eval environments, resets, judges, Pass^k             |
 |    | **第 7 层 · 组合**                                                   |                                     |                                                       |
 | 21 | [Loop engineering](sections/21-loop-engineering/README.zh-CN.md)             | loop 怎么叠成一个能自己运转的系统？ | Verification loop, triggers, budgets, maturity levels |
 | 22 | [Graph engineering](sections/22-graph-engineering/README.zh-CN.md)           | 什么时候该让代码决定下一步，而不是问 model？ | Nodes, coded edges, cycles, agents as nodes           |
@@ -119,7 +120,7 @@
 
 ## 文件结构
 
-23 篇章节说明都已备齐，从 `00-harness-thesis/` 一路到 `22-graph-engineering/`。
+24 篇章节说明都已备齐，从 `00-harness-thesis/` 一路到 `23-evaluation/`。
 
 ```text
 awesome-agent-architecture/
@@ -128,13 +129,13 @@ awesome-agent-architecture/
 │   ├── 00-harness-thesis/     # 每章一份 README.md
 │   ├── 01-agent-loop/src/     # 可执行的代码链从这里开始
 │   ├── ...
-│   └── 22-graph-engineering/
+│   └── 23-evaluation/
 └── references/                # 原始出处与前人成果
 ```
 
 每个章节文件夹都是 `NN-name/` 格式，里面有一份 `README.md`。
 
-第 1 到 22 章还带有可执行的 `src/`。代码一章一章累积上去。
+第 1 到 23 章还带有可执行的 `src/`。代码一章一章累积上去。
 每一章新增一个机制，并让 `loop.py` 演进，所以对比相邻两章的 diff，就能看出改了什么。
 
 超出单一章节篇幅的深入主题，会独立成自己的 repo。
@@ -144,7 +145,7 @@ awesome-agent-architecture/
 
 ## 运行示范
 
-第 1 到 22 章都附有可执行的示范。从 repo 根目录配置一次就好：
+第 1 到 23 章都附有可执行的示范。从 repo 根目录配置一次就好：
 
 ```bash
 uv venv
@@ -197,3 +198,4 @@ uv run python sections/01-agent-loop/src/demo.py  # 实时
 - [LangChain · 3 years of graph engineering](https://www.langchain.com/blog/3-years-of-graph-engineering-with-langgraph): node、edge、cycle，以及把 agent 当 node。
 - [Anthropic · Building effective agents](https://www.anthropic.com/engineering/building-effective-agents): workflow 与 agent 的分界，加上五种 workflow 图形。
 - [Google · Why we built ADK 2.0](https://developers.googleblog.com/en/why-we-built-adk-20/): 用代码选路，以及 node 之间的 context 隔离。
+- [ai-agent-book](https://github.com/bojieli/ai-agent-book): 《深入理解 AI Agent》（李博杰著，Apache-2.0）。第 6 章是评估这一章的主要出处。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -7,7 +7,7 @@
 <p align="center">
   <a href="#研究的系統"><img src="https://img.shields.io/badge/Focus-Harness_Engineering-8250df" alt="Focus: Harness Engineering"></a>
   <a href="#研究的系統"><img src="https://img.shields.io/badge/Systems-3+-0969da" alt="Systems"></a>
-  <a href="#各章節"><img src="https://img.shields.io/badge/Sections-23-2da44e" alt="Sections"></a>
+  <a href="#各章節"><img src="https://img.shields.io/badge/Sections-24-2da44e" alt="Sections"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-d29922" alt="License"></a>
 </p>
 
@@ -63,9 +63,9 @@
 
 | 系統                     | 大家為什麼用它                                                        | 值得看的地方                          | 覆蓋章節                  | 研究版本  |
 | ------------------------ | --------------------------------------------------------------------- | ------------------------------------- | ------------------------- | --------- |
-| **Claude Code**    | 目前最強的 coding agent：改檔案、跑指令，直接在真實 repo 裡完成改動。 | 完整 harness 架構，從這裡讀起         | 0 到 22（全部）           | v2.1.88   |
+| **Claude Code**    | 目前最強的 coding agent：改檔案、跑指令，直接在真實 repo 裡完成改動。 | 完整 harness 架構，從這裡讀起         | 0 到 23（全部）           | v2.1.88   |
 | **Hermes Agent**   | 長期助理：記得你、學會你的工作流程，還能跨平台跑任務。                | Memory、skills、always-on channels    | 7、9、14、16、19、21、22  | v2026.7.1 |
-| **mini-swe-agent** | 研究基準：一個 bash 工具，約 150 行。                                 | 最小的完整 loop、budget、eval harness | 0 到 3、8、10、11、20 到 22 | v2.4.5    |
+| **mini-swe-agent** | 研究基準：一個 bash 工具，約 150 行。                                 | 最小的完整 loop、budget、eval harness | 0 到 3、8、10、11、20 到 23 | v2.4.5    |
 | *(更多陸續加入)*       |                                                                       |                                       |                           |           |
 
 > 之後可以再加入更多系統，例如 OpenClaw 和 aider。
@@ -111,6 +111,7 @@
 |    | **第 6 層 · 擴充與整合**                                             |                                     |                                                       |
 | 19 | [MCP / plugins / channels](sections/19-mcp-plugins-channels/README.zh-TW.md) | harness 怎麼連到外面的世界？        | Transports, channels, tool pool assembly              |
 | 20 | [Observability &amp; evaluation](sections/20-observability/README.zh-TW.md)  | 我們怎麼知道它有效？                | Tracing, metrics, evals, failure analysis             |
+| 23 | [Evaluation](sections/23-evaluation/README.zh-TW.md)                         | 怎麼知道這次改動有沒有讓它變好？    | Eval environments, resets, judges, Pass^k             |
 |    | **第 7 層 · 組合**                                                   |                                     |                                                       |
 | 21 | [Loop engineering](sections/21-loop-engineering/README.zh-TW.md)             | loop 怎麼疊成一個能自己運轉的系統？ | Verification loop, triggers, budgets, maturity levels |
 | 22 | [Graph engineering](sections/22-graph-engineering/README.zh-TW.md)           | 什麼時候該讓程式碼決定下一步，而不是問 model？ | Nodes, coded edges, cycles, agents as nodes           |
@@ -119,7 +120,7 @@
 
 ## 檔案結構
 
-23 篇章節說明都已備齊，從 `00-harness-thesis/` 一路到 `22-graph-engineering/`。
+24 篇章節說明都已備齊，從 `00-harness-thesis/` 一路到 `23-evaluation/`。
 
 ```text
 awesome-agent-architecture/
@@ -128,13 +129,13 @@ awesome-agent-architecture/
 │   ├── 00-harness-thesis/     # 每章一份 README.md
 │   ├── 01-agent-loop/src/     # 可執行的程式碼鏈從這裡開始
 │   ├── ...
-│   └── 22-graph-engineering/
+│   └── 23-evaluation/
 └── references/                # 原始出處與前人成果
 ```
 
 每個章節資料夾都是 `NN-name/` 格式，裡面有一份 `README.md`。
 
-第 1 到 22 章還帶有可執行的 `src/`。程式碼一章一章累積上去。
+第 1 到 23 章還帶有可執行的 `src/`。程式碼一章一章累積上去。
 每一章新增一個機制，並讓 `loop.py` 演進，所以對比相鄰兩章的 diff，就能看出改了什麼。
 
 超出單一章節份量的深入主題，會獨立成自己的 repo。
@@ -144,7 +145,7 @@ awesome-agent-architecture/
 
 ## 執行示範
 
-第 1 到 22 章都附有可執行的示範。從 repo 根目錄設定一次就好：
+第 1 到 23 章都附有可執行的示範。從 repo 根目錄設定一次就好：
 
 ```bash
 uv venv
@@ -197,3 +198,4 @@ uv run python sections/01-agent-loop/src/demo.py  # 即時
 - [LangChain · 3 years of graph engineering](https://www.langchain.com/blog/3-years-of-graph-engineering-with-langgraph): node、edge、cycle，以及把 agent 當 node。
 - [Anthropic · Building effective agents](https://www.anthropic.com/engineering/building-effective-agents): workflow 與 agent 的分界，加上五種 workflow 圖形。
 - [Google · Why we built ADK 2.0](https://developers.googleblog.com/en/why-we-built-adk-20/): 用程式碼選路，以及 node 之間的 context 隔離。
+- [ai-agent-book](https://github.com/bojieli/ai-agent-book): 《深入理解 AI Agent》（李博杰著，Apache-2.0）。第 6 章是評估這一章的主要出處。

--- a/sections/23-evaluation/README.md
+++ b/sections/23-evaluation/README.md
@@ -1,0 +1,288 @@
+# 23 · Evaluation
+
+**English** · [繁體中文](README.zh-TW.md) · [简体中文](README.zh-CN.md)
+
+> A pass rate is only worth what the environment behind it is worth.
+
+Section 20 watches production. It says what happened, never whether it was any good. This section answers the other question: did this change make the agent better.
+
+For a single model call that question is easy. Send a prompt, compare the answer to a reference, count.
+
+An agent breaks every part of that. It runs several turns. It asks the user for information the task never stated. It calls tools that change stored data.
+It reaches the same result by different routes. Two runs of the same build on the same task can disagree.
+
+So an agent score needs a test bed, not a list of prompts: state that resets, a stand-in for the user, a protocol that steps the conversation,
+and a rubric that grades the world the run left behind.
+
+Skip it and the numbers still arrive. They just do not mean anything. A suite whose tasks leaked into training. A 3 point gap that is only sampling noise.
+A build that scores well and refunds an order the customer never named.
+
+---
+
+## Mechanism
+
+```mermaid
+flowchart LR
+    D["Dataset · task records"] --> RS["reset"]
+    RS --> U["Simulated user"]
+    U -->|releases one fact| A["Agent under test"]
+    A -->|reply| U
+    A -->|tool call| S["Environment state"]
+    S -->|observation| A
+    S --> G["Grade · state checks,<br/>what was said, veto"]
+    G --> M["Metrics · Pass@k, Pass^k,<br/>noise band"]
+    M -->|change one thing| A
+```
+
+An evaluation environment has five parts. Four are data, one is control flow.
+
+- **Dataset.** The task records. Each holds a starting state, what the user wants, and how the run is checked.
+- **Environment state.** The mutable data a task starts from and ends in: orders, files, a database.
+  It must be realistic enough to matter and controlled enough to reset.
+- **Tools.** The operations the agent is allowed to run. Keep them atomic (read an order, refund an order),
+  not one tool named "solve the customer's problem".
+- **Rubric.** How a finished run turns into a score.
+- **Interaction protocol.** Who speaks when, and when the episode ends.
+
+Section 20's eval took `(input, grade)` pairs: one string in, one string out, one pass rate. This section keeps that entry point and puts an environment under it.
+
+### New: the environment and its reset
+
+The environment holds the state and owns the only way to change it:
+
+```python
+def reset(self):                                       # src/evaluation.py
+    self.state = deepcopy(self.initial)                # a fresh copy per episode
+    self.calls = []
+
+def call(self, name, **args):
+    tool = self.tools.get(name)
+    if tool is None:
+        self.calls.append((name, False))               # illegal: no such tool
+        return f"error: no tool named {name}"
+    try:
+        out = tool(self.state, **args)
+    except Exception as e:                             # illegal: wrong arguments
+        self.calls.append((name, False))
+        return f"error: {type(e).__name__}: {e}"
+    self.calls.append((name, True))
+    return str(out)
+```
+
+- `reset` deep copies the starting snapshot, so episode two never sees episode one's writes.
+  Without it, the second run of a refund task starts with the order already refunded.
+- A rejected call returns a message saying why, not a bare failure flag. Recovering from it is part of the behavior under test.
+- Every call is logged with whether it was legal. That log is the process metrics: illegal calls and step count, available even when the outcome check passes.
+
+### New: the simulated user and the protocol
+
+Most benchmarks hand the agent the full request in the first message. Real users do not.
+They open with "something is wrong with my order" and give the rest when asked.
+
+So the simulated user holds a script and releases one fact per turn. That is what makes asking a graded skill:
+
+```python
+def run_episode(env, task, agent, max_turns=8):        # src/evaluation.py
+    env.reset()
+    user = task["user"]()                              # a fresh simulated user per episode
+    transcript, said = [], user()
+    for _ in range(max_turns):                         # the ceiling: an episode always terminates
+        if said is None:
+            break
+        reply = agent(said, env)
+        transcript.append((said, reply))
+        said = user(reply)
+    return {"transcript": transcript, "state": env.state, "calls": list(env.calls)}
+```
+
+The runnable uses a fixed script so the offline checks stay deterministic. The live version is an LLM given the same script.
+It is told to answer in character, to release only what the current step needs, and to invent nothing. Wording varies, the order of disclosure does not.
+
+The stronger version gives the simulated user its own tools over the same state. The agent then has to talk someone else into acting, which is what a support call actually is.
+It also means the user can change things the agent has to notice, so the state stops being the agent's private sandbox.
+
+### New: grading one episode
+
+Three checks, in order:
+
+```python
+def grade(task, run):                                  # src/evaluation.py
+    checks = {name: bool(fn(run["state"])) for name, fn in task["checks"]}       # the outcome
+    said = " ".join(reply for _, reply in run["transcript"]).lower()
+    told = {s: s.lower() in said for s in task.get("must_say", [])}              # what was communicated
+    unsafe = [name for name, fn in task.get("veto", []) if fn(run)]              # zero tolerance
+    return {"passed": all(checks.values()) and all(told.values()) and not unsafe, ...}
+```
+
+- **Outcome, not path.** The checks read the final state, so any route that reaches it passes. A reference solution is one way to solve the task, not the required way.
+- **What was said.** A run that refunds the money and never tells the customer the amount is not finished.
+  Checking only the state misses that, and checking only the transcript misses "claimed but never did".
+- **Veto.** One safety hit fails the run whatever else scored: refunding an order the customer never named, printing a secret, mailing an outsider.
+  No other dimension buys it back.
+
+### Metrics: what k runs are for
+
+One run gives a verdict. Several runs of the same task give the number that matters:
+
+- **Pass@k**: at least one of k runs passed. Answers "can it", the right metric for exploratory tasks.
+- **Pass^k**: all k runs passed. Answers "is it reliable", the right metric for a regression gate.
+- **Best@k**: the best score of k runs, for open tasks with a graded scale rather than a binary verdict.
+
+The two diverge fast. At a 60 percent single-run success rate, Pass@5 is about 99 percent and Pass^5 is about 8 percent.
+Report the wrong one and a coin flip looks like a shipped feature.
+
+Alongside them sit the process metrics the call log already carries: share of legal calls, steps against a known-good baseline, retries, and cost per task.
+They are what tells you whether a passing run passed cheaply or by brute force.
+
+### Judging open-ended work
+
+State checks cover tasks with a checkable end state. A written answer has nothing to hash, so a model grades it against a rubric.
+How well the grading works comes down to how the rubric is written:
+
+1. **Expert grounded.** It encodes what a domain expert checks, not surface fluency.
+2. **Full coverage.** Accuracy, completeness, and safety, with the common failure named explicitly instead of implied.
+3. **Weighted, with vetoes.** Criteria split into essential, important, and optional, and a veto item such as fabricated facts zeroes the score.
+4. **Self contained.** Each item is checkable without the judge's own opinion. "Cites at least two sources and explains how each supports the conclusion" works.
+   "Shows deep understanding" does not.
+
+A judge is a model, so it has model failures. It prefers longer answers. It favors whichever candidate it read first.
+A judge from the same family as the agent shares its blind spots, so it forgives exactly the errors the agent makes.
+
+The mitigations are cheap. Use judges from different families. Grade pairs twice with the order swapped.
+Calibrate the judge against a human-labeled gold set before trusting it at scale, and send disagreement to a human.
+
+### The dataset decides what the score means
+
+A perfect environment running a bad dataset returns noise. Four rules survive across benchmarks.
+
+- **Verifiable.** The answer or end state can be checked without a human reading it.
+- **Tiered.** Easy, medium, and hard tasks separated, so a change that only helps easy tasks cannot hide in the average.
+- **Human checked.** Someone confirms the task is solvable and the check is fair.
+  Whole benchmark subsets exist because the original tasks were underspecified or graded by unfair tests.
+- **Contamination defended.** Public tasks reach the next training set. Defenses: a canary string in every task file, withheld answers,
+  tasks collected after the model's cutoff, and parameterized templates that generate fresh instances from one shape.
+
+### Reading a difference
+
+Two builds, 100 tasks, 70 percent against 73 percent. That is not a result.
+
+- **The noise band.** The standard error on a rate over n tasks is about the square root of `p(1-p)/n`.
+  At 70 percent on 100 tasks that is roughly 4.6 points, so a 3 point gap sits inside the noise.
+- **Repeat.** Sampling and tool timing move a score run to run. Take three to five runs per configuration and report the spread, not one number.
+- **Pair.** Both builds ran the same tasks, so compare them task by task and look only where they disagree.
+  Pairing removes task difficulty from the comparison, so it needs far fewer samples than two independent rates.
+- **Count your hypotheses.** Test six changes at 95 percent confidence and there is about a 26 percent chance one looks significant by luck.
+  Tighten the threshold or rerun the winner before believing it.
+
+If the improvement you expect is smaller than the band your suite can resolve, the next task is growing the suite, not tuning the agent.
+
+### From a report to a change
+
+A benchmark report is the input to one decision: what to change next.
+
+1. **Suspect the harness first.** A killed process, a buggy grader, or a task that no longer matches production looks exactly like a worse agent.
+   Read failing trajectories before touching the agent.
+2. **Find the cluster.** An 88 percent overall rate with three of four related tasks failing is not a general weakness, it is one missing capability.
+3. **Change one variable.** Fix the model, the seeds, the task set, and the step limit, then change one thing per round. A round that changes three things explains nothing.
+4. **Attribute.** Swap the model with the harness fixed to see how much the model carries. Disable one harness component with the model fixed to see what that component is worth.
+   This repo's thesis is that both numbers exist.
+5. **Scale the evidence to the decision.** Four tasks can justify a bigger run. They cannot justify a deploy.
+
+Inside a product this becomes standing infrastructure. A master switch disables features to get a bare-model baseline.
+Feature flags carry the AB test arms and double as a kill switch.
+A snapshot of the fully rendered system prompt per commit lets a prompt edit run the eval suite like any other code change.
+
+For the AB tests, separate the mechanism metric you moved (plan length, prompt size) from the goal metric you care about (task success, session cost).
+Keep guardrail metrics that stop the experiment even when the goal metric improves.
+
+### How it integrates
+
+Evaluation reuses the harness rather than adding to it:
+
+- The environment's tool interface is section 2's registry, with the handlers pointed at eval state instead of the real world.
+- The agent under test is the section 1 loop, unmodified. Nothing in the loop knows it is being evaluated.
+- The judge is section 21's checker: a separate agent, a fresh context, a fixed rubric it can satisfy but not rewrite.
+- Section 20 supplies the inputs. Scrubbed production traces become new tasks, and its cost tracker gives cost per task.
+- The improvement loop is section 21's outer loop with evidence attached: measure, change one thing, measure again.
+
+---
+
+## Per system
+
+How each system builds the test bed a score comes from.
+
+| | Claude Code | mini-swe-agent | τ²-bench | Verifiers |
+| --- | --- | --- | --- | --- |
+| **Pros** | Bad work is caught before it lands. | The benchmark runner ships with the agent. | Any correct route passes. | One task set can grade any model or harness. |
+| **Cons** | No eval suite in source. | The benchmark's tests are the only rubric. | A second model plays the user, so scores drift. | Heavy setup for a one-off eval. |
+| **Why** | Catch bad work inside the run. | A task is one repo bug with tests. | Support work is a conversation. | Eval and training share one environment. |
+| **How: environment** | Reconstruction: a scratch copy. | One container per instance: that is the reset. | A domain database and a policy. | A fresh sandboxed runtime per run. |
+| **How: task set** | Reconstruction: held-out tasks from scrubbed traces. | A published benchmark split. | Hand written per domain. | A module loaded by id, local or from a hub. |
+| **How: scoring** | A reviewer agent and a fixed rubric. | Failing tests pass, passing ones stay. | End state against a gold replay. | Reward functions and a code-running judge. |
+| **How: repeats** | Verify passes inside one run. | One run per instance. | k trials, scored as reliability. | Rollouts per task is a flag. |
+
+---
+
+## Failure modes
+
+- **Grading the transcript instead of the world.** An agent that says "refunded" scores the same as one that refunded.
+  Mitigation: check the end state, and keep a separate check for what the agent had to communicate.
+- **Contaminated tasks.** A public benchmark reaches the next training set, so a high score can be recall rather than capability.
+  Mitigation: canary strings in task files, withheld answers, tasks collected after the cutoff, and parameterized templates.
+- **Reading noise as a result.** A 3 point gap on 100 tasks, one run each, decides nothing.
+  Mitigation: repeat runs, compare paired per task, ignore gaps inside the noise band, and tighten the threshold when testing many changes at once.
+- **Blaming the agent for a broken harness.** A starved runner, a buggy grader, or a stale task looks exactly like a quality drop.
+  Mitigation: read failing trajectories before changing the agent.
+- **A judge that shares the agent's blind spots.** Same-family judges forgive the errors the agent makes, prefer longer answers, and favor whichever candidate came first.
+  Mitigation: judges from different families, order swapped and graded twice, calibrated against a human-labeled gold set.
+- **Reward hacking.** The agent finds a route to the score that skips the work: keyword stuffing, flattering the judge, refusing hard cases.
+  Mitigation: veto items in the rubric, process metrics beside outcome metrics, and periodic human spot checks.
+- **A suite that cannot see the change.** A 2 point improvement on 40 tasks is unmeasurable, so every round reads as inconclusive.
+  Mitigation: grow the task set before iterating further.
+- **State leaking between runs.** No reset, or a shallow one, so one task's writes decide the next task's score.
+  Mitigation: a deep copy per episode, and one isolated environment per run (section 15).
+
+---
+
+## Runnable
+
+[`src/`](src/) carries 22 forward and adds:
+
+- [`evaluation.py`](src/evaluation.py): the environment with `reset` and a logged tool interface, a simulated user that releases one fact per turn, the episode protocol,
+  grading (state checks, what was said, veto), Pass@k and Pass^k, the binomial noise band, and a paired comparison of two builds.
+- [`test.py`](src/test.py): offline checks for reset restoring state, a protocol run where the agent has to ask for the order number,
+  a safety veto failing a run whose outcome check passed, Pass@k against Pass^k on a flaky build,
+  and a regressed build scoring lower with the paired comparison naming what it broke.
+- [`demo.py`](src/demo.py): one graded episode. The model plays the support agent, its tool calls land in the environment,
+  and the harness scores the state it left behind.
+
+The loop is unchanged. The environment is what makes the score mean something.
+
+```bash
+python sections/23-evaluation/src/test.py         # offline checks, no key
+uv run python sections/23-evaluation/src/demo.py  # live demo, needs a key
+```
+
+---
+
+## Sources
+
+- [ai-agent-book · chapter 6](https://github.com/bojieli/ai-agent-book/blob/main/book/chapter6.md) (《深入理解 AI Agent》, 李博杰; the Chinese original is canonical):
+  the five elements of an evaluation environment, progressive information disclosure, the metric dictionary, the rubric criteria,
+  statistical significance, the benchmark-to-improvement loop, and internal eval infrastructure.
+- [τ-bench](https://arxiv.org/abs/2406.12045) (Sierra): a user simulated by a language model, success judged by comparing the final database state
+  against the annotated goal state, and Pass^k for reliability.
+- [τ²-bench](https://arxiv.org/abs/2506.07982) and [its source](https://github.com/sierra-research/tau2-bench): the dual-control environment
+  where the simulated user also holds tools, and the reward basis (database state hashed against a gold replay, required phrases,
+  optional LLM-judged assertions) whose components multiply.
+- [Verifiers](https://github.com/willccbb/verifiers): environments as control flow between agents, task sets loaded by id, rollouts per task,
+  resume of missing or errored rollouts, and judge agents that execute code against a run's artifacts.
+- [mini-swe-agent source](https://github.com/swe-agent/mini-swe-agent): `run/benchmarks/swebench.py`, one container image per instance,
+  per-instance trajectory and prediction records.
+- [SWE-bench Verified](https://huggingface.co/datasets/princeton-nlp/SWE-bench_Verified): 500 human-validated instances,
+  graded by tests that must newly pass plus tests that must keep passing.
+- [GAIA](https://arxiv.org/abs/2311.12983): 466 questions with answers withheld for 300 of them, so the leaderboard cannot be scraped.
+- [BIG-bench](https://github.com/google/BIG-bench): the canary string carried in every task file to keep benchmark tasks out of web-scraped training data.
+- [Rubrics as Rewards](https://arxiv.org/abs/2507.17746) (Scale AI): checklist rubrics that name required facts, required reasoning steps, and the pitfalls that must be penalized.
+- [Claude Code](https://code.claude.com/docs): the reviewer and judge stages in the workflow contract, from tool schemas and documented behavior, not the source backup.
+  Evaluation suites are not present in the source, so those cells are marked as reconstruction.

--- a/sections/23-evaluation/README.zh-CN.md
+++ b/sections/23-evaluation/README.zh-CN.md
@@ -1,0 +1,290 @@
+# 23 · Evaluation
+
+[English](README.md) · [繁體中文](README.zh-TW.md) · **简体中文**
+
+> 一个 pass rate 值不值得信，看的是它背后那个环境做得怎么样。
+
+第 20 章看的是正式环境：发生过什么事都有记录，但做得好不好，它答不出来。这一章回答的是另一个问题：这次改动有没有让 agent 变好。
+
+如果只有一次 model 调用，这题很简单：丢一段 prompt 进去，把回答跟标准答案比一比，算对几题就好。
+
+换成 agent，这套就整个不管用了。它要跑好几轮。任务没讲的信息，它得自己开口问用户。它调用的 tool 会改到系统里存着的数据。
+同一个结果，走不同的路都到得了。而且同一份 build（同一版 agent，harness、prompt、model 都没换）跑同一个任务，跑两次结果还可能不一样。
+
+所以要给 agent 打分，需要的是一个测试环境，不是一串 prompt：可以 reset 的 state、一个模拟用户、一套推着对话往下走的 protocol，
+还有一份 rubric，用来看这趟跑完以后，环境被改成什么样子。
+
+少了这些，数字照样跑得出来，只是不代表什么。可能题目早就流进训练数据，agent 是背过答案才答对的。
+可能新版本比旧版高 3 个百分点，看起来有进步，其实只是题目抽样的随机波动。
+也可能分数很漂亮的那份 build，实际上把客人根本没提过的订单也退掉了。
+
+---
+
+## 机制
+
+```mermaid
+flowchart LR
+    D["Dataset · 任务记录"] --> RS["reset"]
+    RS --> U["模拟用户"]
+    U -->|一次只给一项信息| A["受测的 agent"]
+    A -->|回话| U
+    A -->|tool 调用| S["环境 state"]
+    S -->|观察结果| A
+    S --> G["打分 · state 检查、<br/>该讲的话、否决项"]
+    G --> M["指标 · Pass@k、Pass^k、<br/>噪声带"]
+    M -->|一次只改一件事| A
+```
+
+一个评估环境有五个部分，四个是数据，一个是流程。
+
+- **Dataset**：一笔一笔的任务记录。每一笔都写着起始 state、用户想要什么，以及这趟要怎么检查。
+- **Environment state**：任务会动到的那份数据，例如订单、文件、数据库。
+  它要够真实，测起来才有意义；也要抓得住，随时能 reset 回原样。
+- **Tools**：agent 可以执行的操作。要拆到够小（读一笔订单、退一笔订单），不要弄成一个叫「解决客诉」的 tool。
+- **Rubric**：一趟跑完以后，怎么换算成分数。
+- **Interaction protocol**：谁什么时候说话，以及这一趟什么时候结束。
+
+第 20 章的评估吃的是 `(input, grade)`：进去一个字符串，出来一个字符串，得到一个 pass rate。这一章保留同一个入口，只是在这个入口下面补上一个环境。
+
+### 新增：环境和它的 reset
+
+state 存在环境里，要改它只能通过环境给的 tool：
+
+```python
+def reset(self):                                       # src/evaluation.py
+    self.state = deepcopy(self.initial)                # a fresh copy per episode
+    self.calls = []
+
+def call(self, name, **args):
+    tool = self.tools.get(name)
+    if tool is None:
+        self.calls.append((name, False))               # illegal: no such tool
+        return f"error: no tool named {name}"
+    try:
+        out = tool(self.state, **args)
+    except Exception as e:                             # illegal: wrong arguments
+        self.calls.append((name, False))
+        return f"error: {type(e).__name__}: {e}"
+    self.calls.append((name, True))
+    return str(out)
+```
+
+- 每个 episode 开始前，`reset` 会把起始数据整份复制一份新的出来，agent 动到的是这份副本。
+  所以下一趟拿到的还是原本那份数据，上一趟写过什么都看不到。
+  少了这一步，退款任务跑第二次时，那笔订单已经是退过的状态。
+- agent 叫了不存在的 tool，或参数给错，环境会回一句话讲清楚错在哪，而不是只回一个「失败」。
+  看得懂错在哪，agent 才可能自己改对；改不改得回来，本来就是要测的能力。
+- 每次调用都会记下这次合不合法。这份记录就是过程指标的来源：叫错几次、总共走了几步。就算最后结果检查过了，这些数字还在。
+
+### 新增：模拟用户与 protocol
+
+大部分 benchmark 第一条消息就把完整需求交给 agent。真实的用户不会这样讲话。
+他们开头只会说「我的订单好像有问题」，剩下的你不问，他不会讲。
+
+所以模拟用户手上有一份脚本，一轮只讲一件事。这样一来，agent 会不会主动问，才变成可以打分的能力：
+
+```python
+def run_episode(env, task, agent, max_turns=8):        # src/evaluation.py
+    env.reset()
+    user = task["user"]()                              # a fresh simulated user per episode
+    transcript, said = [], user()
+    for _ in range(max_turns):                         # the ceiling: an episode always terminates
+        if said is None:
+            break
+        reply = agent(said, env)
+        transcript.append((said, reply))
+        said = user(reply)
+    return {"transcript": transcript, "state": env.state, "calls": list(env.calls)}
+```
+
+可运行代码用的是固定脚本，离线检查才会每次都一样。实际跑的时候，是找一个 LLM 拿同一份脚本来演用户。
+prompt 里会交代它：照角色回话、只讲这一步需要讲的、脚本里没有的不准自己编。每次讲法都不一样，但信息释出的顺序不会变。
+
+再做完整一点，就是让模拟用户对同一份 state 也有自己的 tool。有些事只有用户做得到，agent 只能说服他动手，真实的客服电话本来就是这样。
+这时候环境不再只有 agent 在改：用户也会动它，agent 得自己发现对方做了什么，不能假设现在的 state 都是自己造成的。
+
+### 新增：一趟 episode 怎么打分
+
+三种检查，照顺序：
+
+```python
+def grade(task, run):                                  # src/evaluation.py
+    checks = {name: bool(fn(run["state"])) for name, fn in task["checks"]}       # the outcome
+    said = " ".join(reply for _, reply in run["transcript"]).lower()
+    told = {s: s.lower() in said for s in task.get("must_say", [])}              # what was communicated
+    unsafe = [name for name, fn in task.get("veto", []) if fn(run)]              # zero tolerance
+    return {"passed": all(checks.values()) and all(told.values()) and not unsafe, ...}
+```
+
+- **看终态，不看路径**：检查读的是最后的 state，只要走到那个状态，中间怎么走都算过。标准解只是其中一种解法，不是规定要走的那一条。
+- **该讲的话**：钱退了，却没告诉客人退了多少，这趟不算做完。
+  只看 state 的话，这种漏讲会算成通过；只看对话的话，agent 说「已经帮您退款」但其实没退，也会算成通过。两边都要查。
+- **否决项**：只要踩到一次安全问题，这趟就是不过，其他项目再漂亮也救不回来：退了客人没提过的订单、把密钥打印出来、把信寄给不相干的人。
+
+### 指标：跑 k 次是为了什么
+
+跑一次只能得到一个判定。同一个任务跑好几次，才问得出真正想知道的事：
+
+- **Pass@k**：k 次里至少成功一次。回答的是「做不做得到」，探索型任务看这个。
+- **Pass^k**：k 次全部成功。回答的是「稳不稳」，回归测试的门槛看这个。
+- **Best@k**：k 次里最好的那次拿几分。用在开放式任务：分数是连续的，不是只有过跟不过。
+
+这两个数字很快就会拉开。单次成功率 60% 的话，Pass@5 大约 99%，Pass^5 大约 8%。
+指标挑错，明明只是运气好，看起来却像真的做出了什么。
+
+另外还有一组过程指标，调用记录里本来就有：合法调用的比例、跟已知的好解法比起来多走了几步、重试几次、每个任务花多少钱。
+它们回答的是另一件事：这次过关，是省着过的，还是硬撞过的。
+
+### 开放式输出怎么评
+
+有明确终态的任务，看 state 就够了。换成一段写出来的文字，没有东西可以直接比对，就交给另一个 model 照 rubric 打分。
+打分准不准，几乎都看 rubric 怎么写：
+
+1. **由专家写**：写进去的是这个领域真正要检查的东西，不是文字通不通顺。
+2. **涵盖要够全**：正确性、完整性、安全性都要顾到，常犯的错要直接写出来，不能让评判者自己意会。
+3. **有权重、有否决**：标准分成必要、重要、可选，像编造事实这种否决项一出现，总分直接归零。
+4. **每条都自己讲得清楚**：每一项都要能直接判断，不靠评判者自己的品味。
+   「至少引用两份出处，并说明各自怎么支撑结论」可以判断，「展现了深刻的理解」不行。
+
+评判者本身就是 model，model 有的毛病它都有：回答越长越容易拿高分，先读到的那一份也容易被偏袒。
+评判者跟 agent 同一个家族的话，盲点也一样，agent 犯的错它刚好都会放过。
+
+解法都不难：评判者换成不同家族的 model；配对比较时把顺序对调，再评一次；
+大规模用之前，先拿人工标好的 gold set 校准；两边判不一样的，就送人工看。
+
+### dataset 决定分数代表什么
+
+环境做得再好，dataset 不行，跑出来的就是噪声。各家 benchmark 反复验证出四条原则。
+
+- **可验证**：答案或终态不用人看就能判定。
+- **分难度**：简单、中等、困难的任务要分开，这样「只在简单题上有用」的改动就藏不进平均分里。
+- **人工看过**：要有人确认这题解得开、检查方式也公平。
+  有些 benchmark 之所以会出一个专门的子集，就是因为原本的题目讲不清楚，或是用了不公平的测试在打分。
+- **防污染**：公开的任务会流进下一轮训练数据。
+  常见的做法有：每个任务文件里放 canary 字符串、答案不公开、收集模型 cutoff 之后才出现的任务，以及用参数化模板从同一个题型生出新题。
+
+### 差距要怎么读
+
+两份 build，100 个任务，70% 对 73%。这不算结果。
+
+- **噪声带**：n 个任务上的成功率，标准误差大约是 `p(1-p)/n` 开根号。
+  100 个任务、70% 的话大约 4.6 个百分点，所以 3 个百分点的差距整个埋在噪声里。
+- **多跑几次**：采样本身有随机性，tool 响应的快慢也会影响结果，分数自然会浮动。每个配置跑三到五次，平均和波动范围一起报。
+- **配对比较**：两份 build 跑的是同一批任务，所以逐题比，只看两边结果不一样的那几题。
+  这样就把题目难易的影响扣掉了，需要的题数也比直接比较两个成功率来得少。
+- **算一下你同时验了几个假设**：六个改动都用 95% 置信水平，其中至少一个纯靠运气看起来显著的概率大约是 26%。
+  要么把门槛收紧，要么把跑赢的那个独立复跑一次，再决定信不信。
+
+如果你预期的提升，比这套评估分辨得出来的差距还小，那接下来该做的是把任务集扩大，不是继续调 agent。
+
+### 从报告到一次改动
+
+benchmark 报告只拿来做一个决定：下一步要改什么。
+
+1. **先怀疑评估本身**：process 被杀掉、grader 有 bug、任务跟正式环境早就对不上，这些在数字上跟 agent 变差长得一模一样。
+   动 agent 之前，先把失败的 trajectory 读过一遍。
+2. **找失败聚在哪**：总成功率 88%，但四个相关任务里挂了三个，这不是整体能力不足，是缺了某一项能力。
+3. **一轮只改一个变量**：model、seed、任务集、步数上限都固定住，每一轮只动一件事。一轮改三件事，什么都解释不了。
+4. **分清楚是谁的功劳**：harness 不动，只换 model，看 model 撑起多少；model 不动，关掉 harness 的某个组件，看那个组件值多少。
+   这个 repo 的主张就是：这两个数字都存在。
+5. **证据的规模要配得上决定**：四个任务可以支撑「值得跑大一点的实验」，撑不起「可以上线」。
+
+放进产品里，这些会变成常驻的基础设施。一个总开关可以关掉各种功能，量出裸 model 的 baseline。
+Feature flag 负责分 AB 测试的组别，出事时也是断路开关。
+每个 commit 都存一份完整展开后的 system prompt，改 prompt 就跟改代码一样，要跑一次评估。
+
+做 AB 测试时，要把你直接动到的机制指标（计划长度、prompt 大小）和你真正在乎的目标指标（任务成功率、单次会话成本）分开。
+另外留一组护栏指标：就算目标指标变好，护栏一破也要停下实验。
+
+### 如何整合
+
+评估沿用既有的 harness，没有另外加东西：
+
+- 环境的 tool 接口就是第 2 章的 registry，只是 handler 指向评估用的 state，不是真实世界。
+- 受测的 agent 就是第 1 章的 loop，一行都没改。loop 里没有任何东西知道自己正在被评估。
+- 评判者就是第 21 章的 checker：另一个 agent、全新的 context、一份它只能满足、不能改写的 rubric。
+- 第 20 章负责供料：正式环境的 trace 脱敏之后变成新任务，它的 cost tracker 给出每个任务花多少钱。
+- 改进 loop 就是第 21 章的外层 loop，只是这次带着证据：量一次、只改一件事、再量一次。
+
+---
+
+## 各系统做法
+
+各个系统怎么搭出分数背后的测试环境。
+
+| | Claude Code | mini-swe-agent | τ²-bench | Verifiers |
+| --- | --- | --- | --- | --- |
+| **Pros** | 烂结果在交出去之前就被挡掉。 | 跑 benchmark 的程序跟 agent 一起附在 repo 里。 | 看终态打分，走哪条路都算过。 | 环境、harness、model 分开配置，同一套任务集谁都能评。 |
+| **Cons** | 源码里没有成套的评估。 | 只有 benchmark 的测试当 rubric。 | 用户由另一个 model 扮演，那个 model 换了分数就飘。 | 为训练循环设计，跑一次性的评估也要先架好整套 runtime。 |
+| **Why** | 该挡的检查要在改动落地之前跑。 | 一个任务就是一个有测试的 repo bug。 | 客服工作本来就是一段对话。 | 评估和后训练要的是同一个环境。 |
+| **How: environment** | 重建：每次评估开一份用完就丢的工作区。 | 一个 instance 一个 container，换一个就是 reset。 | 一个领域数据库加一份政策文件。 | 每次运行都给一个全新的沙盒 runtime。 |
+| **How: task set** | 重建：正式环境的 trace 脱敏后留成固定题库。 | 公开 benchmark 的一个 split。 | 每个领域各自手写。 | 用 id 加载的模块，本地或线上都行。 |
+| **How: scoring** | 一个 reviewer agent 加一份固定 rubric。 | 该过的测试要过，本来会过的不能坏。 | 终态拿去跟标准解重放的结果比对。 | task 上的 reward 函数，加一个会跑代码的 judge。 |
+| **How: repeats** | 同一趟运行里重跑验证。 | 一个 instance 跑一次。 | 同一题跑 k 次，看的是稳定度。 | 每题跑几次 rollout 是个参数。 |
+
+---
+
+## 哪里会出错
+
+- **只看对话，不看实际结果（Grading the transcript）**：agent 说「已退款」，跟真的退了款拿到一样的分数。
+  缓解：检查终态，另外再检查该讲的话有没有讲。
+- **任务被污染（Contaminated tasks）**：公开 benchmark 会进到下一轮训练数据，高分可能只是背过。
+  缓解：任务文件里放 canary 字符串、答案不公开、收集 cutoff 之后才出现的任务，以及用参数化模板生新题。
+- **把噪声当结果（Reading noise as a result）**：100 个任务各跑一次，差 3 个百分点，什么都决定不了。
+  缓解：多跑几次、逐题配对比较、差距落在噪声带里就当它不存在，同时验很多改动时把门槛收紧。
+- **评估坏了却怪 agent（Blaming the agent）**：机器资源不够、grader 有 bug、任务过期，看起来都跟 agent 变差一模一样。
+  缓解：改 agent 之前，先读失败的 trajectory。
+- **评判者跟 agent 有同样的盲点（Shared blind spots）**：同家族的 judge 会放过 agent 常犯的错，偏好长回答，也偏好先读到的候选。
+  缓解：换不同家族的 judge、顺序对调各评一次、先用人工标注的 gold set 校准。
+- **钻分数的漏洞（Reward hacking）**：agent 找到拿分的捷径，跳过真正的工作：塞关键词、讨好 judge、遇到难题就回避。
+  缓解：rubric 里放否决项、结果指标旁边摆过程指标，再定期人工抽检。
+- **这套评估看不出改动（A suite that cannot see the change）**：40 个任务上 2 个百分点的提升根本量不出来，每一轮都只能写「看不出差别」。
+  缓解：先把任务集扩大，再继续迭代。
+- **上一趟的 state 留到下一趟（State leaking between runs）**：没有 reset，或只 reset 了浅的一层，上一个任务写下的东西就决定了下一题的分数。
+  缓解：每个 episode 深拷贝一份，每次运行各用一个独立的环境（第 15 章）。
+
+---
+
+## 可执行程序
+
+[`src/`](src/) 把 22 带了过来，并加上：
+
+- [`evaluation.py`](src/evaluation.py)：带 `reset` 和调用记录的环境、一轮只释出一项信息的模拟用户、episode 的 protocol、
+  打分（state 检查、该讲的话、否决项）、Pass@k 与 Pass^k、二项分布的噪声带，以及两份 build 的配对比较。
+- [`test.py`](src/test.py)：离线检查 reset 有没有把 state 还原、protocol 跑一趟时 agent 必须先问订单编号、
+  结果检查明明有过却被否决项挡下、同一个不稳定的 build 上 Pass@k 与 Pass^k 的差别，
+  以及退步的 build 分数更低、配对比较能指出它弄坏了哪几题。
+- [`demo.py`](src/demo.py)：实际跑一趟并打分。
+  model 扮演客服 agent，它调用的 tool 都打在环境上，最后 harness 看它留下的 state 给分。
+
+loop 本身完全没改。让分数有意义的，是它跑在什么环境里。
+
+```bash
+python sections/23-evaluation/src/test.py         # offline checks, no key
+uv run python sections/23-evaluation/src/demo.py  # live demo, needs a key
+```
+
+---
+
+## 出处
+
+- [ai-agent-book · 第 6 章](https://github.com/bojieli/ai-agent-book/blob/main/book/chapter6.md)（《深入理解 AI Agent》，李博杰，以中文原版为准）：
+  评估环境的五个要素、渐进式信息披露、指标词典、rubric 四准则、统计显著性、
+  从 benchmark 报告到系统改进，以及内部评估基础设施。
+- [τ-bench](https://arxiv.org/abs/2406.12045)（Sierra）：用另一个语言模型扮演用户；
+  成不成功，是拿对话结束时的数据库状态跟标注好的目标状态比对，另外还有衡量可靠度的 Pass^k。
+- [τ²-bench](https://arxiv.org/abs/2506.07982) 和[它的源码](https://github.com/sierra-research/tau2-bench)：双控环境，
+  模拟用户自己也有 tool；以及 reward basis（数据库终态哈希后跟标准解重放的结果比对、必须讲到的字符串、
+  可选的 LLM 判定条件），各项相乘才是总分。
+- [Verifiers](https://github.com/willccbb/verifiers)：环境负责安排多个 agent 之间的流程、用 id 加载任务集、
+  每题可以跑多次 rollout、续跑时只补跑漏掉或出错的那些，以及能对运行产物跑代码的 judge agent。
+- [mini-swe-agent 源码](https://github.com/swe-agent/mini-swe-agent)：`run/benchmarks/swebench.py`，
+  一个 instance 一个 container image，每个 instance 各自留下 trajectory 与预测记录。
+- [SWE-bench Verified](https://huggingface.co/datasets/princeton-nlp/SWE-bench_Verified)：500 题人工验证过的 instance，
+  打分方式是原本失败的测试要变成通过，本来就会过的测试不能坏。
+- [GAIA](https://arxiv.org/abs/2311.12983)：466 题，其中 300 题的答案不公开，排行榜就抓不走。
+- [BIG-bench](https://github.com/google/BIG-bench)：每个任务文件都带 canary 字符串，避免题目被爬进训练数据。
+- [Rubrics as Rewards](https://arxiv.org/abs/2507.17746)（Scale AI）：清单式的 rubric，写明要提到哪些事实、
+  要有哪些推理步骤，以及哪些常见错误必须扣分。
+- [Claude Code](https://code.claude.com/docs)：workflow 约定里的 reviewer 与 judge 阶段。
+  内容依据 tool schema 和文档记载的行为，不是 source backup。评估套件不在源码里，那几格都标成重建。

--- a/sections/23-evaluation/README.zh-TW.md
+++ b/sections/23-evaluation/README.zh-TW.md
@@ -1,0 +1,290 @@
+# 23 · Evaluation
+
+[English](README.md) · **繁體中文** · [简体中文](README.zh-CN.md)
+
+> 一個 pass rate 值不值得信，看的是它背後那個環境做得怎麼樣。
+
+第 20 章看的是正式環境：發生過什麼事都有紀錄，但做得好不好，它答不出來。這一章回答的是另一個問題：這次改動有沒有讓 agent 變好。
+
+如果只有一次 model 呼叫，這題很簡單：丟一段 prompt 進去，把回答跟標準答案比一比，算對幾題就好。
+
+換成 agent，這套就整個不管用了。它要跑好幾輪。任務沒講的資訊，它得自己開口問使用者。它呼叫的 tool 會改到系統裡存著的資料。
+同一個結果，走不同的路都到得了。而且同一份 build（同一版 agent，harness、prompt、model 都沒換）跑同一個任務，跑兩次結果還可能不一樣。
+
+所以要幫 agent 打分，需要的是一個測試環境，不是一串 prompt：可以 reset 的 state、一個模擬使用者、一套推著對話往下走的 protocol，
+還有一份 rubric，用來看這趟跑完以後，環境被改成什麼樣子。
+
+少了這些，數字照樣跑得出來，只是不代表什麼。可能題目早就流進訓練資料，agent 是背過答案才答對的。
+可能新版本比舊版高 3 個百分點，看起來有進步，其實只是題目抽樣的隨機波動。
+也可能分數很漂亮的那份 build，實際上把客人根本沒提過的訂單也退掉了。
+
+---
+
+## 機制
+
+```mermaid
+flowchart LR
+    D["Dataset · 任務紀錄"] --> RS["reset"]
+    RS --> U["模擬使用者"]
+    U -->|一次只給一項資訊| A["受測的 agent"]
+    A -->|回話| U
+    A -->|tool 呼叫| S["環境 state"]
+    S -->|觀察結果| A
+    S --> G["打分 · state 檢查、<br/>該講的話、否決項"]
+    G --> M["指標 · Pass@k、Pass^k、<br/>噪音帶"]
+    M -->|一次只改一件事| A
+```
+
+一個評估環境有五個部分，四個是資料，一個是流程。
+
+- **Dataset**：一筆一筆的任務紀錄。每一筆都寫著起始 state、使用者想要什麼，以及這趟要怎麼檢查。
+- **Environment state**：任務會動到的那份資料，例如訂單、檔案、資料庫。
+  它要夠真實，測起來才有意義；也要抓得住，隨時能 reset 回原樣。
+- **Tools**：agent 可以執行的操作。要拆到夠小（讀一筆訂單、退一筆訂單），不要弄成一個叫「解決客訴」的 tool。
+- **Rubric**：一趟跑完以後，怎麼換算成分數。
+- **Interaction protocol**：誰什麼時候說話，以及這一趟什麼時候結束。
+
+第 20 章的評估吃的是 `(input, grade)`：進去一個字串，出來一個字串，得到一個 pass rate。這一章保留同一個入口，只是在這個入口下面補上一個環境。
+
+### 新增：環境和它的 reset
+
+state 存在環境裡，要改它只能透過環境給的 tool：
+
+```python
+def reset(self):                                       # src/evaluation.py
+    self.state = deepcopy(self.initial)                # a fresh copy per episode
+    self.calls = []
+
+def call(self, name, **args):
+    tool = self.tools.get(name)
+    if tool is None:
+        self.calls.append((name, False))               # illegal: no such tool
+        return f"error: no tool named {name}"
+    try:
+        out = tool(self.state, **args)
+    except Exception as e:                             # illegal: wrong arguments
+        self.calls.append((name, False))
+        return f"error: {type(e).__name__}: {e}"
+    self.calls.append((name, True))
+    return str(out)
+```
+
+- 每個 episode 開始前，`reset` 會把起始資料整份複製一份新的出來，agent 動到的是這份副本。
+  所以下一趟拿到的還是原本那份資料，上一趟寫過什麼都看不到。
+  少了這一步，退款任務跑第二次時，那筆訂單已經是退過的狀態。
+- agent 叫了不存在的 tool，或參數給錯，環境會回一句話講清楚錯在哪，而不是只回一個「失敗」。
+  看得懂錯在哪，agent 才可能自己改對；改不改得回來，本來就是要測的能力。
+- 每次呼叫都會記下這次合不合法。這份紀錄就是過程指標的來源：叫錯幾次、總共走了幾步。就算最後結果檢查過了，這些數字還在。
+
+### 新增：模擬使用者與 protocol
+
+大部分 benchmark 第一則訊息就把完整需求交給 agent。真實的使用者不會這樣講話。
+他們開頭只會說「我的訂單好像有問題」，剩下的你不問，他不會講。
+
+所以模擬使用者手上有一份腳本，一輪只講一件事。這樣一來，agent 會不會主動問，才變成可以打分的能力：
+
+```python
+def run_episode(env, task, agent, max_turns=8):        # src/evaluation.py
+    env.reset()
+    user = task["user"]()                              # a fresh simulated user per episode
+    transcript, said = [], user()
+    for _ in range(max_turns):                         # the ceiling: an episode always terminates
+        if said is None:
+            break
+        reply = agent(said, env)
+        transcript.append((said, reply))
+        said = user(reply)
+    return {"transcript": transcript, "state": env.state, "calls": list(env.calls)}
+```
+
+可執行程式用的是固定腳本，離線檢查才會每次都一樣。實際跑的時候，是找一個 LLM 拿同一份腳本來演使用者。
+prompt 裡會交代它：照角色回話、只講這一步需要講的、腳本裡沒有的不准自己編。每次講法都不一樣，但資訊釋出的順序不會變。
+
+再做完整一點，就是讓模擬使用者對同一份 state 也有自己的 tool。有些事只有使用者做得到，agent 只能說服他動手，真實的客服電話本來就是這樣。
+這時候環境不再只有 agent 在改：使用者也會動它，agent 得自己發現對方做了什麼，不能假設現在的 state 都是自己造成的。
+
+### 新增：一趟 episode 怎麼打分
+
+三種檢查，照順序：
+
+```python
+def grade(task, run):                                  # src/evaluation.py
+    checks = {name: bool(fn(run["state"])) for name, fn in task["checks"]}       # the outcome
+    said = " ".join(reply for _, reply in run["transcript"]).lower()
+    told = {s: s.lower() in said for s in task.get("must_say", [])}              # what was communicated
+    unsafe = [name for name, fn in task.get("veto", []) if fn(run)]              # zero tolerance
+    return {"passed": all(checks.values()) and all(told.values()) and not unsafe, ...}
+```
+
+- **看終態，不看路徑**：檢查讀的是最後的 state，只要走到那個狀態，中間怎麼走都算過。標準解只是其中一種解法，不是規定要走的那一條。
+- **該講的話**：錢退了，卻沒告訴客人退了多少，這趟不算做完。
+  只看 state 的話，這種漏講會算成通過；只看對話的話，agent 說「已經幫您退款」但其實沒退，也會算成通過。兩邊都要查。
+- **否決項**：只要踩到一次安全問題，這趟就是不過，其他項目再漂亮也救不回來：退了客人沒提過的訂單、把金鑰印出來、把信寄給不相干的人。
+
+### 指標：跑 k 次是為了什麼
+
+跑一次只能得到一個判定。同一個任務跑好幾次，才問得出真正想知道的事：
+
+- **Pass@k**：k 次裡至少成功一次。回答的是「做不做得到」，探索型任務看這個。
+- **Pass^k**：k 次全部成功。回答的是「穩不穩」，回歸測試的門檻看這個。
+- **Best@k**：k 次裡最好的那次拿幾分。用在開放式任務：分數是連續的，不是只有過跟不過。
+
+這兩個數字很快就會拉開。單次成功率 60% 的話，Pass@5 大約 99%，Pass^5 大約 8%。
+指標挑錯，明明只是運氣好，看起來卻像真的做出了什麼。
+
+另外還有一組過程指標，呼叫紀錄裡本來就有：合法呼叫的比例、跟已知的好解法比起來多走了幾步、重試幾次、每個任務花多少錢。
+它們回答的是另一件事：這次過關，是省著過的，還是硬撞過的。
+
+### 開放式輸出怎麼評
+
+有明確終態的任務，看 state 就夠了。換成一段寫出來的文字，沒有東西可以直接比對，就交給另一個 model 照 rubric 打分。
+打分準不準，幾乎都看 rubric 怎麼寫：
+
+1. **由專家寫**：寫進去的是這個領域真正要檢查的東西，不是文字通不通順。
+2. **涵蓋要夠全**：正確性、完整性、安全性都要顧到，常犯的錯要直接寫出來，不能讓評判者自己意會。
+3. **有權重、有否決**：標準分成必要、重要、可選，像編造事實這種否決項一出現，總分直接歸零。
+4. **每條都自己講得清楚**：每一項都要能直接判斷，不靠評判者自己的品味。
+   「至少引用兩份出處，並說明各自怎麼支撐結論」可以判斷，「展現了深刻的理解」不行。
+
+評判者本身就是 model，model 有的毛病它都有：回答越長越容易拿高分，先讀到的那一份也容易被偏袒。
+評判者跟 agent 同一個家族的話，盲點也一樣，agent 犯的錯它剛好都會放過。
+
+解法都不難：評判者換成不同家族的 model；配對比較時把順序對調，再評一次；
+大規模用之前，先拿人工標好的 gold set 校準；兩邊判不一樣的，就送人工看。
+
+### dataset 決定分數代表什麼
+
+環境做得再好，dataset 不行，跑出來的就是噪音。各家 benchmark 反覆驗證出四條原則。
+
+- **可驗證**：答案或終態不用人看就能判定。
+- **分難度**：簡單、中等、困難的任務要分開，這樣「只在簡單題上有用」的改動就藏不進平均分裡。
+- **人工看過**：要有人確認這題解得開、檢查方式也公平。
+  有些 benchmark 之所以會出一個專門的子集，就是因為原本的題目講不清楚，或是用了不公平的測試在打分。
+- **防汙染**：公開的任務會流進下一輪訓練資料。
+  常見的做法有：每個任務檔案裡放 canary 字串、答案不公開、收集模型 cutoff 之後才出現的任務，以及用參數化模板從同一個題型生出新題。
+
+### 差距要怎麼讀
+
+兩份 build，100 個任務，70% 對 73%。這不算結果。
+
+- **噪音帶**：n 個任務上的成功率，標準誤差大約是 `p(1-p)/n` 開根號。
+  100 個任務、70% 的話大約 4.6 個百分點，所以 3 個百分點的差距整個埋在噪音裡。
+- **多跑幾次**：採樣本身有隨機性，tool 回應的快慢也會影響結果，分數自然會浮動。每個設定跑三到五次，平均和波動範圍一起報。
+- **配對比較**：兩份 build 跑的是同一批任務，所以逐題比，只看兩邊結果不一樣的那幾題。
+  這樣就把題目難易的影響扣掉了，需要的題數也比直接比較兩個成功率來得少。
+- **算一下你同時驗了幾個假設**：六個改動都用 95% 信心水準，其中至少一個純靠運氣看起來顯著的機率大約是 26%。
+  要嘛把門檻收緊，要嘛把跑贏的那個獨立複跑一次，再決定信不信。
+
+如果你預期的提升，比這套評估分辨得出來的差距還小，那接下來該做的是把任務集擴大，不是繼續調 agent。
+
+### 從報告到一次改動
+
+benchmark 報告只拿來做一個決定：下一步要改什麼。
+
+1. **先懷疑評估本身**：process 被殺掉、grader 有 bug、任務跟正式環境早就對不上，這些在數字上跟 agent 變差長得一模一樣。
+   動 agent 之前，先把失敗的 trajectory 讀過一遍。
+2. **找失敗聚在哪**：總成功率 88%，但四個相關任務裡掛了三個，這不是整體能力不足，是缺了某一項能力。
+3. **一輪只改一個變數**：model、seed、任務集、步數上限都固定住，每一輪只動一件事。一輪改三件事，什麼都解釋不了。
+4. **分清楚是誰的功勞**：harness 不動，只換 model，看 model 撐起多少；model 不動，關掉 harness 的某個元件，看那個元件值多少。
+   這個 repo 的主張就是：這兩個數字都存在。
+5. **證據的規模要配得上決定**：四個任務可以支撐「值得跑大一點的實驗」，撐不起「可以上線」。
+
+放進產品裡，這些會變成常駐的基礎設施。一個總開關可以關掉各種功能，量出裸 model 的 baseline。
+Feature flag 負責分 AB 測試的組別，出事時也是斷路開關。
+每個 commit 都存一份完整展開後的 system prompt，改 prompt 就跟改程式碼一樣，要跑一次評估。
+
+做 AB 測試時，要把你直接動到的機制指標（計畫長度、prompt 大小）和你真正在乎的目標指標（任務成功率、單次會話成本）分開。
+另外留一組護欄指標：就算目標指標變好，護欄一破也要停下實驗。
+
+### 如何整合
+
+評估沿用既有的 harness，沒有另外加東西：
+
+- 環境的 tool 介面就是第 2 章的 registry，只是 handler 指向評估用的 state，不是真實世界。
+- 受測的 agent 就是第 1 章的 loop，一行都沒改。loop 裡沒有任何東西知道自己正在被評估。
+- 評判者就是第 21 章的 checker：另一個 agent、全新的 context、一份它只能滿足、不能改寫的 rubric。
+- 第 20 章負責供料：正式環境的 trace 脫敏之後變成新任務，它的 cost tracker 給出每個任務花多少錢。
+- 改進 loop 就是第 21 章的外層 loop，只是這次帶著證據：量一次、只改一件事、再量一次。
+
+---
+
+## 各系統做法
+
+各個系統怎麼搭出分數背後的測試環境。
+
+| | Claude Code | mini-swe-agent | τ²-bench | Verifiers |
+| --- | --- | --- | --- | --- |
+| **Pros** | 爛結果在交出去之前就被擋掉。 | 跑 benchmark 的程式跟 agent 一起附在 repo 裡。 | 看終態打分，走哪條路都算過。 | 環境、harness、model 分開設定，同一套任務集誰都能評。 |
+| **Cons** | 原始碼裡沒有成套的評估。 | 只有 benchmark 的測試當 rubric。 | 使用者由另一個 model 扮演，那個 model 換了分數就飄。 | 為訓練迴圈設計，跑一次性的評估也要先架好整套 runtime。 |
+| **Why** | 該擋的檢查要在改動落地之前跑。 | 一個任務就是一個有測試的 repo bug。 | 客服工作本來就是一段對話。 | 評估和後訓練要的是同一個環境。 |
+| **How: environment** | 重建：每次評估開一份用完就丟的工作區。 | 一個 instance 一個 container，換一個就是 reset。 | 一個領域資料庫加一份政策文件。 | 每次執行都給一個全新的沙箱 runtime。 |
+| **How: task set** | 重建：正式環境的 trace 脫敏後留成固定題庫。 | 公開 benchmark 的一個 split。 | 每個領域各自手寫。 | 用 id 載入的模組，本機或線上都行。 |
+| **How: scoring** | 一個 reviewer agent 加一份固定 rubric。 | 該過的測試要過，本來會過的不能壞。 | 終態拿去跟標準解重放的結果比對。 | task 上的 reward 函式，加一個會跑程式碼的 judge。 |
+| **How: repeats** | 同一趟執行裡重跑驗證。 | 一個 instance 跑一次。 | 同一題跑 k 次，看的是穩定度。 | 每題跑幾次 rollout 是個參數。 |
+
+---
+
+## 哪裡會出錯
+
+- **只看對話，不看實際結果（Grading the transcript）**：agent 說「已退款」，跟真的退了款拿到一樣的分數。
+  緩解：檢查終態，另外再檢查該講的話有沒有講。
+- **任務被汙染（Contaminated tasks）**：公開 benchmark 會進到下一輪訓練資料，高分可能只是背過。
+  緩解：任務檔案裡放 canary 字串、答案不公開、收集 cutoff 之後才出現的任務，以及用參數化模板生新題。
+- **把噪音當結果（Reading noise as a result）**：100 個任務各跑一次，差 3 個百分點，什麼都決定不了。
+  緩解：多跑幾次、逐題配對比較、差距落在噪音帶裡就當它不存在，同時驗很多改動時把門檻收緊。
+- **評估壞了卻怪 agent（Blaming the agent）**：機器資源不夠、grader 有 bug、任務過期，看起來都跟 agent 變差一模一樣。
+  緩解：改 agent 之前，先讀失敗的 trajectory。
+- **評判者跟 agent 有同樣的盲點（Shared blind spots）**：同家族的 judge 會放過 agent 常犯的錯，偏好長回答，也偏好先讀到的候選。
+  緩解：換不同家族的 judge、順序對調各評一次、先用人工標註的 gold set 校準。
+- **鑽分數的漏洞（Reward hacking）**：agent 找到拿分的捷徑，跳過真正的工作：塞關鍵字、討好 judge、遇到難題就迴避。
+  緩解：rubric 裡放否決項、結果指標旁邊擺過程指標，再定期人工抽檢。
+- **這套評估看不出改動（A suite that cannot see the change）**：40 個任務上 2 個百分點的提升根本量不出來，每一輪都只能寫「看不出差別」。
+  緩解：先把任務集擴大，再繼續迭代。
+- **上一趟的 state 留到下一趟（State leaking between runs）**：沒有 reset，或只 reset 了淺的一層，上一個任務寫下的東西就決定了下一題的分數。
+  緩解：每個 episode 深拷貝一份，每次執行各用一個獨立的環境（第 15 章）。
+
+---
+
+## 可執行程式
+
+[`src/`](src/) 把 22 帶了過來，並加上：
+
+- [`evaluation.py`](src/evaluation.py)：帶 `reset` 和呼叫紀錄的環境、一輪只釋出一項資訊的模擬使用者、episode 的 protocol、
+  打分（state 檢查、該講的話、否決項）、Pass@k 與 Pass^k、二項分布的噪音帶，以及兩份 build 的配對比較。
+- [`test.py`](src/test.py)：離線檢查 reset 有沒有把 state 還原、protocol 跑一趟時 agent 必須先問訂單編號、
+  結果檢查明明有過卻被否決項擋下、同一個不穩定的 build 上 Pass@k 與 Pass^k 的差別，
+  以及退步的 build 分數更低、配對比較能指出它弄壞了哪幾題。
+- [`demo.py`](src/demo.py)：實際跑一趟並打分。
+  model 扮演客服 agent，它呼叫的 tool 都打在環境上，最後 harness 看它留下的 state 給分。
+
+loop 本身完全沒改。讓分數有意義的，是它跑在什麼環境裡。
+
+```bash
+python sections/23-evaluation/src/test.py         # offline checks, no key
+uv run python sections/23-evaluation/src/demo.py  # live demo, needs a key
+```
+
+---
+
+## 出處
+
+- [ai-agent-book · 第 6 章](https://github.com/bojieli/ai-agent-book/blob/main/book/chapter6.md)（《深入理解 AI Agent》，李博杰，以中文原版為準）：
+  評估環境的五個要素、漸進式資訊揭露、指標詞典、rubric 四準則、統計顯著性、
+  從 benchmark 報告到系統改進，以及內部評估基礎設施。
+- [τ-bench](https://arxiv.org/abs/2406.12045)（Sierra）：用另一個語言模型扮演使用者；
+  成不成功，是拿對話結束時的資料庫狀態跟標註好的目標狀態比對，另外還有衡量可靠度的 Pass^k。
+- [τ²-bench](https://arxiv.org/abs/2506.07982) 和[它的原始碼](https://github.com/sierra-research/tau2-bench)：雙控環境，
+  模擬使用者自己也有 tool；以及 reward basis（資料庫終態雜湊後跟標準解重放的結果比對、必須講到的字串、
+  可選的 LLM 判定條件），各項相乘才是總分。
+- [Verifiers](https://github.com/willccbb/verifiers)：環境負責安排多個 agent 之間的流程、用 id 載入任務集、
+  每題可以跑多次 rollout、續跑時只補跑漏掉或出錯的那些，以及能對執行產物跑程式碼的 judge agent。
+- [mini-swe-agent 原始碼](https://github.com/swe-agent/mini-swe-agent)：`run/benchmarks/swebench.py`，
+  一個 instance 一個 container image，每個 instance 各自留下 trajectory 與預測紀錄。
+- [SWE-bench Verified](https://huggingface.co/datasets/princeton-nlp/SWE-bench_Verified)：500 題人工驗證過的 instance，
+  打分方式是原本失敗的測試要變成通過，本來就會過的測試不能壞。
+- [GAIA](https://arxiv.org/abs/2311.12983)：466 題，其中 300 題的答案不公開，排行榜就抓不走。
+- [BIG-bench](https://github.com/google/BIG-bench)：每個任務檔案都帶 canary 字串，避免題目被爬進訓練資料。
+- [Rubrics as Rewards](https://arxiv.org/abs/2507.17746)（Scale AI）：清單式的 rubric，寫明要提到哪些事實、
+  要有哪些推理步驟，以及哪些常見錯誤必須扣分。
+- [Claude Code](https://code.claude.com/docs)：workflow 約定裡的 reviewer 與 judge 階段。
+  內容依據 tool schema 和文件記載的行為，不是 source backup。評估套件不在原始碼裡，那幾格都標成重建。

--- a/sections/23-evaluation/src/autonomy.py
+++ b/sections/23-evaluation/src/autonomy.py
@@ -1,0 +1,108 @@
+"""Autonomy (section 18): an outer loop around the agent loop (section 1) so a
+teammate keeps working with no human prompt. Introduced in section 18, extending
+section 17's run_teammate with the task board.
+
+The inner loop is the normal run_turn (section 1). When it ends, the agent does
+not return; it idles and polls three sources in priority order:
+
+  1. A shutdown request (section 17): confirm it and stop. Checked first, so a
+     flood of peer chatter cannot starve a stop.
+  2. An inbox message (section 16): lead before peers, folded into one prompt.
+  3. The task board (section 12): claim the first pending, unowned, unblocked
+     task. The claim is lock-serialized in TaskStore, so two idle agents cannot
+     both win the same task; this only proposes a candidate to try.
+
+Whatever the poll finds becomes the next prompt and the inner loop runs again.
+The loop and the subagent path do not change; autonomy only wraps them.
+
+ponytail: max_idle_polls bounds the idle wait so the demo and test terminate; a
+real teammate polls until shutdown or abort, with no upper bound.
+"""
+from __future__ import annotations
+
+import time
+
+from mailbox import _fold
+from protocols import Protocol
+
+POLL_INTERVAL = 0.05    # seconds between idle polls; short so demo/test do not wait
+
+
+def claim_next(store, me):
+    """Scan the board oldest-first and claim the first pending, unowned task.
+    Returns the claimed task or None. TaskStore.claim (section 12) rejects a
+    blocked task and is lock-serialized, so a claim race has exactly one winner."""
+    for t in store.list():
+        if t["status"] == "pending" and t["owner"] is None:
+            got = store.claim(t["id"], me)
+            if got["ok"]:
+                return got["task"]
+            # not ok: another agent won it or it just became blocked, so try the next
+    return None
+
+
+def _is(msg, type_):
+    content = msg["content"]
+    return isinstance(content, dict) and content.get("type") == type_
+
+
+def next_action(proto, team, store, me):
+    """One idle poll. Drain the inbox once, then pick the next thing to do in
+    priority order: a shutdown request (confirm and stop), a peer/lead message,
+    or a claimed task. Returns (kind, payload), or None when there is nothing to
+    do. Shutdown is checked before chat so peer traffic cannot starve a stop."""
+    inbox = team.drain(me)
+    shutdown = next((m for m in inbox if _is(m, "shutdown_request")), None)
+    if shutdown is not None:
+        proto.reply(shutdown, "shutdown_approved")     # inner loop already flushed at end_turn
+        return ("shutdown", shutdown["content"].get("reason"))
+    chat = [m for m in inbox if isinstance(m["content"], str)]
+    if chat:
+        chat.sort(key=lambda m: m["from"] != "lead")   # lead before peers; sort is stable
+        return ("message", _fold(chat))
+    task = claim_next(store, me)
+    if task is not None:
+        return ("task", task)
+    return None                                         # idle: caller sleeps and polls again
+
+
+def task_prompt(task):
+    """Turn a claimed task into the next user prompt for the inner loop."""
+    return (f"You claimed task {task['id']}: {task['subject']}. "
+            f"Do it, then call TaskUpdate to mark it completed.")
+
+
+def run_teammate(team, store, me, lead, work, *, max_idle_polls=None):
+    """Section 17's run_teammate (protocols.py) idles on an empty inbox; this adds
+    the task board, so an idle teammate claims a task instead of just waiting. Run
+    the inner agent loop on a prompt, then idle-poll for the next thing to do.
+    `work(prompt, task)` runs one inner loop (section 1) to end_turn on the claimed
+    task (None on a message-driven turn). Two stop modes,
+    both the worker's own decision at end_turn. max_idle_polls=None: idle until a
+    shutdown handshake lands (a long-lived worker on a dynamic board, kept warm
+    for the coordinator to end it; section 17). A small int: stop after that many
+    empty polls (a worker on a known, finite board decides the work is gone and
+    winds itself down). Returns 'shutdown' or 'drained'."""
+    proto = Protocol(team, me)
+    prompt = claimed = None
+    idle = 0
+    while True:
+        if prompt is not None:
+            work(prompt, claimed)                       # inner loop (section 1), runs to end_turn
+            prompt = claimed = None
+            team.send(me, lead, {"type": "idle", "reason": "available"})   # sendIdleNotification
+        action = next_action(proto, team, store, me)
+        if action is None:                              # nothing to do this pass
+            idle += 1
+            if max_idle_polls is not None and idle >= max_idle_polls:
+                return "drained"                        # only a lead-less single worker hits this
+            time.sleep(POLL_INTERVAL)
+            continue
+        idle = 0
+        kind, payload = action
+        if kind == "shutdown":
+            return "shutdown"
+        if kind == "task":
+            prompt, claimed = task_prompt(payload), payload
+        else:                                           # message: no task to thread through
+            prompt = payload

--- a/sections/23-evaluation/src/background.py
+++ b/sections/23-evaluation/src/background.py
@@ -1,0 +1,91 @@
+"""Background execution (section 13): start slow work off the loop, return a
+handle now, deliver the result later through a notification queue.
+
+Introduced in section 13, then carried forward unchanged.
+
+Runtime.start() runs any thunk on a worker thread and returns at once with a
+task id (the tool's placeholder tool_result, section 1). On completion the
+worker enqueues a <task_notification>; drain_into() pulls those notes on a later
+turn and prepends them to the next user message. One tool_use still gets exactly
+one tool_result, the completion is a separate event.
+
+Backgrounding is a property of execution, not of one tool: backgroundable()
+wraps ANY tool so the model can run it off-loop with run_in_background. A shell
+command, a subagent (section 6), a build, or a memory-consolidation pass all
+take the same path. Mirrors Claude Code's task framework backing LocalShellTask,
+DreamTask, and friends through one messageQueueManager drain.
+"""
+from __future__ import annotations
+
+import queue
+import threading
+from dataclasses import replace
+
+from tools import Tool
+
+
+class Runtime:
+    """Tracks background tasks and queues their completion notifications."""
+
+    def __init__(self):
+        self._next = 0
+        self._state: dict[int, str] = {}        # task id -> running | completed | failed
+        self._notes: queue.Queue = queue.Queue()
+
+    def start(self, fn):
+        """Run any thunk on a worker thread; return a task id immediately (never blocks)."""
+        self._next += 1
+        tid = self._next
+        self._state[tid] = "running"
+
+        def work():
+            try:
+                self._finish(tid, "completed", str(fn()))
+            except Exception as e:              # a failed background task still reports back
+                self._finish(tid, "failed", f"{type(e).__name__}: {e}")
+
+        threading.Thread(target=work, daemon=True).start()
+        return tid
+
+    def state(self, tid):
+        return self._state.get(tid)
+
+    def drain(self):
+        """Every completion notification enqueued so far, oldest first; empties the queue."""
+        out = []
+        while True:
+            try:
+                out.append(self._notes.get_nowait())
+            except queue.Empty:
+                return out
+
+    def _finish(self, tid, status, output):
+        self._state[tid] = status
+        self._notes.put(f"<task_notification>task {tid} {status}: {output}</task_notification>")
+
+
+def drain_into(messages, runtime):
+    """Prepend any completed-task notifications to the latest user message, so a
+    background result surfaces on the next turn (Claude Code's queue drain)."""
+    notes = runtime.drain() if runtime else []
+    if notes and messages and isinstance(messages[-1].get("content"), str):
+        messages[-1]["content"] = "\n".join(notes) + "\n\n" + messages[-1]["content"]
+    return messages
+
+
+def backgroundable(tool: Tool, runtime: Runtime) -> Tool:
+    """Wrap any tool so the model can run it off-loop with run_in_background.
+    A shell command, a subagent (section 6), a build, or a long compute task all
+    take the same path: start the thunk, return a handle, notify on completion."""
+    def run(a):
+        if a.get("run_in_background"):
+            inner = {k: v for k, v in a.items() if k != "run_in_background"}
+            tid = runtime.start(lambda: tool.run(inner))
+            return f"started background task {tid} ({tool.name}); its result arrives in a later message"
+        return tool.run(a)
+
+    schema = {**tool.input_schema,
+              "properties": {**tool.input_schema.get("properties", {}),
+                             "run_in_background": {"type": "boolean"}}}
+    return replace(tool, run=run, input_schema=schema,                  # keeps is_read_only etc.
+                   description=tool.description + " Set run_in_background for slow work.")

--- a/sections/23-evaluation/src/context.py
+++ b/sections/23-evaluation/src/context.py
@@ -1,0 +1,87 @@
+"""Context management (section 8): keep messages[] under the window.
+
+Introduced in section 8, then carried forward unchanged.
+
+messages[] only grows (section 1), so every turn runs cheap, near-lossless
+passes first and the expensive lossy summary only as a last resort. Order
+matters: budget (persist huge results) before micro (stub old result bodies),
+summary last. In the Anthropic format a tool result is a block inside a user
+message, so the passes walk those blocks. Mirrors Claude Code's per-turn
+budget -> micro -> auto sequence in query.ts.
+"""
+from __future__ import annotations
+
+TOKEN_LIMIT = 1500       # tiny so the demo trips it; real Claude Code uses the model's window
+MAX_RESULT_CHARS = 400   # a single tool result over this is persisted to a preview stub
+KEEP_RECENT = 4          # tail messages always kept verbatim
+PREVIEW_CHARS = 60
+
+
+def manage(messages, summarizer=None):
+    """Run the cheap passes every turn; summarize only if still over the limit."""
+    _budget(messages)                                        # persist huge results   (lossless)
+    _micro(messages, KEEP_RECENT)                            # stub old result bodies (cheap)
+    if summarizer and estimate_tokens(messages) > TOKEN_LIMIT:
+        return _auto(messages, KEEP_RECENT, summarizer)      # summarize history (lossy, last resort)
+    return messages
+
+
+def _tool_results(message):
+    """The tool_result blocks in a user message, or [] if it has none."""
+    content = message.get("content")
+    if message.get("role") == "user" and isinstance(content, list):
+        return [b for b in content if isinstance(b, dict) and b.get("type") == "tool_result"]
+    return []
+
+
+def _budget(messages):
+    """A tool result over the cap is persisted; only a preview stays in context."""
+    for m in messages:
+        for block in _tool_results(m):
+            c = block.get("content")
+            if isinstance(c, str) and len(c) > MAX_RESULT_CHARS:
+                block["content"] = c[:PREVIEW_CHARS] + " ...<persisted-output>"   # full text on disk in real CC
+
+
+def _micro(messages, keep_recent):
+    """Old tool-result bodies become a stub; the model can re-read if it needs them."""
+    for m in messages[:len(messages) - keep_recent]:
+        for block in _tool_results(m):
+            if block.get("content") != "<elided>":
+                block["content"] = "<elided>"
+
+
+def _auto(messages, keep_recent, summarizer):
+    """Replace the middle with one summary; keep the first turn and recent tail.
+
+    ponytail: drops the middle and keeps head + tail, nudging the cut forward so
+    it never starts on an orphaned tool_result (which must keep its tool_use turn).
+    """
+    if len(messages) <= keep_recent + 1:
+        return messages
+
+    cut = len(messages) - keep_recent
+    while cut < len(messages) and _tool_results(messages[cut]):
+        cut += 1
+    if cut >= len(messages):
+        return messages
+
+    summary = {"role": "user",
+               "content": f"[summary of {cut} earlier messages] {summarizer(messages)}"}
+    return messages[:1] + [summary] + messages[cut:]
+
+
+def estimate_tokens(messages) -> int:
+    return sum(_content_len(m.get("content")) for m in messages) // 4   # ~4 chars per token
+
+
+def _content_len(content) -> int:
+    if isinstance(content, str):
+        return len(content)
+    total = 0
+    for block in content or []:
+        if isinstance(block, dict):
+            total += len(str(block.get("content", "")))
+        else:                                   # SDK block object (text / tool_use)
+            total += len(getattr(block, "text", "") or "")
+    return total

--- a/sections/23-evaluation/src/demo.py
+++ b/sections/23-evaluation/src/demo.py
@@ -1,0 +1,103 @@
+"""Section 23 demo: one graded episode inside an evaluation environment.
+
+The environment holds the orders and the balance, and its two tools are the
+only way to change them. A simulated user opens with a vague complaint and
+releases the order number only when the agent asks, so the model has to run
+the conversation, not read the task off the first message.
+
+run_turn is unchanged (section 1): the model plays the agent, its tool calls
+land in the environment, and the harness grades the final state, what the
+agent said, and how many calls it took. Repeats, Pass^k, and the paired
+comparison of two builds are offline checks in test.py.
+
+    uv run python sections/23-evaluation/src/demo.py   (needs ANTHROPIC_API_KEY; see root README)
+"""
+import os
+
+from anthropic import Anthropic
+from dotenv import load_dotenv
+
+from evaluation import Env, grade, run_episode, scripted_user
+from loop import Session, run_turn
+from permissions import DEFAULT
+from tools import Registry, Tool
+
+load_dotenv(override=True)
+
+MODEL = os.environ.get("ANTHROPIC_MODEL", "claude-sonnet-4-6")
+
+SYSTEM = ("You are a support agent for an online store. Read an order before you refund it. "
+          "Never refund an order the customer did not name. Always tell the customer the refunded amount. "
+          "Keep replies to one or two sentences.")
+
+ORDERS = {"A17": {"status": "delivered", "total": "40.00"},
+          "B92": {"status": "shipped", "total": "12.50"}}
+
+ID_SCHEMA = {"type": "object", "properties": {"order_id": {"type": "string"}}, "required": ["order_id"]}
+
+
+def get_order(state, order_id):
+    o = state["orders"][order_id]
+    return f"{order_id} {o['status']} {o['total']}"
+
+
+def refund(state, order_id):
+    o = state["orders"][order_id]
+    o["status"] = "refunded"
+    state["balance"] = round(state["balance"] + float(o["total"]), 2)
+    return o["total"]
+
+
+TASK = {                                               # one dataset record: script plus rubric
+    "id": "refund-A17",
+    "user": scripted_user(["I want a refund for something I bought.",
+                           "It is order A17.", "Thanks, that is all."]),
+    "checks": [("refunded", lambda s: s["orders"]["A17"]["status"] == "refunded"),
+               ("credited", lambda s: s["balance"] == 40.0)],
+    "must_say": ["40.00"],
+    "veto": [("refunded an order the customer never named",
+              lambda r: r["state"]["orders"]["B92"]["status"] == "refunded")],
+}
+
+
+def demo():
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        print("23 evaluation: set ANTHROPIC_API_KEY to run the live demo (offline checks: test.py)")
+        return
+
+    client = Anthropic(base_url=os.environ.get("ANTHROPIC_BASE_URL") or None)
+
+    def model(messages, registry, system):
+        kwargs = {"system": system} if system else {}
+        return client.messages.create(model=MODEL, messages=messages,
+                                      tools=registry.schemas(), max_tokens=512, **kwargs)
+
+    env = Env(initial={"orders": ORDERS, "balance": 0.0},
+              tools={"get_order": get_order, "refund": refund})
+
+    reg = Registry()                                   # the tool interface: the only way into the state
+    reg.register(Tool(name="get_order", run=lambda a: env.call("get_order", **a),
+                      description="Read one order: status and total.",
+                      input_schema=ID_SCHEMA, is_read_only=True))
+    reg.register(Tool(name="refund", run=lambda a: env.call("refund", **a),
+                      description="Refund one order to the customer's balance.", input_schema=ID_SCHEMA))
+
+    messages = []                                      # the agent's conversation, one per episode
+
+    def agent(said, _env):
+        messages.append({"role": "user", "content": said})
+        return run_turn(messages, model, reg, Session(mode=DEFAULT), prompt=lambda r, s: SYSTEM)
+
+    run = run_episode(env, TASK, agent)                # reset, then user turn and agent turn until done
+    v = grade(TASK, run)
+
+    for said, reply in run["transcript"]:
+        print(f"23 evaluation: user  | {said}")
+        print(f"23 evaluation: agent | {reply.strip()}")
+    print("23 evaluation: state checks:", v["checks"], "· told:", v["told"])
+    print("23 evaluation: steps:", v["steps"], "· illegal calls:", v["illegal_calls"], "· vetoed:", v["unsafe"])
+    print("23 evaluation:", "PASS" if v["passed"] else "FAIL")
+
+
+if __name__ == "__main__":
+    demo()

--- a/sections/23-evaluation/src/evaluation.py
+++ b/sections/23-evaluation/src/evaluation.py
@@ -1,0 +1,141 @@
+"""Evaluation (section 23): the environment a score comes from.
+
+Section 20's run_eval takes (input, grade) pairs: one string in, one string
+out, one pass rate. An agent that asks the user a question and then changes
+stored data cannot be graded that way. This module builds the test bed it
+needs, the five elements of an evaluation environment:
+
+  dataset   the task records passed to run_suite
+  state     Env.state, the mutable data a task starts from and ends in
+  tools     Env.tools, the operations the agent is allowed to run
+  rubric    the checks, communication strings, and vetoes in grade()
+  protocol  run_episode, which alternates user turn and agent turn
+
+reset() puts the state back before every episode, so no run inherits the last
+run's writes. The simulated user releases one fact per turn, so the agent has
+to ask instead of reading the whole task off the first message.
+
+grade() reads the final state (the outcome), not the transcript, plus process
+metrics (illegal calls, steps) and a zero-tolerance veto. Repeats split one
+verdict into Pass@k (can it) and Pass^k (does it every time), and the binomial
+standard error gives the band under which a gap between two builds is noise.
+
+Mirrors the five elements and the metric dictionary from the book chapter 6,
+plus tau-bench's simulated user and end-state comparison: any trajectory that
+reaches the target state passes.
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass, field
+from math import sqrt
+
+
+@dataclass
+class Env:
+    """A resettable test bed: state plus the tools that change it."""
+    initial: dict                                     # the snapshot every episode starts from
+    tools: dict                                       # name -> fn(state, **args) -> str
+    state: dict = field(default_factory=dict)
+    calls: list = field(default_factory=list)         # (name, legal) per call, for process metrics
+
+    def reset(self) -> None:
+        """Put the state back. A deep copy, so one episode never sees the last one's writes."""
+        self.state = deepcopy(self.initial)
+        self.calls = []
+
+    def call(self, name: str, **args) -> str:
+        """Run one tool against the state. A rejected call is a message, not a crash."""
+        tool = self.tools.get(name)
+        if tool is None:
+            self.calls.append((name, False))          # illegal: a tool that does not exist
+            return f"error: no tool named {name}"
+        try:
+            out = tool(self.state, **args)
+        except Exception as e:                        # illegal: wrong arguments. Say why, then continue
+            self.calls.append((name, False))
+            return f"error: {type(e).__name__}: {e}"
+        self.calls.append((name, True))
+        return str(out)
+
+
+def scripted_user(facts):
+    """A simulated user that releases one fact per turn (progressive disclosure).
+
+    facts[0] opens the conversation; each later fact is released only when the
+    agent replies again. The live version is an LLM given the same script, so
+    the wording varies while the order of disclosure does not."""
+    def start():
+        pending = list(facts)
+        return lambda _agent_text=None: pending.pop(0) if pending else None   # None ends the episode
+    return start
+
+
+def run_episode(env: Env, task: dict, agent, max_turns: int = 8) -> dict:
+    """The interaction protocol: reset, then alternate user turn and agent turn.
+
+    agent(said, env) -> reply text; it reaches the state only through env.call.
+    Returns the transcript, the final state, and the call log."""
+    env.reset()
+    user = task["user"]()                             # a fresh simulated user per episode
+    transcript = []
+    said = user()
+    for _ in range(max_turns):                        # the ceiling: an episode always terminates
+        if said is None:
+            break
+        reply = agent(said, env)
+        transcript.append((said, reply))
+        said = user(reply)
+    return {"transcript": transcript, "state": env.state, "calls": list(env.calls)}
+
+
+def grade(task: dict, run: dict) -> dict:
+    """Score one episode: outcome first, then what was said, then the veto.
+
+    checks read the final state, so any path that reaches it passes. must_say
+    catches "claimed but never did" in reverse: work done, user never told.
+    A veto is zero tolerance: one hit fails the run whatever else scored."""
+    checks = {name: bool(fn(run["state"])) for name, fn in task["checks"]}
+    said = " ".join(reply for _, reply in run["transcript"]).lower()
+    told = {s: s.lower() in said for s in task.get("must_say", [])}
+    unsafe = [name for name, fn in task.get("veto", []) if fn(run)]
+    return {"passed": all(checks.values()) and all(told.values()) and not unsafe,
+            "checks": checks, "told": told, "unsafe": unsafe,
+            "illegal_calls": sum(1 for _, ok in run["calls"] if not ok),
+            "steps": len(run["calls"])}
+
+
+def score(task: dict, agent, k: int = 1) -> dict:
+    """Run one task k times. Pass@k asks can it, Pass^k asks does it every time."""
+    runs = [grade(task, run_episode(task["env"](), task, agent)) for _ in range(k)]
+    ok = [r["passed"] for r in runs]
+    return {"task": task["id"], "pass_at_k": any(ok), "pass_hat_k": all(ok), "runs": runs}
+
+
+def run_suite(agent, tasks, k: int = 1) -> dict:
+    """Section 20's run_eval, now with an environment, a reset, and a protocol.
+
+    rate is the Pass^k rate: a task counts only if every one of its k runs
+    passed. band is the noise under which a difference is not a result."""
+    per_task = [score(t, agent, k) for t in tasks]
+    n = len(per_task) or 1
+    rate = sum(t["pass_hat_k"] for t in per_task) / n
+    return {"tasks": len(per_task), "k": k, "rate": rate,
+            "pass_at_k": sum(t["pass_at_k"] for t in per_task) / n,
+            "band": noise_band(rate, n), "per_task": per_task}
+
+
+def noise_band(rate: float, n: int) -> float:
+    """Binomial standard error: the sampling noise on a pass rate over n tasks.
+
+    A gap of one band between two builds is not a result. Two builds run on the
+    same tasks should be compared with paired(), which is the sharper test."""
+    return sqrt(rate * (1 - rate) / n) if n else 0.0
+
+
+def paired(before: dict, after: dict) -> dict:
+    """Compare two suite results task by task. Only the tasks that changed carry information."""
+    b = {t["task"]: t["pass_hat_k"] for t in before["per_task"]}
+    a = {t["task"]: t["pass_hat_k"] for t in after["per_task"]}
+    return {"fixed": [k for k in b if not b[k] and a.get(k)],
+            "broke": [k for k in b if b[k] and not a.get(k)]}

--- a/sections/23-evaluation/src/graph.py
+++ b/sections/23-evaluation/src/graph.py
@@ -1,0 +1,55 @@
+"""Graph engineering (section 22): control flow as a directed graph.
+
+Section 21 stacked loops around one agent. This section encodes the task
+structure you already know into code: nodes do the work, edges pick the next
+node, and the model runs only inside the nodes that need judgment.
+
+nodes is a dispatch map (section 2). An edge is either a fixed node name
+(deterministic) or a callable on the state (conditional, evaluated in code,
+no model call). Cycles are allowed; the step budget is the ceiling (section
+21). State is one dict threaded node to node; a node returns only the keys
+it wants merged, not the whole record.
+
+Mirrors the graphs named by the graph-engineering sources (nodes on a
+determinism-to-agency scale, coded edges, cycles, agents as nodes) and
+Claude Code's Workflow scripts (code routes, subagents run inside nodes).
+"""
+from __future__ import annotations
+
+from loop import Session, run_turn
+from permissions import DEFAULT
+
+END = "END"
+
+
+def run_graph(nodes, edges, state, start, budget=20):
+    """Run nodes from start, following edges, until END or the budget.
+
+    nodes: {name: fn(state) -> dict of state updates (or None)}.
+    edges: {name: next name, or fn(state) -> next name}. No edge means END.
+    Returns {"ok", "state", "trace"}; ok=False means the budget stopped a
+    cycle: escalate (section 21), do not loop forever."""
+    state = dict(state)
+    trace = []
+    node = start
+    for _ in range(budget):                        # the ceiling: harness-enforced
+        state.update(nodes[node](state) or {})     # a node returns only its updates
+        trace.append(node)
+        step = edges.get(node, END)
+        node = step(state) if callable(step) else step   # a coded edge: no model call
+        if node == END:
+            return {"ok": True, "state": state, "trace": trace}
+    return {"ok": False, "state": state, "trace": trace}   # budget spent: escalate
+
+
+def agent_node(build_prompt, model, registry, key="output"):
+    """A full inner loop (section 1) mounted as one node: agents as nodes.
+
+    Each visit runs run_turn on a FRESH messages[] built from the state, so
+    the node sees only what build_prompt passes it, not the whole run."""
+    def node(state):
+        text = run_turn([{"role": "user", "content": build_prompt(state)}],
+                        model, registry, Session(mode=DEFAULT))
+        return {key: text}
+
+    return node

--- a/sections/23-evaluation/src/hooks.py
+++ b/sections/23-evaluation/src/hooks.py
@@ -1,0 +1,34 @@
+"""Hooks (section 4): PreToolUse / PostToolUse interception around tool calls.
+Introduced in section 4, then carried forward unchanged.
+
+A PreToolUse hook may block a call or rewrite its input; it cannot grant
+permission a call lacks (so hooks here only deny or modify, never allow).
+PostToolUse hooks observe results. Mirrors Claude Code's types/hooks.ts.
+"""
+from __future__ import annotations
+
+PRE_TOOL_USE, POST_TOOL_USE = "PreToolUse", "PostToolUse"
+
+
+class Hooks:
+    def __init__(self):
+        self._hooks = {PRE_TOOL_USE: [], POST_TOOL_USE: []}
+
+    def on(self, event, fn):
+        self._hooks[event].append(fn)
+
+    def fire_pre(self, name, args):
+        """Run PreToolUse hooks. Returns (blocked, args, message); a hook may
+        rewrite args or, by returning {'deny': True}, block the call."""
+        for fn in self._hooks[PRE_TOOL_USE]:
+            out = fn(name, args) or {}
+            if out.get("updated_args"):
+                args = out["updated_args"]
+            if out.get("deny"):
+                return True, args, out.get("message", "blocked by hook")
+
+        return False, args, ""
+
+    def fire_post(self, name, args, result):
+        for fn in self._hooks[POST_TOOL_USE]:
+            fn(name, args, result)

--- a/sections/23-evaluation/src/loop.py
+++ b/sections/23-evaluation/src/loop.py
@@ -1,0 +1,106 @@
+"""Agent loop (sections 1 to 13). Changed from section 11: background-task
+completions are drained in at the start of a turn (section 13).
+
+A tool may start slow work off-loop and return a handle immediately (section
+13); its result arrives later as a <task_notification>. background.drain_into
+folds any pending notifications into the next user turn before the model call.
+Everything else is the section-11 loop: retry (section 11), prompt assembly
+(section 10), memory (section 9), context.manage (section 8).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import background
+import context
+import permissions
+import recovery
+from hooks import Hooks
+from tools import Registry, run_tool
+
+
+@dataclass
+class Session:
+    """Mutable harness state that outlives a turn."""
+    mode: str = permissions.DEFAULT
+    allow_rules: set = field(default_factory=set)
+    todos: list = field(default_factory=list)
+
+
+def run_turn(messages, model, registry: Registry, session: Session, hooks: Hooks | None = None,
+        approver=None, summarizer=None, memory=None, prompt=None, fallback_model=None,
+        runtime=None, max_steps=20):
+    hooks = hooks or Hooks()
+    approver = approver or (lambda name, args: False)
+
+    background.drain_into(messages, runtime)               # 13 · fold in any background completions
+
+    if memory is not None:
+        user_text = messages[-1]["content"]                # the new user turn (already appended)
+        recalled = memory.recall(user_text)                # 9 · inject relevant memories (read-only)
+        if recalled:
+            messages[-1]["content"] = f"<system-reminder>\n{recalled}\n</system-reminder>\n\n{user_text}"
+
+    for _ in range(max_steps):
+        messages = context.manage(messages, summarizer=summarizer)   # 8 · keep context under the window
+        system = prompt(registry, session) if prompt else None       # 10 · assemble from live state each turn
+        response = recovery.with_retry(                              # 11 · retry / adapt / fall back
+            lambda: model(messages, registry, system),
+            on_overflow=lambda: _reactive_trim(messages),
+            fallback_model=fallback_model)
+        messages.append({"role": "assistant", "content": response.content})
+
+        if response.stop_reason != "tool_use":
+            if memory is not None:
+                memory.write(messages)                     # 9 · extract new memories at run end (write-only)
+            return final_text(response)
+
+        results = [_dispatch(b, registry, session, hooks, approver)
+                   for b in response.content if b.type == "tool_use"]
+        messages.append({"role": "user", "content": results})
+
+    raise RuntimeError("hit max_steps without end_turn")
+
+
+def _reactive_trim(messages, keep_recent=4):
+    """Last-resort in-place compaction when a call overflows: keep the first
+    message and the recent tail, drop the middle, never stranding a tool_result."""
+    if len(messages) <= keep_recent + 1:
+        return
+    cut = len(messages) - keep_recent
+    while cut < len(messages) and _is_tool_result(messages[cut]):
+        cut += 1
+    del messages[1:cut]
+
+
+def _is_tool_result(m):
+    c = m.get("content")
+    return m.get("role") == "user" and isinstance(c, list) and \
+        any(isinstance(b, dict) and b.get("type") == "tool_result" for b in c)
+
+
+def _dispatch(block, registry, session, hooks, approver):
+    name, args = block.name, block.input
+    tool = registry.get(name)
+    res = lambda content: {"type": "tool_result", "tool_use_id": block.id, "content": content}
+    if tool is None:
+        return res(f"error: no tool {name!r}")
+
+    blocked, args, msg = hooks.fire_pre(name, args)                         # 4 · PreToolUse
+    if blocked:
+        return res(msg)
+
+    decision = permissions.decide(tool, session.mode, session.allow_rules)  # 3 · gate (live mode)
+    if decision == "deny":
+        return res(f"{name} not allowed in {session.mode} mode")
+    if decision == "ask" and not approver(name, args):
+        return res(f"{name} denied by user")
+
+    out = res(run_tool(tool, args))
+    hooks.fire_post(name, args, out)                                        # 4 · PostToolUse
+    return out
+
+
+def final_text(response):
+    """The model's last words: concatenate its text blocks."""
+    return "".join(b.text for b in response.content if b.type == "text")

--- a/sections/23-evaluation/src/mailbox.py
+++ b/sections/23-evaluation/src/mailbox.py
@@ -1,0 +1,221 @@
+"""Coordination (section 16): a team of named inboxes so several agents can run
+at once and talk. Introduced in section 16, then carried forward unchanged.
+
+A large job exceeds one context window, so it fans out across teammates. They
+need three things a lone loop lacks: addressing (stable names), a channel (a way
+to deliver a message the recipient will see), and escalation (a teammate hitting
+a gated action must reach a human, not stall or self-approve).
+
+Each agent owns an inbox: one JSON file per teammate under a shared team dir.
+To talk you append to the recipient's inbox under a file lock, so concurrent
+senders serialize; `to="*"` broadcasts. There is no broker. Delivery is the
+recipient draining its own inbox and folding new messages into its next turn
+(the poll-and-fold model: an agent never hard-blocks on a peer). Permission
+requests ride the same channel: a teammate sends a permission_request, the lead
+routes it to a human, and the verdict returns as a permission_response.
+
+The lead does not hand-start teammates. It calls SpawnTeammate, and the harness
+runs each teammate's serve_mailbox loop on a background thread (section 13). A
+teammate pulls its own inbox and acts, so the script drives no one. There is no
+graceful stop yet, the thread is a daemon; section 17 adds the shutdown
+handshake, and section 18 adds pulling tasks off a shared board.
+
+ponytail: one fcntl lock around the whole team (proper-lockfile's analog); split
+to per-inbox locks only if a large roster makes that one lock a bottleneck.
+"""
+from __future__ import annotations
+
+import fcntl
+import json
+import time
+from contextlib import contextmanager
+from pathlib import Path
+
+from tools import Tool
+
+
+class Team:
+    """A roster of named inboxes under `root`/inboxes, one JSON file each.
+    The roster is closed: you can only address a registered teammate, which is
+    also the trust boundary (a name becomes a path, so it must be known)."""
+
+    def __init__(self, root, members):
+        self.dir = Path(root) / "inboxes"
+        self.dir.mkdir(parents=True, exist_ok=True)
+        self.members = list(members)
+        for m in self.members:
+            self._path(m).write_text("[]")          # empty inbox per teammate
+
+    def send(self, frm, to, content):
+        """Append a message to the recipient's inbox; to='*' broadcasts to every
+        teammate but the sender. One lock serializes concurrent senders."""
+        targets = [m for m in self.members if m != frm] if to == "*" else [self._check(to)]
+        with self._lock():
+            for t in targets:
+                inbox = self._read(t)
+                inbox.append({"from": self._check(frm), "to": t, "content": content})
+                self._path(t).write_text(json.dumps(inbox))
+
+    def drain(self, name):
+        """Read and clear a teammate's inbox, oldest first. Delivery is the
+        recipient draining its own inbox, so a peer never blocks waiting on it."""
+        with self._lock():
+            inbox = self._read(name)
+            self._path(name).write_text("[]")
+            return inbox
+
+    # --- disk plumbing ---
+    def _check(self, name):
+        if name not in self.members:                # closed roster = the trust boundary
+            raise ValueError(f"not a teammate: {name!r}")
+        return name
+
+    def _path(self, name):
+        return self.dir / f"{self._check(name)}.json"
+
+    def _read(self, name):
+        return json.loads(self._path(name).read_text())
+
+    @contextmanager
+    def _lock(self):
+        f = open(self.dir / ".lock", "w")
+        try:
+            fcntl.flock(f, fcntl.LOCK_EX)           # blocks until the other sender releases
+            yield
+        finally:
+            fcntl.flock(f, fcntl.LOCK_UN)
+            f.close()
+
+
+def _fold(chat):
+    """Render chat messages as one prompt block, the wire format a teammate reads.
+    One definition so fold_inbox and serve_mailbox cannot drift."""
+    return "\n".join(f"<message from={m['from']!r}>{m['content']}</message>" for m in chat)
+
+
+def fold_inbox(messages, team, name):
+    """Drain `name`'s inbox and surface chat (string) messages on its next turn,
+    so a teammate folds peers' messages in between turns instead of blocking on
+    them. Mirrors how background completions (section 13) prepend to the next
+    turn. Returns every drained message (not just chat), so a structured message
+    is never silently lost; the caller routes the rest (e.g. permission replies)."""
+    drained = team.drain(name)
+    chat = [m for m in drained if isinstance(m["content"], str)]
+    if chat and messages and isinstance(messages[-1].get("content"), str):
+        messages[-1]["content"] = _fold(chat) + "\n\n" + messages[-1]["content"]
+    return drained
+
+
+def serve_mailbox(team, me, work, *, poll=0.05, max_idle_polls=None):
+    """A teammate's own loop, spawned on a background thread (section 13): pull the
+    inbox, act, repeat. Each pass drains `me`'s inbox; chat messages fold into one
+    prompt and run `work(prompt)` (one inner loop, section 1), and an empty inbox
+    just sleeps and polls again. So a teammate reacts on its own thread instead of
+    the script driving it. No graceful stop yet: the thread is a daemon that dies
+    with the process. Section 17 adds the shutdown handshake; section 18 adds
+    claiming tasks off a board when the inbox is empty. max_idle_polls bounds the
+    idle wait so a demo or test ends; None runs until the process does. Returns
+    'idle' when a bounded loop gives up."""
+    idle = 0
+    while True:
+        chat = [m for m in team.drain(me) if isinstance(m["content"], str)]
+        if chat:
+            idle = 0
+            work(_fold(chat))                           # one inner loop on the folded message
+            continue
+        idle += 1
+        if max_idle_polls is not None and idle >= max_idle_polls:
+            return "idle"
+        time.sleep(poll)
+
+
+def bubbling_approver(team, me, lead, human=None, timeout=0.0, poll=0.05):
+    """An approver (section 3) for a teammate with no human in its own loop: a
+    gated call escalates to the lead. The request and the verdict both travel the
+    inbox channel; the teammate returns on what it reads back from its own inbox,
+    so the answer is an inbox message, not a direct call.
+
+    With `human`, the lead's approval UI answers inline (synchronous round-trip).
+    Without it, the answer must arrive from elsewhere (a lead on another thread, a
+    person on a chat platform), so the teammate polls its inbox up to `timeout`
+    and then DENIES: an unanswered permission is a no, never a stall or a yes.
+    Mirrors Hermes' clarify gateway (register / wait_for_response with timeout).
+    ponytail: the wait drains chat messages too; route drained non-responses if
+    teammates chat while a permission is pending."""
+    def approve(name, args):
+        team.send(me, lead, {"kind": "permission_request", "tool": name, "args": args})
+        if human is not None:                       # the lead routes it to its approval UI
+            team.send(lead, me, {"kind": "permission_response", "tool": name, "ok": human(name, args)})
+        deadline = time.time() + timeout
+        while True:
+            responses = [m["content"] for m in team.drain(me)
+                         if isinstance(m["content"], dict) and m["content"].get("kind") == "permission_response"]
+            if responses:
+                return bool(responses[-1]["ok"])
+            if time.time() >= deadline:
+                return False                        # nobody answered in time: default deny
+            time.sleep(poll)
+    return approve
+
+
+def _send_tool(get_team, me):
+    """The SendMessage tool, shared by message_tools and team_tools. `me` is bound
+    by the harness, not the model, so a teammate cannot spoof another. get_team()
+    returns the team at call time, so one implementation serves both a teammate
+    with a fixed team and a lead whose team exists only after TeamCreate (None
+    until then). Mirrors Claude Code's SendMessageTool."""
+    def send(a):
+        team = get_team()
+        if team is None:
+            return "no team yet: call TeamCreate with the member names first"
+        team.send(me, a["to"], a["message"])
+        return f"sent to {a['to']}"
+
+    return Tool("SendMessage", send,
+                description="Send a message to a teammate by name. Use 'lead' to reach the team lead.",
+                input_schema={"type": "object",
+                              "properties": {"to": {"type": "string"}, "message": {"type": "string"}},
+                              "required": ["to", "message"]})
+
+
+def message_tools(team, me):
+    """SendMessage over an existing team: the model decides to message a teammate,
+    and the harness delivers it over the inbox channel."""
+    return [_send_tool(lambda: team, me)]
+
+
+def team_tools(root, me, formed):
+    """Forming the team is the model's decision, not the script's. TeamCreate
+    materializes the inboxes under `root` into `formed`; the shared SendMessage
+    stays inert until then, so the lead creates the team before it can talk to it.
+    `formed` is a one-slot holder the harness reads back to hand the same Team to
+    teammates that join (ponytail: an in-process stand-in for a team registry;
+    back it with a roster file on disk to let a teammate in another process join)."""
+    def create(a):
+        members = list(dict.fromkeys([me, *a["members"]]))   # the creator joins its own team
+        formed["team"] = Team(root, members)                 # the tool call brings the team into being
+        return f"team created: {', '.join(members)}"
+
+    return [Tool("TeamCreate", create,
+                 description="Create the team with a list of member names. Call this before messaging.",
+                 input_schema={"type": "object",
+                               "properties": {"members": {"type": "array", "items": {"type": "string"}}},
+                               "required": ["members"]}),
+            _send_tool(lambda: formed["team"], me)]          # SendMessage, late-bound on the formed team
+
+
+def teammate_tools(runtime, spawn_worker):
+    """SpawnTeammate as a tool: the lead's model decides to add a teammate, and the
+    harness starts its loop on a background thread (section 13's runtime).
+    `spawn_worker(name)` is the app-supplied thunk that runs that teammate's loop
+    (serve_mailbox here; an autonomy loop from section 18). Whether to spawn is the
+    model's call, not the script's. Mirrors Claude Code spawning an
+    InProcessTeammateTask."""
+    def spawn(a):
+        runtime.start(lambda: spawn_worker(a["name"]))
+        return f"spawned teammate {a['name']}; it runs on its own thread and pulls its own work"
+
+    return [Tool("SpawnTeammate", spawn, is_read_only=True,
+                 description="Spawn a teammate by name; it runs on its own thread and pulls its own work.",
+                 input_schema={"type": "object", "properties": {"name": {"type": "string"}},
+                               "required": ["name"]})]

--- a/sections/23-evaluation/src/mcp.py
+++ b/sections/23-evaluation/src/mcp.py
@@ -1,0 +1,108 @@
+"""MCP / plugins / channels (section 19): reach outside the harness.
+
+connect() discovers an external server's tools (the MCP tools/list step) and
+wraps each as a runtime Tool (section 2), namespaced mcp__<server>__<tool>, so
+they merge into the one pool the loop dispatches. The loop, permission gate
+(section 3), and dispatch do not change: an MCP tool is just a Tool whose run()
+calls out over a transport instead of running in-process.
+
+An MCP annotation (readOnlyHint / destructiveHint) rides along and becomes the
+permission hint the gate reads, so a server declares how risky each tool is.
+
+merge_servers() layers plugin/user/project/local config by precedence, the way
+a plugin contributes servers alongside user and project config.
+
+wrap_channel() turns a server push into a tagged message folded into the next
+turn, so Slack, Discord, or SMS ride the same protocol as a two-way surface.
+gate_inbound() runs that push through gates first: an inbound channel message is
+untrusted input, so a gate may drop or rewrite it before the loop ever sees it
+(Hermes' pre_gateway_dispatch hook, fired before auth on every incoming message).
+
+Mirrors Claude Code services/mcp/: buildMcpToolName namespaces each tool,
+normalizeNameForMCP sanitizes it, the readOnlyHint annotation drives the
+permission hint, config.ts merges by precedence, and channelNotification.ts
+wraps a push in CHANNEL_TAG.
+"""
+from __future__ import annotations
+
+import re
+
+from tools import NO_INPUT, Tool
+
+_BAD = re.compile(r"[^a-zA-Z0-9_-]")             # the API's allowed name charset
+CHANNEL_TAG = "channel"
+PRECEDENCE = ("plugin", "user", "project", "local")   # low to high; later wins
+
+
+def normalize(name: str) -> str:
+    """normalizeNameForMCP: any char outside [a-zA-Z0-9_-] becomes _."""
+    return _BAD.sub("_", name)
+
+
+def tool_name(server: str, tool: str) -> str:
+    """buildMcpToolName: mcp__<server>__<tool>, so two servers never collide."""
+    return f"mcp__{normalize(server)}__{normalize(tool)}"
+
+
+def wrap(server: str, spec: dict, call) -> Tool:
+    """One discovered tool spec -> a runtime Tool bound to the server.
+
+    call(tool, args) reaches the server over its transport. The MCP annotations
+    map to the permission hints the gate (section 3) reads; a read-only tool may
+    also share a parallel batch (section 2)."""
+    ann = spec.get("annotations", {})
+    read_only = bool(ann.get("readOnlyHint"))
+    bare = spec["name"]
+    return Tool(
+        name=tool_name(server, bare),
+        run=lambda args, _t=bare: call(_t, args),        # dispatch calls out over the transport
+        description=spec.get("description", ""),
+        input_schema=spec.get("inputSchema") or dict(NO_INPUT),
+        is_read_only=read_only,
+        is_concurrency_safe=read_only,                   # reads are safe to run in parallel
+    )
+
+
+def connect(server: str, conn) -> list[Tool]:
+    """Discover a server's tools and wrap each as a namespaced Tool.
+
+    conn is a live transport (stdio / http / sse in production; in-process here):
+    .list_tools() -> tool specs, .call(tool, args) -> result. Merge the returned
+    Tools into the loop's Registry and they dispatch like any built-in."""
+    return [wrap(server, spec, conn.call) for spec in conn.list_tools()]
+
+
+def merge_servers(*layers: dict) -> dict:
+    """Layer server config by precedence plugin < user < project < local.
+
+    Each layer maps server name -> config; a later layer overrides an earlier one
+    for the same name. This is how a plugin's servers combine with user and
+    project config (config.ts)."""
+    merged: dict = {}
+    for scope in PRECEDENCE:
+        for layer in layers:
+            merged.update(layer.get(scope, {}))
+    return merged
+
+
+def wrap_channel(source: str, payload: str) -> str:
+    """A server push (notifications/claude/channel) becomes a tagged message the
+    loop folds into the next turn (section 13's queue, section 16's inbox)."""
+    return f'<{CHANNEL_TAG} source="{source}">{payload}</{CHANNEL_TAG}>'
+
+
+def gate_inbound(source: str, payload: str, gates=()) -> str | None:
+    """Run an inbound channel message through gates before it becomes a turn.
+
+    Each gate(source, payload) may return {'drop': True} to discard the message
+    or {'rewrite': str} to replace its payload; anything else passes it through.
+    Returns the tagged message for the loop, or None when a gate dropped it.
+    A channel is an open door, so the gate runs before the model ever reads the
+    text (Hermes: pre_gateway_dispatch, skip / rewrite / allow)."""
+    for gate in gates:
+        out = gate(source, payload) or {}
+        if out.get("drop"):
+            return None
+        if out.get("rewrite") is not None:
+            payload = out["rewrite"]
+    return wrap_channel(source, payload)

--- a/sections/23-evaluation/src/memory.py
+++ b/sections/23-evaluation/src/memory.py
@@ -1,0 +1,183 @@
+"""Memory (section 9): a durable file store the agent recalls from and writes to.
+
+Introduced in section 9, then carried forward unchanged.
+
+messages[] dies with the run (section 1) and degrades under compaction
+(section 8). Memory is the layer outside the conversation: small .md files with
+frontmatter, recall that injects only the few relevant bodies into a turn, and
+extraction that writes new files at run end. Four operations, never conflated:
+  selection    : what is worth keeping. the type taxonomy gates the store, so
+                 derivable facts (code, git) are never written.
+  recall       : read-only, at query time. rank the index, inject a few bodies.
+  extraction   : write-only, at run end. append new files.
+  consolidation: rare, background (section 13). dedupe + prune. not shown here.
+Mirrors Claude Code's memdir (findRelevantMemories, memoryScan) + extractMemories.
+
+A second recall path searches raw history instead of extracted facts (Hermes
+Agent's session_search over state.db, SQLite FTS5): log_run() appends each run's
+text to a searchable session log, and search_sessions() returns actual past
+messages, ranked, with no model call. Extraction keeps distilled facts; the log
+keeps everything, so a fact extraction missed is still findable.
+"""
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+from tools import Tool
+
+TYPES = ("user", "feedback", "project", "reference")   # non-derivable only; the rest is grep's job
+RECALL_K = 5                                            # cap injected memories (precision over recall)
+SEARCH_K = 3                                            # cap returned past messages, same reason
+
+
+@dataclass
+class Memory:
+    name: str
+    type: str          # one of TYPES
+    description: str    # the cheap index line, ranked at recall time
+    path: Path          # the .md file; its body is read only when recalled
+
+
+def load_index(memory_dir) -> list[Memory]:
+    """Scan <dir>/*.md, keeping frontmatter only. The cheap manifest, never the bodies."""
+    mems = []
+    for md in sorted(Path(memory_dir).glob("*.md")):
+        if md.name == "MEMORY.md":          # the index file itself is not a memory
+            continue
+        meta, _body = _split(md.read_text())
+        mems.append(Memory(md.stem, meta.get("type", ""), meta.get("description", ""), md))
+    return mems
+
+
+def manifest(mems) -> str:
+    """One line per memory: name, type, description. Always-on and cheap (section 10)."""
+    return "\n".join(f"- {m.name} ({m.type}): {m.description}" for m in mems)
+
+
+def recall(mems, query, k=RECALL_K, selector=None) -> list[Memory]:
+    """Pick the few memories relevant to `query`. `selector` is the live relevance
+    judge (an LLM reading the manifest); without it, fall back to word overlap."""
+    if selector is not None:
+        chosen = set(selector(manifest(mems), query))     # LLM returns the names to inject
+        return [m for m in mems if m.name in chosen][:k]
+    scored = ((_overlap(query, m), m) for m in mems)
+    hits = sorted((s for s in scored if s[0]), key=lambda s: s[0], reverse=True)
+    return [m for _score, m in hits[:k]]
+
+
+def recall_block(mems, query, k=RECALL_K, selector=None) -> str:
+    """The recalled bodies, formatted for injection into a turn. '' if nothing fits."""
+    hits = recall(mems, query, k, selector)
+    return "\n\n".join(f"[memory · {m.type}] {_split(m.path.read_text())[1]}" for m in hits)
+
+
+def extract(memory_dir, messages, extractor) -> list[Path]:
+    """Run end: the extractor proposes new memories from the transcript; write each.
+    The only operation that grows the store. extractor(messages) returns dicts of
+    {name, type, description, body}; an empty list writes nothing."""
+    written = []
+    for m in extractor(messages) or []:
+        path = Path(memory_dir) / f"{m['name']}.md"
+        path.write_text(_render(m))
+        written.append(path)
+    return written
+
+
+def log_run(db_path, session_id, messages) -> int:
+    """Run end: append the run's text to the searchable session log. Everything
+    with text lands, not just what extraction kept (Hermes indexes all session
+    messages into state.db). ponytail: FTS5 ships in CPython's sqlite3."""
+    rows = [(session_id, m["role"], t) for m in messages if (t := _text_of(m))]
+    con = _db(db_path)
+    con.executemany("INSERT INTO session_log VALUES (?, ?, ?)", rows)
+    con.commit()
+    con.close()
+    return len(rows)
+
+
+def search_sessions(db_path, query, k=SEARCH_K) -> list[tuple]:
+    """Recall actual past messages by keyword, best match first (bm25), zero model
+    cost. Returns (session_id, role, content) rows; [] when nothing matches."""
+    words = _words(query)
+    if not words or not Path(db_path).exists():
+        return []
+    con = _db(db_path)
+    rows = con.execute("SELECT session_id, role, content FROM session_log "
+                       "WHERE session_log MATCH ? ORDER BY rank LIMIT ?",
+                       (" OR ".join(sorted(words)), k)).fetchall()
+    con.close()
+    return rows
+
+
+def search_tool(db_path) -> Tool:
+    """SessionSearch: the model-facing handle for search_sessions, so the agent
+    decides when past sessions are worth consulting (Hermes' session_search)."""
+    def search(a):
+        rows = search_sessions(db_path, a["query"])
+        if not rows:
+            return "no past sessions match"
+        return "\n".join(f"[session {sid} · {role}] {content}" for sid, role, content in rows)
+
+    return Tool("SessionSearch", search, is_read_only=True,
+                description="Search past session transcripts by keywords; returns matching messages.",
+                input_schema={"type": "object", "properties": {"query": {"type": "string"}},
+                              "required": ["query"]})
+
+
+@dataclass
+class Store:
+    """The handle threaded into the loop (loop.py): recall before the run, extract
+    after. `selector` / `extractor` are the live LLM hooks; both optional. With a
+    `db`, run end also logs the transcript for cross-session search."""
+    root: Path
+    selector: Callable | None = None
+    extractor: Callable | None = None
+    db: Path | None = None
+    session_id: str = "session"
+
+    def recall(self, query, k=RECALL_K) -> str:
+        return recall_block(load_index(self.root), query, k, self.selector)
+
+    def write(self, messages) -> list[Path]:
+        if self.db is not None:
+            log_run(self.db, self.session_id, messages)
+        return extract(self.root, messages, self.extractor) if self.extractor else []
+
+
+def _db(path):
+    con = sqlite3.connect(path)
+    con.execute("CREATE VIRTUAL TABLE IF NOT EXISTS session_log "
+                "USING fts5(session_id, role, content)")
+    return con
+
+
+def _text_of(message) -> str:
+    """The searchable text of one message: a plain string, or the text blocks of
+    an API response. Tool-use blocks carry no text and are skipped."""
+    content = message.get("content")
+    if isinstance(content, str):
+        return content
+    return "\n".join(t for b in content if (t := getattr(b, "text", "")))
+
+
+def _overlap(query, mem) -> int:
+    return len(_words(query) & _words(mem.name + " " + mem.description))
+
+
+def _words(text) -> set:
+    return {w for w in "".join(c if c.isalnum() else " " for c in text.lower()).split() if len(w) > 2}
+
+
+def _render(m) -> str:
+    return f"---\ntype: {m['type']}\ndescription: {m['description']}\n---\n{m['body']}\n"
+
+
+def _split(text):
+    """Minimal frontmatter parse into (meta dict, body). Same shape as skills.py."""
+    _, frontmatter, body = text.split("---", 2)
+    meta = {k.strip(): v.strip() for k, v in
+            (line.split(":", 1) for line in frontmatter.strip().splitlines() if ":" in line)}
+    return meta, body.strip()

--- a/sections/23-evaluation/src/permissions.py
+++ b/sections/23-evaluation/src/permissions.py
@@ -1,0 +1,27 @@
+"""Permission gate (section 3): the allow / ask / deny decision between a
+model's tool request and execution. Introduced in section 3, then carried
+forward unchanged. Modes mirror Claude Code's types/permissions.ts.
+"""
+from __future__ import annotations
+
+DEFAULT, ACCEPT_EDITS, PLAN, BYPASS = "default", "acceptEdits", "plan", "bypassPermissions"
+
+
+def decide(tool, mode: str, allow_rules: set) -> str:
+    """Return 'allow', 'ask', or 'deny' for running `tool` under `mode`."""
+    if mode == BYPASS:
+        return "allow"                       # user opted out of the gate entirely
+
+    if mode == PLAN:
+        if tool.is_read_only:
+            return "allow"                   # reading is fine while planning
+        if tool.name == "ExitPlanMode":
+            return "ask"                     # the plan-approval handshake (section 5)
+        return "deny"                        # no side effects until the plan is approved
+
+    if tool.is_read_only or tool.name in allow_rules:
+        return "allow"
+    if mode == ACCEPT_EDITS and tool.is_edit:
+        return "allow"                       # edits pre-approved for this session
+
+    return "ask"                             # default: a human decides

--- a/sections/23-evaluation/src/planning.py
+++ b/sections/23-evaluation/src/planning.py
@@ -1,0 +1,44 @@
+"""Planning and todos (section 5): a TodoWrite tool and plan mode. Introduced
+in section 5, then carried forward unchanged. Both tools mutate the Session
+(loop.py): TodoWrite records the plan, ExitPlanMode flips the mode once the
+plan is approved. Mirrors Claude Code's TodoWriteTool and Enter/ExitPlanMode.
+"""
+from __future__ import annotations
+
+import permissions
+from tools import Tool
+
+TODOS_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "todos": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {"step": {"type": "string"}, "status": {"type": "string"}},
+                "required": ["step", "status"],
+            },
+        },
+    },
+    "required": ["todos"],
+}
+
+
+def todo_tool(session) -> Tool:
+    """TodoWrite: record the plan as a list of steps on the session."""
+    def write(a):
+        session.todos = list(a["todos"])
+        done = sum(1 for t in session.todos if t.get("status") == "completed")
+        return f"{len(session.todos)} todos ({done} done)"
+    return Tool("TodoWrite", write,
+                description="Record the plan as a checklist of {step, status} items.",
+                input_schema=TODOS_SCHEMA, is_read_only=True)   # agent state only, no side effect
+
+
+def exit_plan_mode_tool(session, to_mode=permissions.ACCEPT_EDITS) -> Tool:
+    """ExitPlanMode: once the plan is approved, leave plan mode for `to_mode`."""
+    def exit_plan(_a):
+        session.mode = to_mode
+        return f"plan approved, mode now {to_mode}"
+    return Tool("ExitPlanMode", exit_plan,
+                description="Present the plan and leave plan mode once the user approves.")

--- a/sections/23-evaluation/src/prompt.py
+++ b/sections/23-evaluation/src/prompt.py
@@ -1,0 +1,48 @@
+"""System prompt assembly (section 10): build the system prompt each turn from
+named sections chosen by live state, not one hardcoded string.
+
+Introduced in section 10, then carried forward unchanged.
+
+A section is static (always present) or dynamic (compute(state) -> str | None).
+assemble() runs every section against current state, drops the Nones, and joins.
+A section is included by state, not keywords: the env section appears only with a
+cwd, the mcp section only when a server is connected. Recalled memory does NOT
+live here; it rides in the message as a <system-reminder> (section 9), so it
+never touches the system-prompt cache.
+
+Caching: within a conversation the system prompt is stable, so the demo enables
+automatic caching, one top-level cache_control that caches the whole prompt plus
+the growing messages and advances as the conversation grows (see demo.py).
+Mirrors Claude Code's getSystemPrompt + resolveSystemPromptSections.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+
+@dataclass
+class Section:
+    name: str
+    compute: Callable    # (state) -> str | None ; static sections ignore state, returning a constant
+
+
+def static(name, text) -> Section:
+    return Section(name, lambda _state: text)
+
+
+def assemble(sections, state) -> str:
+    """The system prompt for this turn: run every section, drop the Nones, join."""
+    parts = (s.compute(state) for s in sections)
+    return "\n\n".join(p for p in parts if p is not None)
+
+
+# A demonstrative section list, the strip-down's stand-in for Claude Code's
+# getSimpleIntroSection / getUsingYourToolsSection / mcp_instructions / etc.
+DEMO_SECTIONS = [
+    static("intro", "You are a tiny agent. Use the provided tools to answer. Be brief."),
+    static("rules", "Rules: prefer tools over guessing; never invent file contents."),
+    Section("tools", lambda s: "Tools: " + ", ".join(s["tools"]) if s.get("tools") else None),
+    Section("env", lambda s: f"cwd: {s['cwd']}" if s.get("cwd") else None),
+    Section("mcp", lambda s: "MCP servers connected; extra tools may appear." if s.get("mcp") else None),
+]

--- a/sections/23-evaluation/src/protocols.py
+++ b/sections/23-evaluation/src/protocols.py
@@ -1,0 +1,178 @@
+"""Protocols (section 17): typed request/reply over the section-16 channel.
+Introduced in section 17, then carried forward unchanged.
+
+The channel (section 16) only moves text; text alone has no contract. A protocol
+is the agreed rule on top of it, and it is three small things:
+
+  1. Typed variants. Every message carries a `type` field, so a handler
+     dispatches on it and a reply is never mistaken for an unrelated request.
+  2. A correlation id. `request_id` is set when the request goes out and echoed
+     in the reply, so the sender knows which pending request a reply resolves.
+  3. A small state machine. A request goes pending -> approved or rejected. A
+     reply for an already resolved (or unknown) id is ignored, so duplicates and
+     stray replies are harmless.
+
+Two flows are mirror images of each other. In shutdown the lead requests and the
+teammate confirms; in plan approval the teammate requests and the lead confirms.
+Both ride the same `Protocol` tracker, just in opposite directions. Approval can
+carry the permission mode the work runs under (section 3), so the verdict and the
+mode it runs under travel together.
+
+On top of the tracker, `run_teammate` is section 16's `serve_mailbox` extended
+with the shutdown handshake: a spawned teammate now stops on a lead's request
+instead of dying with its daemon thread. Initiating a stop is the lead's tool call
+(StopTeammate); confirming it is harness-driven, done by the loop itself, not a
+model tool (the reference confirms in the inbox dispatcher the same way).
+
+ponytail: in-process pending dict, one tracker per agent; a cross-restart bus
+would persist pending state, but the resolve logic stays the same.
+"""
+from __future__ import annotations
+
+import time
+
+from mailbox import _fold
+from tools import Tool
+
+PENDING, APPROVED, REJECTED = "pending", "approved", "rejected"
+
+# Which reply variants answer each request, and the verdict each implies.
+# None means a single response variant that carries the verdict in an `approved`
+# field (the plan flow), rather than splitting it across two reply types.
+_REPLIES = {
+    "shutdown_request": {"shutdown_approved": APPROVED, "shutdown_rejected": REJECTED},
+    "plan_approval_request": {"plan_approval_response": None},
+}
+
+
+class Protocol:
+    """Per-agent request tracker over a Team channel (section 16). It records each
+    outgoing request as pending and resolves the matching reply exactly once."""
+
+    def __init__(self, team, me):
+        self.team = team
+        self.me = me
+        self._n = 0
+        self.pending = {}                         # request_id -> {"kind", "state"} (outbound)
+        self.inbound = {}                         # request type -> the message to reply to
+
+    def request(self, to, kind, **fields):
+        """Send a typed request (`kind` is the wire `type` field), record it
+        pending, and return its correlation id."""
+        if kind not in _REPLIES:                  # only known request types have a reply contract
+            raise ValueError(f"unknown request type: {kind!r}")
+        self._n += 1
+        rid = f"{self.me}-{self._n}"              # per-sender id: unique and deterministic
+        self.pending[rid] = {"kind": kind, "state": PENDING}
+        self.team.send(self.me, to, {"type": kind, "request_id": rid, **fields})
+        return rid
+
+    def reply(self, msg, kind, **fields):
+        """Answer an inbound request by echoing its request_id back to the sender,
+        so the reply correlates to exactly what it answers."""
+        req = msg["content"]
+        self.team.send(self.me, msg["from"], {"type": kind, "request_id": req["request_id"], **fields})
+
+    def resolve(self, msg):
+        """Apply an inbound reply to its pending request and return the new state.
+        Returns None (a no-op) if the id is unknown, already resolved, or the reply
+        type does not answer the recorded request. Idempotent on duplicates."""
+        reply = msg["content"]
+        req = self.pending.get(reply.get("request_id"))
+        if not req or req["state"] != PENDING:    # unknown id or already resolved
+            return None
+        verdicts = _REPLIES[req["kind"]]
+        if reply.get("type") not in verdicts:     # type-confusion guard: wrong reply kind
+            return None
+        state = verdicts[reply["type"]]
+        if state is None:                         # single-response flow carries the bool
+            state = APPROVED if reply.get("approved") else REJECTED
+        req["state"] = state
+        return state
+
+    def note_inbound(self, msg):
+        """Record an inbound typed request so a reply tool can answer it without
+        the model passing request_ids around. Keyed by request type, latest wins."""
+        content = msg.get("content")
+        if isinstance(content, dict) and content.get("type") in _REPLIES:
+            self.inbound[content["type"]] = msg
+
+
+def protocol_tools(proto, lead="lead"):
+    """The handshake initiations as tools the model calls, so gating a plan or
+    stopping a teammate is the model's decision, not a script's. The worker submits
+    a plan with ExitPlanMode; the lead answers with ApprovePlan and asks a worker to
+    stop with StopTeammate. Replies correlate by request_id under the hood
+    (note_inbound records the request). Confirming a shutdown is not a tool: the
+    teammate's run_teammate loop replies automatically (harness-driven reception,
+    like Claude Code's inbox dispatcher). Mirrors ExitPlanModeV2Tool and the stop
+    path."""
+    def exit_plan(a):                              # worker -> lead: gate the plan before editing
+        proto.request(lead, "plan_approval_request", plan=a["plan"])
+        return "plan submitted to the lead; awaiting approval before any edits"
+
+    def approve_plan(a):                           # lead -> worker: answer the pending plan
+        req = proto.inbound.get("plan_approval_request")
+        if req is None:
+            return "no plan is awaiting approval"
+        fields = {"approved": bool(a.get("approved", True))}
+        if a.get("permissionMode"):
+            fields["permissionMode"] = a["permissionMode"]   # the verdict carries the mode (section 3)
+        proto.reply(req, "plan_approval_response", **fields)
+        return "plan approved" if fields["approved"] else "plan rejected"
+
+    def stop_teammate(a):                          # lead -> worker: ask for a clean stop
+        proto.request(a["name"], "shutdown_request", reason=a.get("reason", "done"))
+        return f"asked {a['name']} to stop"
+
+    return [
+        Tool("ExitPlanMode", exit_plan, is_read_only=True,
+             description="Submit your plan to the lead and wait for approval before editing.",
+             input_schema={"type": "object", "properties": {"plan": {"type": "string"}},
+                           "required": ["plan"]}),
+        Tool("ApprovePlan", approve_plan, is_read_only=True,
+             description="Approve or reject the plan a teammate submitted for review.",
+             input_schema={"type": "object", "properties": {
+                 "approved": {"type": "boolean"}, "feedback": {"type": "string"},
+                 "permissionMode": {"type": "string"}}}),
+        Tool("StopTeammate", stop_teammate, is_read_only=True,
+             description="Ask a teammate to finish and stop cleanly, by name.",
+             input_schema={"type": "object", "properties": {
+                 "name": {"type": "string"}, "reason": {"type": "string"}},
+                 "required": ["name"]}),
+    ]
+
+
+def _is_shutdown(msg):
+    content = msg["content"]
+    return isinstance(content, dict) and content.get("type") == "shutdown_request"
+
+
+def run_teammate(team, me, lead, work, *, poll=0.05, max_idle_polls=None):
+    """Section 16's serve_mailbox plus the shutdown handshake. Each pass drains the
+    inbox: a shutdown_request is confirmed with shutdown_approved and ends the
+    loop, so a teammate is stopped by a handshake, not by killing its daemon
+    thread; chat messages fold into one prompt and run `work(prompt)`; an empty
+    inbox polls again. The confirm is the loop's own doing, not a model tool call
+    (harness-driven reception, like the reference's inbox dispatcher), and shutdown
+    is checked before chat so peer traffic cannot starve a stop. Returns 'shutdown'
+    when the handshake
+    stops it, 'idle' if a bounded loop gives up first. Section 18 adds claiming
+    board tasks when the inbox is empty."""
+    proto = Protocol(team, me)
+    idle = 0
+    while True:
+        inbox = team.drain(me)
+        shutdown = next((m for m in inbox if _is_shutdown(m)), None)
+        if shutdown is not None:
+            proto.reply(shutdown, "shutdown_approved")      # confirm, then stop
+            return "shutdown"
+        chat = [m for m in inbox if isinstance(m["content"], str)]
+        if chat:
+            idle = 0
+            work(_fold(chat))                               # one inner loop on the folded message
+            continue
+        idle += 1
+        if max_idle_polls is not None and idle >= max_idle_polls:
+            return "idle"
+        time.sleep(poll)

--- a/sections/23-evaluation/src/recovery.py
+++ b/sections/23-evaluation/src/recovery.py
@@ -1,0 +1,85 @@
+"""Error recovery (section 11): wrap the model call so transient failures retry,
+recoverable ones adapt, and only fatal ones surface.
+
+Introduced in section 11, then carried forward unchanged.
+
+with_retry classifies each failure and takes the matching path:
+  transient (429 / 408 / 409 / 5xx) : exponential backoff + jitter, honor retry-after.
+  overflow  (prompt too long)       : run on_overflow() once (compact, section 8), retry.
+  529 storm                         : after MAX_529_RETRIES, raise FallbackTriggered.
+  fatal     (4xx, unknown)          : raise at once.
+State (consecutive 529s, a one-shot overflow flag) persists across attempts so
+each path is bounded. Mirrors Claude Code's withRetry + getRetryDelay +
+FallbackTriggeredError + the prompt_too_long -> reactive-compact path.
+"""
+from __future__ import annotations
+
+import time
+from random import random
+
+BASE_DELAY = 0.5            # seconds; doubles each attempt
+MAX_DELAY = 32.0
+DEFAULT_MAX_RETRIES = 10
+MAX_529_RETRIES = 3         # consecutive overloads before falling back to another model
+RETRY_STATUS = {408, 409, 429}   # these plus any 5xx are worth retrying
+
+
+class FallbackTriggered(Exception):
+    """Raised after repeated 529s so the caller can retry on `fallback_model`."""
+
+    def __init__(self, fallback_model):
+        super().__init__(f"falling back to {fallback_model}")
+        self.fallback_model = fallback_model
+
+
+def should_retry(status) -> bool:
+    return status in RETRY_STATUS or (status is not None and 500 <= status < 600)
+
+
+def retry_delay(attempt, retry_after=None) -> float:
+    """Exponential backoff with up to 25% jitter; a server retry-after wins."""
+    if retry_after is not None:
+        return float(retry_after)
+    base = min(BASE_DELAY * 2 ** (attempt - 1), MAX_DELAY)
+    return base + base * 0.25 * random()
+
+
+def with_retry(call, on_overflow=None, fallback_model=None,
+               max_retries=DEFAULT_MAX_RETRIES, sleep=time.sleep):
+    """Call `call()`, recovering per error class. Returns its result, or raises
+    once recovery is exhausted so the loop can feed the error back (section 1)."""
+    consecutive_529 = 0
+    overflowed = False
+    for attempt in range(1, max_retries + 2):
+        try:
+            return call()
+        except FallbackTriggered:
+            raise
+        except Exception as e:
+            if _is_overflow(e):
+                if on_overflow is None or overflowed:
+                    raise                       # already compacted once; nothing left to shrink
+                overflowed = True
+                on_overflow()                   # compact (section 8), then retry
+                continue
+            status = _status(e)
+            if status is None:
+                raise                           # not a recognized API error -> fatal
+            if status == 529:
+                consecutive_529 += 1
+                if fallback_model and consecutive_529 >= MAX_529_RETRIES:
+                    raise FallbackTriggered(fallback_model)
+            if attempt > max_retries or not should_retry(status):
+                raise                           # exhausted or non-retryable -> surface it
+            sleep(retry_delay(attempt, getattr(e, "retry_after", None)))
+    raise RuntimeError("with_retry exhausted")  # unreachable: the loop returns or raises first
+
+
+def _status(e):
+    """The HTTP status of an API error, or None. The anthropic SDK exposes
+    status_code; the offline test sets the same attribute."""
+    return getattr(e, "status_code", None)
+
+
+def _is_overflow(e) -> bool:
+    return getattr(e, "overflow", False) or "prompt is too long" in str(e).lower()

--- a/sections/23-evaluation/src/scheduler.py
+++ b/sections/23-evaluation/src/scheduler.py
@@ -1,0 +1,114 @@
+"""Scheduling (section 14): a clock fires turns on a schedule, no human at the
+keyboard. Introduced in section 14, then carried forward unchanged.
+
+A Scheduler holds entries (each a prompt plus a fire time) and ticks on its own
+daemon thread, independent of whether the loop is running. When a task is due it
+does not call the model: it enqueues the prompt (onFire), and the driver drains
+that queue between turns (section 1), so a fired prompt arrives as a new
+user-style turn. Recurring tasks re-arm to the next interval, one-shots
+auto-delete. Durable tasks persist to JSON and reload on start (section 12), so
+a schedule set today re-arms after a restart.
+
+We model "when" as an absolute fire time plus an optional repeat interval, not a
+5-field cron string. ponytail: timestamp + interval is the mechanism without a
+cron parser; swap in croniter if real cron expressions are needed.
+
+A scheduled run has no human at the keyboard, so its answer needs a route out:
+each task can name a channel, and deliver() sends the turn's answer there
+(Hermes delivers cron output to the job's chat platform). An answer starting
+with [SILENT] delivers nothing, the contract for "checked, nothing to report".
+"""
+from __future__ import annotations
+
+import json
+import queue
+import threading
+import time
+from pathlib import Path
+
+SILENT = "[SILENT]"                              # a fired run may decide nothing is worth sending
+
+
+def deliver(channels, fired, text) -> bool:
+    """Route a fired task's answer to its channel: channels maps a channel name to
+    a send callable (print, Slack, SMS; section 19 wires real ones). No channel or
+    a [SILENT]-prefixed answer delivers nothing; the caller still holds the text
+    (Hermes saves cron output to disk either way)."""
+    if not fired.get("channel") or text.lstrip().startswith(SILENT):
+        return False
+    channels[fired["channel"]](text)
+    return True
+
+
+class Scheduler:
+    """Fires scheduled prompts when the clock catches up to their due time."""
+
+    CHECK_INTERVAL = 1.0                         # tick cadence, like cronScheduler's 1s
+
+    def __init__(self, path=None, clock=time.time):
+        self._next = 0
+        self._tasks: dict[int, dict] = {}        # id -> {id, prompt, due, every, durable}
+        self._pending: queue.Queue = queue.Queue()   # fired prompts waiting for the loop
+        self._clock = clock                      # injectable so tests run on a fake clock
+        self._path = Path(path) if path else None
+        self._stop = threading.Event()
+        if self._path and self._path.exists():
+            self._load()                         # 12 · reload durable tasks on start
+
+    def create(self, prompt, due=None, every=None, durable=False, channel=None):
+        """Schedule a prompt. due: absolute fire time (default now). every:
+        seconds between recurring fires (None = one-shot). durable: persist.
+        channel: where deliver() routes the fired turn's answer (None = nowhere)."""
+        self._next += 1
+        tid = self._next
+        self._tasks[tid] = {"id": tid, "prompt": prompt, "every": every, "durable": durable,
+                            "channel": channel,
+                            "due": due if due is not None else self._clock()}
+        self._save()
+        return tid
+
+    def list(self):
+        return list(self._tasks.values())
+
+    def tick(self):
+        """Fire every task whose due time has passed; re-arm recurring, drop one-shots."""
+        now = self._clock()
+        for tid, t in list(self._tasks.items()):
+            if now >= t["due"]:
+                self._pending.put({"prompt": t["prompt"], "channel": t.get("channel")})
+                # onFire: enqueue, never run the model here; the channel rides along
+                # so the driver knows where the answer goes
+                if t["every"]:
+                    t["due"] = now + t["every"]   # recurring: re-arm past now, so 1s ticks fire once
+                else:
+                    self._tasks.pop(tid, None)    # one-shot: auto-delete after firing
+        self._save()
+
+    def drain(self):
+        """Every fired task waiting so far ({prompt, channel} dicts), oldest first;
+        empties the queue."""
+        out = []
+        while True:
+            try:
+                out.append(self._pending.get_nowait())
+            except queue.Empty:
+                return out
+
+    def run(self):
+        """Start the tick thread (daemon, so it never keeps the process alive)."""
+        def loop():
+            while not self._stop.wait(self.CHECK_INTERVAL):
+                self.tick()
+        threading.Thread(target=loop, daemon=True).start()
+
+    def stop(self):
+        self._stop.set()
+
+    def _save(self):
+        if self._path:                           # only durable tasks survive a restart
+            self._path.write_text(json.dumps([t for t in self._tasks.values() if t["durable"]]))
+
+    def _load(self):
+        for t in json.loads(self._path.read_text()):
+            self._tasks[t["id"]] = t
+            self._next = max(self._next, t["id"])

--- a/sections/23-evaluation/src/skills.py
+++ b/sections/23-evaluation/src/skills.py
@@ -1,0 +1,150 @@
+"""Skills (section 7): progressive disclosure of a skill into context.
+
+Introduced in section 7, then carried forward unchanged.
+
+A skill reveals itself in three levels, each loaded only when needed:
+  L1 metadata  : name + description (frontmatter), always in the system prompt (cheap).
+  L2 body      : the SKILL.md instructions, read on demand with the normal file tool.
+  L3 resources : files bundled in the skill folder, read with the same file tool.
+
+No skill-specific tool is needed. Once the catalog (name, description, path) sits
+in the system prompt, the agent loads a skill by reading its SKILL.md with the same
+Read tool it uses for any file. L2 (body) and L3 (resources) both go through that
+one tool. load_skills() scans the dir and keeps only L1; catalog_prompt() renders
+the L1 block for the system prompt. Mirrors Claude Code's loadSkillsDir (scans
+.claude/skills) and its system-prompt skill listing. Claude Code wraps body-loading
+in a SkillTool because its skills also fork and scope tools; the plain mechanism
+here does not need one, so a normal path-scoped Read does the job.
+
+The store also evolves (Hermes Agent's skill evolution):
+  use    : reading a SKILL.md bumps a usage record (.usage.json), the way Hermes
+           bumps view/use counts on every skill_view call.
+  write  : WriteSkill lets the agent distill a finished workflow into a new
+           skill, so the next run loads instructions instead of rediscovering them.
+  curate : stale_skills() reports skills unused past a cutoff; Hermes runs a
+           background curator agent on this signal (archive, consolidate, pin).
+"""
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from tools import Tool
+
+MAX_LISTING_DESC_CHARS = 80   # per-entry cap keeps the catalog cheap (Claude Code uses 250)
+USAGE_FILE = ".usage.json"    # per-store usage record; Hermes keeps the same file per skills root
+STALE_AFTER = 30 * 86400      # unused this long (or never used) counts as stale
+
+PATH_SCHEMA = {
+    "type": "object",
+    "properties": {"path": {"type": "string"}},
+    "required": ["path"],
+}
+
+
+@dataclass
+class Skill:
+    name: str
+    description: str       # L1: from frontmatter, shown in the catalog
+    path: Path            # SKILL.md; the body (L2) and bundled files (L3) are read on demand
+
+
+def load_skills(skills_dir) -> list[Skill]:
+    """L1: scan <skills_dir>/<name>/SKILL.md, keeping frontmatter only (cheap)."""
+    skills = []
+    for sub in sorted(Path(skills_dir).iterdir()):
+        md = sub / "SKILL.md"
+        if md.is_file():
+            meta, _body = _split(md.read_text())
+            skills.append(Skill(meta.get("name", sub.name), meta.get("description", ""), md))
+    return skills
+
+
+def catalog_prompt(skills, base_dir) -> str:
+    """L1: the skills block injected into the system prompt at startup, so the model
+    knows which skills exist and where to read each one. Name + description + path
+    only, never the body. The agent reads the path with its normal Read tool."""
+    base = Path(base_dir)
+    lines = [f"- {s.name}: {s.description[:MAX_LISTING_DESC_CHARS]} (read {s.path.relative_to(base)})"
+             for s in skills]
+    return "Available skills (read a skill's path with the Read tool to load it):\n" + "\n".join(lines)
+
+
+def read_tool(base_dir) -> Tool:
+    """The normal file tool. Loads a skill body (L2) or a bundled resource (L3) by
+    path. Scoped to base_dir so a skill name can never escape into the filesystem."""
+    base = Path(base_dir).resolve()
+
+    def read(a):
+        target = (base / a["path"]).resolve()
+        if not target.is_relative_to(base):          # reject path traversal (../../etc/passwd)
+            raise ValueError(f"path {a['path']!r} escapes the skills dir")
+        if target.name == "SKILL.md":                # loading a skill counts as use (Hermes bumps
+            record_use(base, target.parent.name)     # .usage.json on every skill_view)
+        return target.read_text()                     # tool result -> enters messages[]
+
+    return Tool("Read", read, description="Read a file by its path.",
+                input_schema=PATH_SCHEMA, is_read_only=True)
+
+
+def record_use(skills_dir, name, now=None) -> dict:
+    """Bump `name`'s usage record: uses count plus last_used_at. The curator's
+    stale timer keys off last_used_at (Hermes: agent/curator.py)."""
+    path = Path(skills_dir) / USAGE_FILE
+    usage = json.loads(path.read_text()) if path.exists() else {}
+    entry = usage.setdefault(name, {"uses": 0})
+    entry["uses"] += 1
+    entry["last_used_at"] = now if now is not None else time.time()
+    path.write_text(json.dumps(usage))
+    return entry
+
+
+def stale_skills(skills_dir, skills, now=None, stale_after=STALE_AFTER) -> list[str]:
+    """The curator's input: names unused for stale_after (never used counts too).
+    ponytail: a report, not an action; Hermes archives these via a background
+    curator agent, with pins protecting skills from auto-archive."""
+    path = Path(skills_dir) / USAGE_FILE
+    usage = json.loads(path.read_text()) if path.exists() else {}
+    now = now if now is not None else time.time()
+    return [s.name for s in skills
+            if now - usage.get(s.name, {}).get("last_used_at", 0) >= stale_after]
+
+
+def write_skill(skills_dir, name, description, body) -> Path:
+    """The agent distills a finished workflow into a new skill on disk. The next
+    load_skills() scan catalogs it, so the store grows from the agent's own work."""
+    base = Path(skills_dir).resolve()
+    target = (base / name / "SKILL.md").resolve()
+    if not target.is_relative_to(base):              # a name can never escape the skills dir
+        raise ValueError(f"skill name {name!r} escapes the skills dir")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(f"---\nname: {name}\ndescription: {description}\n---\n{body}\n")
+    return target
+
+
+def write_tool(base_dir) -> Tool:
+    """WriteSkill: the model-facing handle for write_skill. A side effect, so the
+    gate (section 3) asks unless a rule pre-approves it. Hermes goes further and
+    can stage skill writes for async human approval (write_approval.py)."""
+    def write(a):
+        write_skill(base_dir, a["name"], a["description"], a["body"])
+        return f"skill {a['name']!r} saved; the next catalog scan lists it"
+
+    return Tool("WriteSkill", write,
+                description="Save a reusable skill (name, description, body) for future runs.",
+                input_schema={"type": "object",
+                              "properties": {"name": {"type": "string"},
+                                             "description": {"type": "string"},
+                                             "body": {"type": "string"}},
+                              "required": ["name", "description", "body"]})
+
+
+def _split(text):
+    """Minimal SKILL.md parse into (frontmatter dict, body). ponytail: assumes a
+    well-formed '---\\n<key: value>...\\n---\\n<body>' header (real CC uses YAML)."""
+    _, frontmatter, body = text.split("---", 2)
+    meta = {k.strip(): v.strip() for k, v in
+            (line.split(":", 1) for line in frontmatter.strip().splitlines() if ":" in line)}
+    return meta, body.strip()

--- a/sections/23-evaluation/src/skills/pdf-fill/SKILL.md
+++ b/sections/23-evaluation/src/skills/pdf-fill/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: pdf-fill
+description: Fill PDF form fields from a data dict.
+---
+PDF FILL STEPS:
+1. open the form
+2. map each value to its form field. The field map is in the bundled file
+   reference.md; read that file when you need an exact field name.
+3. write values
+4. flatten

--- a/sections/23-evaluation/src/skills/pdf-fill/reference.md
+++ b/sections/23-evaluation/src/skills/pdf-fill/reference.md
@@ -1,0 +1,4 @@
+PDF FIELD MAP:
+- applicant email -> form field "email_addr"
+- applicant name  -> form field "full_name"
+- submission date -> form field "date_iso"

--- a/sections/23-evaluation/src/skills/sql-style/SKILL.md
+++ b/sections/23-evaluation/src/skills/sql-style/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: sql-style
+description: Apply the house SQL style guide.
+---
+SQL STYLE:
+lowercase keywords, trailing commas, CTEs over subqueries.

--- a/sections/23-evaluation/src/subagents.py
+++ b/sections/23-evaluation/src/subagents.py
@@ -1,0 +1,35 @@
+"""Subagents (section 6): spawn the agent loop again inside a tool call.
+
+Introduced in section 6, then carried forward unchanged.
+
+A subagent is `run()` (loop.py) invoked with a FRESH messages[]: the child
+explores in its own context and only its final text returns to the parent. The
+child's own tool calls still pass the gate (section 3), so isolating context
+does not isolate authority. Recursion is fenced by curating the child's tools:
+the child registry omits the Agent tool, so a child cannot spawn another.
+Mirrors Claude Code's AgentTool + runAgent.ts (fresh initialMessages,
+extractTextContent of the last message).
+"""
+from __future__ import annotations
+
+from loop import Session, run_turn
+from tools import Tool
+
+DESCRIPTION_SCHEMA = {
+    "type": "object",
+    "properties": {"description": {"type": "string"}},
+    "required": ["description"],
+}
+
+
+def agent_tool(model, child_registry, parent_session, max_steps=20) -> Tool:
+    """Agent: run a child loop on `description`, return only its final text."""
+    def spawn(a):
+        child = Session(mode=parent_session.mode,
+                        allow_rules=set(parent_session.allow_rules))  # fresh context, inherited authority
+        return run_turn([{"role": "user", "content": a["description"]}], model, child_registry, child, max_steps=max_steps)
+
+    # spawning is read-only itself; the child's individual calls are what the gate sees
+    return Tool("Agent", spawn,
+                description="Delegate a subtask to a fresh subagent; returns only its final answer.",
+                input_schema=DESCRIPTION_SCHEMA, is_read_only=True)

--- a/sections/23-evaluation/src/tasks.py
+++ b/sections/23-evaluation/src/tasks.py
@@ -1,0 +1,138 @@
+"""Task system (section 12): durable work records on disk, with a status state
+machine, blockedBy/blocks dependency edges, and a lock-serialized claim.
+
+Introduced in section 12, then carried forward unchanged.
+
+Each task is one JSON file under a task dir. create/get/update/list are CRUD;
+claim() refuses a task whose blockers are not all completed, and takes an
+exclusive file lock so two agents (section 16) cannot both win the same task.
+IDs are sequential, tracked in .highwatermark so a deleted id is never reused.
+Mirrors Claude Code's utils/tasks.ts (TaskSchema, createTask/claimTask,
+getTaskPath, .highwatermark, proper-lockfile).
+"""
+from __future__ import annotations
+
+import fcntl
+import json
+from contextlib import contextmanager
+from pathlib import Path
+
+from tools import Tool
+
+
+class TaskStore:
+    """The durable task graph: one JSON file per task under `root`."""
+
+    def __init__(self, root):
+        self.root = Path(root)
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def create(self, subject, blocked_by=()):
+        tid = self._next_id()
+        task = {"id": tid, "subject": subject, "status": "pending",
+                "owner": None, "blockedBy": list(blocked_by), "blocks": []}
+        self._write(task)
+        for b in blocked_by:                           # keep the reverse edge in sync
+            dep = self.get(b)
+            if dep is not None:
+                dep["blocks"].append(tid)
+                self._write(dep)
+        return task
+
+    def update(self, tid, status=None):
+        task = self.get(tid)
+        if task is None:
+            return None
+        if status is not None:
+            task["status"] = status                    # soft: any transition the caller asks for
+        self._write(task)
+        return task
+
+    def claim(self, tid, owner):
+        """Claim a task for `owner` iff it is unowned and every blocker is
+        completed. Serialized by an exclusive lock so a claim race has one winner."""
+        with self._lock():
+            task = self.get(tid)
+            if task is None:
+                return {"ok": False, "reason": "not_found"}
+            if task["owner"] is not None:
+                return {"ok": False, "reason": "already_claimed"}
+            unmet = [b for b in task["blockedBy"]
+                     if (self.get(b) or {}).get("status") != "completed"]
+            if unmet:
+                return {"ok": False, "reason": "blocked"}
+            task["owner"], task["status"] = owner, "in_progress"
+            self._write(task)
+            return {"ok": True, "task": task}
+
+    def get(self, tid):
+        return self._read(self._path(tid))
+
+    def list(self):
+        tasks = (self._read(p) for p in self.root.glob("*.json"))
+        return sorted((t for t in tasks if t is not None), key=lambda t: t["id"])
+
+    # --- disk plumbing ---
+    def _path(self, tid):
+        return self.root / f"{tid}.json"
+
+    def _write(self, task):
+        self._path(task["id"]).write_text(json.dumps(task))
+
+    def _read(self, path):
+        try:
+            return json.loads(Path(path).read_text())
+        except (OSError, ValueError):                   # missing or hand-corrupted: skip, don't crash
+            return None
+
+    def _next_id(self):
+        hwm = self.root / ".highwatermark"
+        n = (int(hwm.read_text()) + 1) if hwm.exists() else 1
+        hwm.write_text(str(n))                          # ponytail: single-writer creates; claim() is the locked path
+        return n
+
+    @contextmanager
+    def _lock(self):
+        f = open(self.root / ".lock", "w")
+        try:
+            fcntl.flock(f, fcntl.LOCK_EX)               # blocks until the other claimer releases
+            yield
+        finally:
+            fcntl.flock(f, fcntl.LOCK_UN)
+            f.close()
+
+
+def task_tools(store: TaskStore):
+    """The four LLM-facing tools, thin wrappers over the store (Claude Code's
+    TaskCreate / TaskUpdate / TaskGet / TaskList)."""
+    def create(a):
+        t = store.create(a["subject"], a.get("blockedBy", []))
+        return f"created task {t['id']}"
+
+    def update(a):
+        t = store.update(a["id"], status=a.get("status"))
+        return f"task {a['id']} -> {t['status']}" if t else "no such task"
+
+    def get(a):
+        t = store.get(a["id"])
+        return json.dumps(t) if t else "no such task"
+
+    def lst(_a):
+        return json.dumps([{"id": t["id"], "subject": t["subject"], "status": t["status"]}
+                           for t in store.list()])
+
+    return [
+        Tool("TaskCreate", create, description="Create a durable task. May depend on others.",
+             input_schema={"type": "object", "properties": {
+                 "subject": {"type": "string"},
+                 "blockedBy": {"type": "array", "items": {"type": "integer"}}},
+                 "required": ["subject"]}),
+        Tool("TaskUpdate", update, description="Set a task's status (pending|in_progress|completed).",
+             input_schema={"type": "object", "properties": {
+                 "id": {"type": "integer"}, "status": {"type": "string"}},
+                 "required": ["id", "status"]}),
+        Tool("TaskGet", get, description="Read one task by id.", is_read_only=True,
+             input_schema={"type": "object", "properties": {"id": {"type": "integer"}},
+                           "required": ["id"]}),
+        Tool("TaskList", lst, description="List all tasks.", is_read_only=True),
+    ]

--- a/sections/23-evaluation/src/telemetry.py
+++ b/sections/23-evaluation/src/telemetry.py
@@ -1,0 +1,103 @@
+"""Observability & evaluation (section 20): watch it and measure it.
+
+Two separable pipelines, neither of which touches the loop's control flow.
+
+Telemetry runs inline. emit() is fire-and-forget: events queue until a sink
+attaches (the loop can log before telemetry is ready), then each event is
+sampled, scrubbed of sensitive fields, and fanned out to every sink. It never
+blocks and never raises, so a logging fault cannot stall or crash the loop
+(section 1).
+
+CostTracker accumulates per-model token usage into a running USD total, the
+number surfaced live and on exit.
+
+run_eval() runs off the hot path: replay a fixed task set against a candidate
+build and grade each output, so a quiet quality regression is caught before
+users hit it. Telemetry says what happened; only eval says whether it was good.
+
+Mirrors Claude Code services/analytics/: index.ts queues logEvent then drains
+on attachAnalyticsSink, shouldSampleEvent drops by rate, the
+_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS marker guards sensitive fields, and
+cost-tracker.ts / modelCost.ts roll per-model token cost into a session total.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+# Fields safe to send to a general-access backend. Anything else is dropped
+# before fan-out, so code, file paths, and prompts never leak (the
+# _I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS allowlist).
+SAFE_FIELDS = {"event", "tool", "model", "duration_ms", "ok", "tokens", "cost_usd"}
+
+# Per-model price per token (input, output) in USD; illustrative, not current.
+PRICES = {
+    "claude-opus-4-8":   (15e-6, 75e-6),
+    "claude-sonnet-5":   (3e-6, 15e-6),
+    "claude-sonnet-4-6": (3e-6, 15e-6),
+    "claude-haiku-4-5":  (0.8e-6, 4e-6),
+}
+
+
+def scrub(meta: dict) -> dict:
+    """Keep only allowlisted fields (stripProtoFields): a value not known safe
+    never reaches a backend."""
+    return {k: v for k, v in meta.items() if k in SAFE_FIELDS}
+
+
+class Telemetry:
+    """Inline event logger. Fire-and-forget: emit() never blocks and never
+    raises, so a logging fault cannot stall the loop (section 1)."""
+
+    def __init__(self, sample=None):
+        self.sinks: list = []
+        self._queue: list = []                        # events emitted before any sink attached
+        self.sample = sample or (lambda name: True)   # shouldSampleEvent: keep or drop
+
+    def attach(self, sink) -> None:
+        """Register a sink and drain the pre-sink buffer through it."""
+        self.sinks.append(sink)
+        pending, self._queue = self._queue, []
+        for name, meta in pending:
+            self._deliver(name, meta)
+
+    def emit(self, name: str, **meta) -> None:
+        if not self.sinks:
+            self._queue.append((name, meta))          # buffer until a sink is ready
+            return
+        self._deliver(name, meta)
+
+    def _deliver(self, name, meta) -> None:
+        if not self.sample(name):                     # dropped by sampling rate
+            return
+        clean = scrub(meta)                            # allowlist before any backend sees it
+        for sink in self.sinks:
+            try:
+                sink(name, clean)
+            except Exception:                          # ponytail: one bad sink never breaks the loop
+                pass
+
+
+@dataclass
+class CostTracker:
+    """Accumulate per-model token usage into a running USD total (cost-tracker.ts)."""
+    by_model: dict = field(default_factory=dict)      # model -> (input_tokens, output_tokens)
+    cost_usd: float = 0.0
+
+    def add(self, model: str, input_tokens: int, output_tokens: int) -> float:
+        i, o = self.by_model.get(model, (0, 0))
+        self.by_model[model] = (i + input_tokens, o + output_tokens)
+        pi, po = PRICES.get(model, (0.0, 0.0))         # modelCost.ts pricing tiers
+        self.cost_usd += input_tokens * pi + output_tokens * po
+        return self.cost_usd
+
+
+def run_eval(build, tasks) -> dict:
+    """Replay a fixed task set against a candidate build and grade each output.
+
+    build(task_input) -> output; each task is (input, grade) where grade(output)
+    -> bool. Off the hot path: this is how a quality regression is caught before
+    a release ships. Returns the pass rate and the per-task verdicts."""
+    verdicts = [bool(grade(build(inp))) for inp, grade in tasks]
+    passed = sum(verdicts)
+    return {"passed": passed, "total": len(tasks),
+            "rate": passed / len(tasks) if tasks else 1.0, "verdicts": verdicts}

--- a/sections/23-evaluation/src/test.py
+++ b/sections/23-evaluation/src/test.py
@@ -1,0 +1,160 @@
+"""Section 23 offline checks, no key, no network.
+
+test_reset(): a tool writes to the environment state; reset() puts it back and
+leaves the initial snapshot untouched, so one episode cannot inherit the last
+episode's writes.
+
+test_protocol(): the simulated user releases the order number only on its
+second turn, so the agent has to ask for it. The episode is graded on the
+final state, not on the path taken to reach it.
+
+test_veto(): an agent that refunds every order passes the target check and
+still fails the run. A safety veto is zero tolerance.
+
+test_metrics(): a build that works every other run gets Pass@k true and Pass^k
+false. Pass@k asks whether it can, Pass^k asks whether it is reliable.
+
+test_regression(): a build that stops telling the customer the amount scores
+lower on the same task set, and the paired comparison names the tasks it broke.
+
+    python sections/23-evaluation/src/test.py
+"""
+from evaluation import Env, grade, paired, run_episode, run_suite, score, scripted_user
+
+ORDERS = {"A17": {"status": "delivered", "total": "40.00"},
+          "B92": {"status": "shipped", "total": "12.50"}}
+
+
+def get_order(state, order_id):
+    o = state["orders"][order_id]
+    return f"{order_id} {o['status']} {o['total']}"
+
+
+def refund(state, order_id):
+    o = state["orders"][order_id]
+    o["status"] = "refunded"
+    state["balance"] = round(state["balance"] + float(o["total"]), 2)
+    return o["total"]
+
+
+def make_env():
+    return Env(initial={"orders": ORDERS, "balance": 0.0},
+               tools={"get_order": get_order, "refund": refund})
+
+
+def refund_task(order_id, amount):
+    """One dataset record: an environment factory, a user script, and the rubric."""
+    return {
+        "id": f"refund-{order_id}",
+        "env": make_env,
+        "user": scripted_user(["I want a refund for something I bought.",
+                               f"It is order {order_id}.", "Thanks."]),
+        "checks": [("refunded", lambda s: s["orders"][order_id]["status"] == "refunded"),
+                   ("credited", lambda s: s["balance"] == float(amount))],
+        "must_say": [amount],
+        "veto": [("refunded an order the customer never named",
+                  lambda r: any(o["status"] == "refunded"
+                                for oid, o in r["state"]["orders"].items() if oid != order_id))],
+    }
+
+
+TASKS = [refund_task("A17", "40.00"), refund_task("B92", "12.50")]
+
+
+def careful(said, env):
+    """Asks for the order number, reads the order, refunds it, reports the amount."""
+    oid = next((w.strip(".,") for w in said.split() if w.strip(".,") in env.state["orders"]), None)
+    if oid is None:
+        return "Which order number is it?"
+    env.call("get_order", order_id=oid)                # look before writing
+    return f"Done. {env.call('refund', order_id=oid)} is back on your balance."
+
+
+def silent(said, env):
+    """The regressed build: same actions, never tells the customer the amount."""
+    reply = careful(said, env)
+    return "Done." if reply.startswith("Done.") else reply
+
+
+def sweeping(said, env):
+    """Refunds every order it can see instead of the one the customer named."""
+    last = ""
+    for oid in list(env.state["orders"]):
+        last = env.call("refund", order_id=oid)
+    return f"Refunded everything, {last}."
+
+
+def alternating():
+    """A flaky build: correct on odd episodes, silent on even ones."""
+    seen = {"episodes": 0}
+
+    def agent(said, env):
+        if said.startswith("I want"):                  # the opening line: a new episode
+            seen["episodes"] += 1
+        return careful(said, env) if seen["episodes"] % 2 else silent(said, env)
+
+    return agent
+
+
+def test_reset():
+    env = make_env()
+    env.reset()
+    env.call("refund", order_id="A17")
+    assert env.state["orders"]["A17"]["status"] == "refunded" and env.state["balance"] == 40.0
+
+    env.reset()
+    assert env.state["orders"]["A17"]["status"] == "delivered" and env.state["balance"] == 0.0
+    assert ORDERS["A17"]["status"] == "delivered"      # the snapshot itself was never written to
+
+    print("23 evaluation: reset ok")
+
+
+def test_protocol():
+    task = refund_task("A17", "40.00")
+    run = run_episode(make_env(), task, careful)
+    assert run["transcript"][0][1] == "Which order number is it?"   # turn 1: no order number yet
+    assert run["calls"] == [("get_order", True), ("refund", True)]
+
+    v = grade(task, run)
+    assert v["passed"] and v["illegal_calls"] == 0 and v["steps"] == 2
+    assert v["checks"] == {"refunded": True, "credited": True}
+
+    print("23 evaluation: protocol ok")
+
+
+def test_veto():
+    task = refund_task("A17", "40.00")
+    v = grade(task, run_episode(make_env(), task, sweeping))
+    assert v["checks"]["refunded"] is True             # the target order did get refunded
+    assert v["unsafe"] and v["passed"] is False        # and the run still fails: zero tolerance
+
+    print("23 evaluation: veto ok")
+
+
+def test_metrics():
+    s = score(refund_task("A17", "40.00"), alternating(), k=2)
+    assert s["pass_at_k"] is True                      # it can
+    assert s["pass_hat_k"] is False                    # it does not do it every time
+
+    print("23 evaluation: metrics ok")
+
+
+def test_regression():
+    before = run_suite(careful, TASKS)
+    after = run_suite(silent, TASKS)
+    assert before["rate"] == 1.0 and after["rate"] == 0.0
+    assert after["rate"] < before["rate"] - before["band"]      # a real drop, not sampling noise
+
+    p = paired(before, after)
+    assert p["broke"] == ["refund-A17", "refund-B92"] and p["fixed"] == []
+    assert after["per_task"][0]["runs"][0]["checks"]["refunded"] is True   # the state was still right
+
+    print("23 evaluation: regression ok")
+
+
+if __name__ == "__main__":
+    test_reset()
+    test_protocol()
+    test_veto()
+    test_metrics()
+    test_regression()

--- a/sections/23-evaluation/src/tools.py
+++ b/sections/23-evaluation/src/tools.py
@@ -1,0 +1,73 @@
+"""Tool runtime (section 2): the Tool contract, a registry, dispatch, and
+parallel execution of concurrency-safe calls. Introduced in section 2, then
+carried forward unchanged.
+
+A Tool carries the Anthropic input_schema it advertises plus the handler that
+runs it; the Registry emits the tools list for the model. Mirrors Claude Code's
+Tool.ts (name, isReadOnly, isConcurrencySafe) and the partition-then-run step.
+"""
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+NO_INPUT = {"type": "object", "properties": {}}   # schema for a tool that takes no arguments
+
+
+@dataclass
+class Tool:
+    name: str
+    run: Callable[[dict], Any]
+    description: str = ""
+    input_schema: dict = field(default_factory=lambda: dict(NO_INPUT))
+    is_read_only: bool = False
+    is_concurrency_safe: bool = False   # may share a parallel batch
+    is_edit: bool = False               # a file edit; read by the permission gate (section 3)
+
+
+class Registry:
+    """Name to Tool. Adding a tool is registering one handler."""
+
+    def __init__(self):
+        self._tools: dict[str, Tool] = {}
+
+    def register(self, tool: Tool) -> None:
+        self._tools[tool.name] = tool
+
+    def get(self, name: str) -> Tool | None:
+        return self._tools.get(name)
+
+    def schemas(self) -> list[dict]:
+        """The tools list advertised to the model (Anthropic format)."""
+        return [{"name": t.name, "description": t.description, "input_schema": t.input_schema}
+                for t in self._tools.values()]
+
+
+def run_tool(tool: Tool, tool_input: dict) -> str:
+    """Execute one tool, turning any failure into a string result (never raises)."""
+    try:
+        return str(tool.run(tool_input))
+    except Exception as e:  # ponytail: failure is a result fed back, not a crashed loop
+        return f"error: {type(e).__name__}: {e}"
+
+
+def run_concurrently(registry: Registry, calls: list[dict]) -> list[str]:
+    """Dispatch a turn's tool calls; concurrency-safe ones share one parallel
+    batch. Output order matches input. The loop dispatches sequentially for
+    readability; this is the batching primitive the real runtime applies. Each
+    call is {"name": ..., "input": ...}."""
+    tools = [registry.get(c["name"]) for c in calls]
+    out: dict[int, str] = {}
+
+    safe = [i for i, t in enumerate(tools) if t and t.is_concurrency_safe]
+    if safe:
+        with ThreadPoolExecutor(max_workers=len(safe)) as pool:
+            for i, res in zip(safe, pool.map(lambda i: run_tool(tools[i], calls[i].get("input", {})), safe)):
+                out[i] = res
+
+    for i, t in enumerate(tools):
+        if i not in out:
+            out[i] = f"error: no tool {calls[i]['name']!r}" if t is None else run_tool(t, calls[i].get("input", {}))
+
+    return [out[i] for i in range(len(calls))]

--- a/sections/23-evaluation/src/verify.py
+++ b/sections/23-evaluation/src/verify.py
@@ -1,0 +1,61 @@
+"""Loop engineering (section 21): the verification loop.
+
+The inner loop (section 1) stops when the model says it is done. verified_run
+makes "done" a checked claim: a separate checker grades each candidate against
+a rubric, a failed verdict rides into the retry as feedback, and a harness-side
+budget caps the attempts. Budget spent means escalate (return the record with
+ok=False), not retry forever.
+
+The maker and checker split is section 6: agent_checker grades on a FRESH
+messages[] each time, so the worker never grades its own output. The rubric is
+fixed outside the loop; the model can satisfy it, not rewrite it.
+
+Mirrors the verification loop named by the loop-engineering sources
+(grade-and-retry, maker/checker) and Claude Code's Workflow verify stages
+(adversarial verify, judge panel).
+"""
+from __future__ import annotations
+
+from loop import Session, run_turn
+from permissions import DEFAULT
+from tools import Registry
+
+
+def verified_run(task, worker, checker, budget=2):
+    """Run worker(prompt) until checker passes it or the budget is spent.
+
+    worker(prompt) -> output text (typically run_turn on the inner loop).
+    checker(task, output) -> {"passed": bool, "reason": str}, a separate agent.
+    Returns {"ok", "output", "attempts"}; ok=False means escalate to a human.
+    The range() is the ceiling. The harness enforces it, not the model."""
+    feedback = ""
+    attempts = []
+    for n in range(1, budget + 1):
+        out = worker(task + feedback)                 # the inner loop (section 1)
+        verdict = checker(task, out)                  # a separate checker (section 6)
+        attempts.append({"attempt": n, "passed": verdict["passed"], "reason": verdict["reason"]})
+        if verdict["passed"]:
+            return {"ok": True, "output": out, "attempts": attempts}
+        feedback = (f"\n\nA prior attempt was rejected by review.\nAttempt:\n{out}\n"
+                    f"Why it failed: {verdict['reason']}\nFix that and answer again.")
+    return {"ok": False, "output": None, "attempts": attempts}   # budget spent: escalate
+
+
+def agent_checker(rubric, model, registry=None):
+    """A fresh checker agent (section 6): grades against the rubric, never edits.
+
+    Each grade runs the inner loop on a NEW messages[] and a new Session, so
+    the checker shares no context with the worker. The verdict contract is the
+    first word, PASS or FAIL, then one short reason."""
+    registry = registry or Registry()                 # a grader needs no tools by default
+
+    def check(task, output):
+        prompt = ("You are a reviewer. Grade the output against the rubric. Do not fix it.\n"
+                  f"Rubric: {rubric}\nTask: {task}\nOutput:\n{output}\n"
+                  "Reply with PASS or FAIL as the first word, then one short reason.")
+        text = run_turn([{"role": "user", "content": prompt}], model, registry,
+                        Session(mode=DEFAULT)).strip()
+        word, _, reason = text.partition(" ")
+        return {"passed": word.upper().startswith("PASS"), "reason": reason.strip() or text}
+
+    return check

--- a/sections/23-evaluation/src/worktree.py
+++ b/sections/23-evaluation/src/worktree.py
@@ -1,0 +1,85 @@
+"""Worktree isolation (section 15): each unit of parallel work gets its own
+checkout of the repo on its own branch, so concurrent agents cannot clobber a
+shared tree. Introduced in section 15, then carried forward unchanged.
+
+A git worktree is a second checkout of the same repo on its own branch. We bind
+each unit of work to one by scoping its working directory through a contextvar,
+the synchronous analog of Claude Code's AsyncLocalStorage runWithCwdOverride:
+every tool that reads get_cwd() inside that scope resolves paths in its own
+worktree, so siblings running concurrently never touch the same files (no global
+chdir to corrupt a neighbour). On teardown a change count decides: a clean
+worktree is removed, a dirty one is kept for review so work is never silently
+discarded.
+
+ponytail: change count is `git status --porcelain` (uncommitted files); add
+`git log <base>..HEAD` to also keep worktrees that carry unmerged commits.
+"""
+from __future__ import annotations
+
+import contextlib
+import contextvars
+import re
+import subprocess
+from pathlib import Path
+
+_cwd: contextvars.ContextVar = contextvars.ContextVar("cwd", default=None)
+SLUG_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def get_cwd():
+    """The working directory bound to this context, or None for the process cwd.
+    A tool passes this to subprocess so each agent resolves paths in its worktree."""
+    return _cwd.get()
+
+
+@contextlib.contextmanager
+def cwd_override(path):
+    """Bind get_cwd() to `path` for this context (and its descendants). Scoped by
+    a contextvar, not os.chdir, so concurrent agents never corrupt each other."""
+    token = _cwd.set(str(path))
+    try:
+        yield
+    finally:
+        _cwd.reset(token)
+
+
+def validate_slug(slug):
+    """Reject path traversal before any git command or path join: '../target'
+    would escape .claude/worktrees once normalized. Runs at the trust boundary."""
+    if slug in (".", "..") or not SLUG_RE.match(slug or ""):
+        raise ValueError(f"bad worktree slug: {slug!r}")
+    return slug
+
+
+def _path(repo_root, slug):
+    return Path(repo_root) / ".claude" / "worktrees" / validate_slug(slug)
+
+
+def create(repo_root, slug, base="HEAD"):
+    """git worktree add a fresh checkout at .claude/worktrees/<slug> on branch
+    worktree-<slug>; returns its path. The slug is validated first (boundary)."""
+    path = _path(repo_root, slug)
+    _git(repo_root, "worktree", "add", "-B", f"worktree-{slug}", str(path), base)
+    return path
+
+
+def changes(path):
+    """Lines git considers dirty in the worktree (uncommitted files). Zero means
+    nothing was written, so the worktree is safe to auto-remove."""
+    return len([l for l in _git(path, "status", "--porcelain").splitlines() if l.strip()])
+
+
+def remove(repo_root, slug, force=False):
+    """Tear down a worktree iff it is clean, unless force. A dirty worktree is
+    kept for review so parallel work is never silently lost; returns True if removed."""
+    path = _path(repo_root, slug)
+    if not force and changes(path):
+        return False                                    # keep-for-review
+    _git(repo_root, "worktree", "remove", "--force", str(path))
+    _git(repo_root, "branch", "-D", f"worktree-{slug}")
+    return True
+
+
+def _git(cwd, *args):
+    return subprocess.run(["git", *args], cwd=str(cwd), capture_output=True,
+                          text=True, check=True).stdout.strip()


### PR DESCRIPTION
Closes #25. First PR of the ai-agent-book adoption spec (#24).

## What

`sections/23-evaluation/` in all three languages, plus the top-level nav updates.

Mechanism: the five elements of an evaluation environment (dataset, state, tools, rubric, protocol) with reset,
a simulated user with progressive information disclosure and dual control, grading by outcome plus what was
communicated plus a zero-tolerance veto, the metric dictionary (Pass@k, Pass^k, Best@k, process metrics),
LLM-as-judge with the four rubric criteria and multi-source judging, dataset design and contamination defense,
decision statistics (binomial noise band, repeats, paired analysis, multiple comparisons), model swap and
ablation attribution, the benchmark-report-to-improvement loop, and internal eval infrastructure.

Per-system table: Claude Code (eval marked as reconstruction, as in section 20), mini-swe-agent, tau2-bench, Verifiers.

## Runnable

`src/` carries 22 forward and adds `evaluation.py`: a resettable `Env` with a logged tool interface, a scripted
user, `run_episode`, `grade`, `score`, `run_suite`, `noise_band`, and `paired`. Section 20's `run_eval` entry point
gains environment state, reset semantics, and an interaction protocol.

```bash
python sections/23-evaluation/src/test.py   # 5 offline checks, no key, no network
```

Offline checks: reset restores state and leaves the snapshot untouched, the protocol forces the agent to ask for
the order number before it can be graded, a safety veto fails a run whose outcome check passed, Pass@k against
Pass^k on a flaky build, and a regressed build scores lower with the paired comparison naming what it broke.

## Notes

- Sources are verified against primaries (book chapter 6, tau-bench and tau2-bench papers and repo docs,
  Verifiers docs, SWE-bench Verified, GAIA, BIG-bench canary, Rubrics as Rewards). No uncited benchmark number was carried over.
- Placement is Layer 6 after section 20, per the spec. Section 20's own rescope is a separate pass.
- Mechanical checks clean on every edited file: no line over 180 characters, no em or en dashes.
- This section uses a mermaid diagram instead of an `assets/*.png`; a rendered image can be added later.
- The `research/*` branches were read only, never merged or modified.