### PR TITLE
docs: gate skill growth in section 7

### DIFF
--- a/sections/07-skills/README.md
+++ b/sections/07-skills/README.md
@@ -37,19 +37,9 @@ Skills use progressive disclosure. The model sees only enough information to dec
 No skill-specific tool is needed. Once the catalog names each skill and its path,
 the agent loads a skill by reading its file with the normal Read tool. L2 and L3 are both just file reads.
 
-Three details decide whether disclosure works.
-
-- **A description is a routing condition, not a summary.** The catalog line is all the model sees before it commits.
-  Write when to use the skill and when not to, with a counter-example. A line that only names the topic leaves the model guessing.
-- **Catalog placement is a choice.** The listing can ride in the system prompt, or it can live inside the description of one activation tool.
-  The open standard allows both. A system prompt listing costs prefix tokens in every session. An activation tool keeps the prefix smaller and moves the listing into a tool schema.
-- **Disclosure is cheap, not free.** The catalog is still prefilled once, and a loaded body still occupies the window until compaction.
-  After the first turn the prefix is cached, so the recurring cost is small. The budget question is how many skills the catalog carries, not how often bodies are read.
-
-The same pattern now runs under the tool layer. Instead of putting every tool schema in the prefix, the harness keeps names and one-line descriptions,
-and the model pulls full schemas on demand. OpenAI's Responses API marks tools with `defer_loading`, Claude Code applies tool search to MCP servers,
-and Codex CLI ranks its tool list with BM25. The loaded schema appends at the end of the context, so the cached prefix survives.
-Skills were the first place this repo met progressive disclosure. It is now native to tool definitions too (section 2).
+The description does most of the work. It is a routing condition, not a summary.
+That one line is all the model sees before it decides. So say when to use the skill, and say when not to.
+Add one counter-example. A line that only names the topic makes the model guess.
 
 ### New: scan the skills and list them in the prompt
 
@@ -126,28 +116,6 @@ def stale_skills(skills_dir, skills, now=None, stale_after=STALE_AFTER) -> list[
 - `stale_skills` is a report, not an action. Deciding what to do with it is a curator's job; Hermes runs a background curator agent on the same signal (archive, consolidate, pin).
 - The data flow is a loop across runs: read bumps `.usage.json`, the curator reads it, the catalog reflects what survives, and `WriteSkill` feeds new entries in.
 
-**When to write.** The demo promotes on first success: one finished workflow, one `WriteSkill` call, and the next scan catalogs it.
-That is the smallest rule that shows the loop, and it is what the runnable code does.
-
-The book sets a higher bar. A skill becomes a formal capability only when the evidence repeats, at least two non-failed runs showing the same pattern,
-and only after a validation step that does not come from the run that proposed it. Voyager applies the same rule: a skill enters the library after the environment confirms it.
-Before writing, search the store and patch a near match instead of creating a duplicate. Keep the pitfalls the run hit in the body, not just the path that worked.
-Both positions hold. First success teaches the mechanism and keeps a demo short. A support threshold is what stops a store of hundreds from filling with one-off notes.
-
-A candidate step reconciles them. The distilled workflow lands as a candidate, not as a catalog entry, and is drafted, tested, evaluated, and revised before promotion.
-Anthropic's Skill Creator runs that loop. In this section's code it would be a staging folder that `load_skills` skips until a curator promotes it.
-
-**Consolidation runs offline.** The curator is a scheduled pass, not a live one. The book calls it sleep-time learning and gives it five steps:
-
-1. **Trigger.** A schedule, an idle window, or a store that crossed a size threshold.
-2. **Orient.** Snapshot the store first, so every later step can be rolled back.
-3. **Gather and merge.** Read usage and recent runs, fold near-duplicates into one skill, and pull candidates in.
-4. **Validate and approve.** Check merged bodies against the runs that produced them. What fails validation stays out.
-5. **Prune and index.** Archive stale skills by a fixed rule, then rebuild the catalog.
-
-Keeping this offline is the safety boundary. The online loop executes and records. It never edits the store mid-run.
-One lucky run cannot promote itself, and text the agent read from the outside cannot turn into a permanent instruction between turns.
-
 ### How it integrates
 
 The loop does not change. Reading a skill returns a tool result that enters `messages[]`.
@@ -156,6 +124,50 @@ The catalog belongs in the system prompt. The body enters the conversation only 
 
 Because loaded skill text lives in `messages[]`, it can be compacted like any other message when the context fills (section 8).
 Keep skill bodies short and point to files for large references.
+
+### Further reading
+
+None of what follows is in `src/`. It comes from ai-agent-book's account of production agents, plus vendor documentation.
+It is not confirmed behaviour of the two systems in the per-system table.
+
+**What disclosure costs.** Disclosure is cheap, not free. The catalog is still read once at prefill.
+A loaded body still sits in the window until something compacts it. After the first turn the prefix is cached, so the repeat cost is small.
+So the number to watch is how many skills the catalog carries, not how often bodies get read.
+
+**Where the catalog lives.** The listing can sit in the system prompt, which is what `src/` does.
+It can also sit inside the description of one activation tool. The open standard allows both.
+The system prompt version costs prefix tokens in every session. The tool version keeps the prefix smaller.
+
+**Deferred tool loading.** Tools can borrow the same trick. The prefix keeps only tool names and one-line descriptions.
+The model asks for a full schema when it needs one, and that schema is appended at the end of the context.
+The cached prefix is untouched, so nothing before it has to be recomputed.
+Skills were the first place this repo met progressive disclosure. The book reports the same pattern moving into the tool layer (section 2).
+
+**When to write a skill.** The demo here promotes on first success. One workflow finishes, the agent calls `WriteSkill`, and the next scan catalogs it.
+That is the smallest rule that shows the loop, and it is what the runnable code does.
+
+The book sets a higher bar. It treats one run as too little evidence.
+It asks for the same pattern in at least two runs that did not fail, and for a check that does not come from the run that proposed the skill.
+Voyager works the same way: a skill enters the library after the environment confirms it.
+Before writing, search the store. If something close already exists, patch it instead of adding a duplicate.
+Keep the pitfalls the run hit in the body, not just the path that worked.
+
+Both rules are defensible. First success teaches the mechanism and keeps a demo short.
+A support threshold is what stops a store of hundreds from filling with notes used once.
+A candidate step sits between them. The distilled workflow lands as a candidate, not as a catalog entry.
+It gets drafted, tested, evaluated, and revised before promotion. Anthropic's Skill Creator runs that loop.
+In this section's code it would be a staging folder that `load_skills` skips until a curator promotes it.
+
+**Consolidation runs offline.** The curator is a scheduled pass, not a live one. The book calls it sleep-time learning and gives it five steps:
+
+1. **Trigger.** A schedule, an idle window, or a store that grew past a size limit.
+2. **Orient.** Snapshot the store first, so every later step can be rolled back.
+3. **Gather and merge.** Read the usage records and recent runs. Fold near-duplicates into one skill. Pull candidates in.
+4. **Validate and approve.** Check the merged bodies against the runs that produced them. What fails stays out.
+5. **Prune and index.** Archive stale skills by a fixed rule, then rebuild the catalog.
+
+Running this offline is itself a safety boundary. The online loop executes and records. It never edits the store mid-run.
+So one lucky run cannot promote itself, and text the agent read from outside cannot become a permanent instruction between turns.
 
 ---
 
@@ -181,12 +193,14 @@ How each agent describes, triggers, and finds skills.
 - **Body is lost after compaction.** Re-read the skill file or keep the body short.
 - **Path traversal.** The catalog hands the model a path. Scope the Read tool to the skills directory so `../` cannot escape it.
 - **Forked skill loses live context.** Use forked skills only for self-contained work.
-- **Poisoned skill from the supply chain.** An installed third-party skill is outside content that loads as instructions, with more reach than a poisoned web page,
-  because the catalog already vouches for it. Read the body and any bundled scripts before install, pin the version, and review again on update.
-- **Injected text becomes permanent.** A prompt injection in `messages[]` dies with the session. The same text distilled into `SKILL.md` loads on every future run.
-  Never let unreviewed outside content reach `WriteSkill`. Hold new skills as candidates until a separate pass approves them, and never let a skill edit that approval gate.
-- **Use counts overstate learning.** Loading a skill is not following it. A load count says the catalog routed, not that the skill changed the outcome.
-  Track whether a skill fires and whether the run improved as two separate numbers.
+- **Poisoned skill from the supply chain.** An installed third-party skill is outside content, but it loads as instructions.
+  That gives it more reach than a poisoned web page, because the catalog already vouches for it.
+  Read the body and any bundled scripts before install. Pin the version. Review again on update.
+- **Injected text becomes permanent.** A prompt injection in `messages[]` dies with the session. The same text written into `SKILL.md` loads on every later run.
+  So never let unreviewed outside content reach `WriteSkill`. Hold new skills as candidates until a separate pass approves them.
+  Never let a skill edit that approval gate.
+- **Use counts overstate learning.** Loading a skill is not following it. A load count says the catalog routed.
+  It does not say the skill changed the outcome. Track two numbers instead: did the skill fire, and did the run get better.
 
 ---
 
@@ -217,7 +231,6 @@ uv run python sections/07-skills/src/demo.py  # live demo, needs a key
 - [learn-claude-code · s07_skill_loading](https://github.com/shareAI-lab/learn-claude-code): section framing.
 - [ai-agent-book](https://github.com/bojieli/ai-agent-book): `book/chapter2.md`, `book/chapter8.md`, Chinese original canonical.
 - [Agent Skills open standard](https://agentskills.io): catalog placement, system prompt or activation-tool description.
-- Deferred tool loading: OpenAI Responses API tool search (`defer_loading`), Claude Code MCP tool search, Codex CLI `search_tool`.
 - [Claude Code · prompt caching](https://code.claude.com/docs/en/prompt-caching): where a loaded skill body lands and what it costs.
 - [Voyager](https://arxiv.org/abs/2305.16291): a skill enters the library only after the environment verifies it.
 - [Anthropic Skill Creator](https://github.com/anthropics/skills): draft, test, evaluate, revise before promotion.

--- a/sections/07-skills/README.md
+++ b/sections/07-skills/README.md
@@ -37,6 +37,20 @@ Skills use progressive disclosure. The model sees only enough information to dec
 No skill-specific tool is needed. Once the catalog names each skill and its path,
 the agent loads a skill by reading its file with the normal Read tool. L2 and L3 are both just file reads.
 
+Three details decide whether disclosure works.
+
+- **A description is a routing condition, not a summary.** The catalog line is all the model sees before it commits.
+  Write when to use the skill and when not to, with a counter-example. A line that only names the topic leaves the model guessing.
+- **Catalog placement is a choice.** The listing can ride in the system prompt, or it can live inside the description of one activation tool.
+  The open standard allows both. A system prompt listing costs prefix tokens in every session. An activation tool keeps the prefix smaller and moves the listing into a tool schema.
+- **Disclosure is cheap, not free.** The catalog is still prefilled once, and a loaded body still occupies the window until compaction.
+  After the first turn the prefix is cached, so the recurring cost is small. The budget question is how many skills the catalog carries, not how often bodies are read.
+
+The same pattern now runs under the tool layer. Instead of putting every tool schema in the prefix, the harness keeps names and one-line descriptions,
+and the model pulls full schemas on demand. OpenAI's Responses API marks tools with `defer_loading`, Claude Code applies tool search to MCP servers,
+and Codex CLI ranks its tool list with BM25. The loaded schema appends at the end of the context, so the cached prefix survives.
+Skills were the first place this repo met progressive disclosure. It is now native to tool definitions too (section 2).
+
 ### New: scan the skills and list them in the prompt
 
 ```python
@@ -112,13 +126,36 @@ def stale_skills(skills_dir, skills, now=None, stale_after=STALE_AFTER) -> list[
 - `stale_skills` is a report, not an action. Deciding what to do with it is a curator's job; Hermes runs a background curator agent on the same signal (archive, consolidate, pin).
 - The data flow is a loop across runs: read bumps `.usage.json`, the curator reads it, the catalog reflects what survives, and `WriteSkill` feeds new entries in.
 
+**When to write.** The demo promotes on first success: one finished workflow, one `WriteSkill` call, and the next scan catalogs it.
+That is the smallest rule that shows the loop, and it is what the runnable code does.
+
+The book sets a higher bar. A skill becomes a formal capability only when the evidence repeats, at least two non-failed runs showing the same pattern,
+and only after a validation step that does not come from the run that proposed it. Voyager applies the same rule: a skill enters the library after the environment confirms it.
+Before writing, search the store and patch a near match instead of creating a duplicate. Keep the pitfalls the run hit in the body, not just the path that worked.
+Both positions hold. First success teaches the mechanism and keeps a demo short. A support threshold is what stops a store of hundreds from filling with one-off notes.
+
+A candidate step reconciles them. The distilled workflow lands as a candidate, not as a catalog entry, and is drafted, tested, evaluated, and revised before promotion.
+Anthropic's Skill Creator runs that loop. In this section's code it would be a staging folder that `load_skills` skips until a curator promotes it.
+
+**Consolidation runs offline.** The curator is a scheduled pass, not a live one. The book calls it sleep-time learning and gives it five steps:
+
+1. **Trigger.** A schedule, an idle window, or a store that crossed a size threshold.
+2. **Orient.** Snapshot the store first, so every later step can be rolled back.
+3. **Gather and merge.** Read usage and recent runs, fold near-duplicates into one skill, and pull candidates in.
+4. **Validate and approve.** Check merged bodies against the runs that produced them. What fails validation stays out.
+5. **Prune and index.** Archive stale skills by a fixed rule, then rebuild the catalog.
+
+Keeping this offline is the safety boundary. The online loop executes and records. It never edits the store mid-run.
+One lucky run cannot promote itself, and text the agent read from the outside cannot turn into a permanent instruction between turns.
+
 ### How it integrates
 
 The loop does not change. Reading a skill returns a tool result that enters `messages[]`.
 
 The catalog belongs in the system prompt. The body enters the conversation only after the model reads the file. Resource files are read later only if needed.
 
-Because loaded skill text lives in `messages[]`, it can be compacted like any other message when the context fills (section 8). Keep skill bodies short and point to files for large references.
+Because loaded skill text lives in `messages[]`, it can be compacted like any other message when the context fills (section 8).
+Keep skill bodies short and point to files for large references.
 
 ---
 
@@ -144,6 +181,12 @@ How each agent describes, triggers, and finds skills.
 - **Body is lost after compaction.** Re-read the skill file or keep the body short.
 - **Path traversal.** The catalog hands the model a path. Scope the Read tool to the skills directory so `../` cannot escape it.
 - **Forked skill loses live context.** Use forked skills only for self-contained work.
+- **Poisoned skill from the supply chain.** An installed third-party skill is outside content that loads as instructions, with more reach than a poisoned web page,
+  because the catalog already vouches for it. Read the body and any bundled scripts before install, pin the version, and review again on update.
+- **Injected text becomes permanent.** A prompt injection in `messages[]` dies with the session. The same text distilled into `SKILL.md` loads on every future run.
+  Never let unreviewed outside content reach `WriteSkill`. Hold new skills as candidates until a separate pass approves them, and never let a skill edit that approval gate.
+- **Use counts overstate learning.** Loading a skill is not following it. A load count says the catalog routed, not that the skill changed the outcome.
+  Track whether a skill fires and whether the run improved as two separate numbers.
 
 ---
 
@@ -172,3 +215,10 @@ uv run python sections/07-skills/src/demo.py  # live demo, needs a key
   `tools/skills_tool.py` (`skills_list`, `skill_view`), `tools/skill_usage.py`, `hermes_cli/curator.py`, `tools/skills_hub.py`, `tools/skills_ast_audit.py`.
 - [Anthropic Agent Skills best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices): progressive disclosure levels.
 - [learn-claude-code · s07_skill_loading](https://github.com/shareAI-lab/learn-claude-code): section framing.
+- [ai-agent-book](https://github.com/bojieli/ai-agent-book): `book/chapter2.md`, `book/chapter8.md`, Chinese original canonical.
+- [Agent Skills open standard](https://agentskills.io): catalog placement, system prompt or activation-tool description.
+- Deferred tool loading: OpenAI Responses API tool search (`defer_loading`), Claude Code MCP tool search, Codex CLI `search_tool`.
+- [Claude Code · prompt caching](https://code.claude.com/docs/en/prompt-caching): where a loaded skill body lands and what it costs.
+- [Voyager](https://arxiv.org/abs/2305.16291): a skill enters the library only after the environment verifies it.
+- [Anthropic Skill Creator](https://github.com/anthropics/skills): draft, test, evaluate, revise before promotion.
+- Lin et al., [arXiv:2605.30621](https://arxiv.org/abs/2605.30621), via the book: whether an update lands and whether it helps are separate measurements.

--- a/sections/07-skills/README.md
+++ b/sections/07-skills/README.md
@@ -127,8 +127,7 @@ Keep skill bodies short and point to files for large references.
 
 ### Further reading
 
-None of what follows is in `src/`. It comes from ai-agent-book's account of production agents, plus vendor documentation.
-It is not confirmed behaviour of the two systems in the per-system table.
+None of this is in `src/`. It comes from ai-agent-book and vendor docs, and is not confirmed of the systems in the table.
 
 **What the catalog costs.** Progressive disclosure lowers the cost of a large skill store. It does not make it free.
 The catalog sits in the prefix, so it is read once at prefill and re-sent on every turn after that.

--- a/sections/07-skills/README.md
+++ b/sections/07-skills/README.md
@@ -130,30 +130,36 @@ Keep skill bodies short and point to files for large references.
 None of what follows is in `src/`. It comes from ai-agent-book's account of production agents, plus vendor documentation.
 It is not confirmed behaviour of the two systems in the per-system table.
 
-**What disclosure costs.** Disclosure is cheap, not free. The catalog is still read once at prefill.
-A loaded body still sits in the window until something compacts it. After the first turn the prefix is cached, so the repeat cost is small.
+**What the catalog costs.** Progressive disclosure lowers the cost of a large skill store. It does not make it free.
+The catalog sits in the prefix, so it is read once at prefill and re-sent on every turn after that.
+After the first turn that prefix is cached, so re-sending it is cheap.
+A loaded body costs more, and it stays in the window until something compacts it.
 So the number to watch is how many skills the catalog carries, not how often bodies get read.
 
 **Where the catalog lives.** The listing can sit in the system prompt, which is what `src/` does.
 It can also sit inside the description of one activation tool. The open standard allows both.
-The system prompt version costs prefix tokens in every session. The tool version keeps the prefix smaller.
+The trade-off is where the tokens land. In the system prompt they are part of every session's prefix.
+In a tool description the prefix stays smaller, and the model reaches the listing through that tool instead.
 
-**Deferred tool loading.** Tools can borrow the same trick. The prefix keeps only tool names and one-line descriptions.
-The model asks for a full schema when it needs one, and that schema is appended at the end of the context.
-The cached prefix is untouched, so nothing before it has to be recomputed.
+**Deferred tool loading.** Tools can use the same pattern, for the same reason: a schema is large and most turns do not need it.
+The prefix keeps only tool names and one-line descriptions. The model asks for a full schema when it needs one.
+That schema is appended at the end of the context, so the cached prefix is untouched and nothing before it has to be recomputed.
 Skills were the first place this repo met progressive disclosure. The book reports the same pattern moving into the tool layer (section 2).
 
-**When to write a skill.** The demo here promotes on first success. One workflow finishes, the agent calls `WriteSkill`, and the next scan catalogs it.
+**When to write a skill.** Say a run finishes a long workflow correctly for the first time. Should that become a skill?
+The demo here says yes. The workflow finishes, the agent calls `WriteSkill`, and the next scan catalogs it.
 That is the smallest rule that shows the loop, and it is what the runnable code does.
 
-The book sets a higher bar. It treats one run as too little evidence.
-It asks for the same pattern in at least two runs that did not fail, and for a check that does not come from the run that proposed the skill.
-Voyager works the same way: a skill enters the library after the environment confirms it.
-Before writing, search the store. If something close already exists, patch it instead of adding a duplicate.
-Keep the pitfalls the run hit in the body, not just the path that worked.
+**The book's higher bar.** The book says no, because one run is too little evidence.
+It asks for four things before a skill becomes a formal capability:
 
-Both rules are defensible. First success teaches the mechanism and keeps a demo short.
-A support threshold is what stops a store of hundreds from filling with notes used once.
+- The same pattern in at least two runs that did not fail.
+- A check that does not come from the run that proposed the skill. Voyager works this way: a skill enters the library after the environment confirms it.
+- A search of the store first. If something close already exists, patch it instead of adding a duplicate.
+- The pitfalls the run hit, kept in the body, not just the path that worked.
+
+**Which rule to pick.** Both are defensible, because they answer different questions.
+First success teaches the mechanism and keeps a demo short. A support threshold is what stops a store of hundreds from filling with notes used once.
 A candidate step sits between them. The distilled workflow lands as a candidate, not as a catalog entry.
 It gets drafted, tested, evaluated, and revised before promotion. Anthropic's Skill Creator runs that loop.
 In this section's code it would be a staging folder that `load_skills` skips until a curator promotes it.
@@ -166,8 +172,9 @@ In this section's code it would be a staging folder that `load_skills` skips unt
 4. **Validate and approve.** Check the merged bodies against the runs that produced them. What fails stays out.
 5. **Prune and index.** Archive stale skills by a fixed rule, then rebuild the catalog.
 
-Running this offline is itself a safety boundary. The online loop executes and records. It never edits the store mid-run.
-So one lucky run cannot promote itself, and text the agent read from outside cannot become a permanent instruction between turns.
+**Why offline matters.** Running the curator offline is itself a safety boundary. The online loop executes and records.
+It never edits the store mid-run. So one lucky run cannot promote itself,
+and text the agent read from outside cannot become a permanent instruction between turns.
 
 ---
 

--- a/sections/07-skills/README.zh-CN.md
+++ b/sections/07-skills/README.zh-CN.md
@@ -128,35 +128,41 @@ loop 不用改。读取 skill 就是一次普通的工具调用，tool 结果照
 下面这些做法，`src/` 都没有实现。它们来自 ai-agent-book 对正式环境 agent 的梳理，还有一些厂商文档。
 上面各系统表格里的那两套系统，也没有被证实就是这样做的。
 
-**progressive disclosure 的成本。** 它是便宜，不是免费。catalog 在 prefill 阶段还是要被读一次。
-加载的正文也会一直占着 context，直到有东西来压缩它。第一个 turn 之后 prefix 就被缓存住，后面每一次的成本都很低。
+**catalog 要花多少成本：**progressive disclosure 让一个很大的 skill store 变便宜，但没有让它变免费。
+catalog 就在 prefix 里，prefill 时要被读一次，之后每个 turn 都要再送一次。
+第一个 turn 之后那段 prefix 就被缓存住，所以重送的成本很低。
+加载正文比较贵，而且正文会一直占着 context，直到有东西来压缩它。
 所以真正要盯的数字是 catalog 挂了几个 skill，而不是正文被读了几次。
 
-**catalog 放在哪。** 这份列表可以放在 system prompt，`src/` 就是这样做的。
+**catalog 放在哪：**这份列表可以放在 system prompt，`src/` 就是这样做的。
 它也可以塞进某一个启用用 tool 的 description 里，open standard 两种都允许。
-放 system prompt，每个 session 的 prefix 都要付这笔 token；放进 tool，prefix 就小一些。
+差别在这笔 token 算到哪边。放 system prompt，它就是每个 session prefix 的一部分。
+放进 tool description，prefix 就小一些，模型改成透过那个 tool 去看这份列表。
 
-**Deferred tool loading。** tool 也可以学同一招。prefix 里只留 tool 名称和一行描述。
-模型要用到某个 tool 时才去要完整 schema，要来的 schema 接在 context 尾端。
-缓存住的 prefix 完全没被动到，前面的东西都不用重算。
+**Deferred tool loading：**tool 也可以用同一套做法，理由也一样：schema 很大，但大部分 turn 根本用不到。
+prefix 里只留 tool 名称和一行描述，模型要用到某个 tool 时，才去要完整 schema。
+要来的 schema 接在 context 尾端，所以缓存住的 prefix 完全没被动到，前面的东西也都不用重算。
 skill 是这个 repo 第一次碰到 progressive disclosure 的地方；照书上说，同一套做法现在也长到 tool 这一层了（第 2 章）。
 
-**什么时候该写一个 skill。** 这里的 demo 是一次成功就写：一段流程跑完，agent 调用一次 `WriteSkill`，下一次扫描就把它编进 catalog。
+**什么时候该写一个 skill：**假设某一趟运行第一次把一段长流程跑对了，这该不该存成 skill？
+这里的 demo 说该。流程一跑完，agent 就调用一次 `WriteSkill`，下一次扫描把它编进 catalog。
 这是能把整个 loop 演出来的最小规则，也是可执行代码实际在做的事。
 
-书里的门槛更高。它认为一次运行不算证据。
-它要求同一个模式至少在两次没有失败的运行里出现过，而且验证那一步不能来自提出这个 skill 的那次运行。
-Voyager 也是这样做：环境确认过，skill 才进得了 library。
-写之前先搜一下 store。如果已经有很像的，就去改它，不要再多开一个重复的。
-正文里也要留下这次踩到的坑，不要只留走得通的那条路。
+**书里的门槛更高：**书的答案是不该，因为一趟运行不算证据。
+要让一个 skill 变成正式能力，书要求四件事：
 
-两种规则都说得通。一次成功比较好教机制，demo 也短。
-门槛则是在 store 长到几百个的时候，挡住那些只用过一次的笔记。
+- 同一个模式至少在两趟没有失败的运行里出现过。
+- 验证那一步不能来自提出这个 skill 的那趟运行。Voyager 也是这样做：环境确认过，skill 才进得了 library。
+- 动手写之前先搜一下 store。如果已经有很像的，就去改它，不要再多开一个重复的。
+- 这趟踩到的坑要留在正文里，不要只留走得通的那条路。
+
+**该选哪一种：**两种都说得通，因为它们回答的不是同一个问题。
+一次成功比较好教机制，demo 也短。门槛则是在 store 长到几百个的时候，挡住那些只用过一次的笔记。
 中间还可以插一个 candidate 步骤。沉淀出来的流程先落成 candidate，不直接进 catalog。
 它会经过起草、测试、评估、修订，才被升级。Anthropic 的 Skill Creator 就是跑这个 loop。
 放到这一章的代码里，就是多一个暂存文件夹，`load_skills` 先跳过它，等 curator 升级才收。
 
-**合并整理是离线做的。** curator 是排程跑的，不是实时跑的。书里叫它 sleep-time learning，分成五步：
+**合并整理是离线做的：**curator 是排程跑的，不是实时跑的。书里叫它 sleep-time learning，分成五步：
 
 1. **触发。** 排程时间到、系统空闲，或 store 大小超过上限。
 2. **定位。** 先对 store 做一次快照，后面每一步才都能回滚。
@@ -164,8 +170,8 @@ Voyager 也是这样做：环境确认过，skill 才进得了 library。
 4. **验证与核准。** 拿产生它们的那几次运行，去检查合并后的正文。没过的就不收。
 5. **修剪与建索引。** 按固定规则归档过期的 skill，然后重建 catalog。
 
-离线做这件事，本身就是一条安全边界。线上 loop 只负责运行和记录，跑到一半绝不去动 store。
-所以一次刚好成功的运行没办法把自己升级，agent 从外面读进来的文本，也没办法在两个 turn 之间变成永久指令。
+**为什么一定要离线：**把 curator 放在离线跑，本身就是一条安全边界。线上 loop 只负责运行和记录，跑到一半绝不去动 store。
+所以一趟刚好成功的运行没办法把自己升级，agent 从外面读进来的文本，也没办法在两个 turn 之间变成永久指令。
 
 ---
 

--- a/sections/07-skills/README.zh-CN.md
+++ b/sections/07-skills/README.zh-CN.md
@@ -125,8 +125,7 @@ loop 不用改。读取 skill 就是一次普通的工具调用，tool 结果照
 
 ### 延伸阅读
 
-下面这些做法，`src/` 都没有实现。它们来自 ai-agent-book 对正式环境 agent 的梳理，还有一些厂商文档。
-上面各系统表格里的那两套系统，也没有被证实就是这样做的。
+以下设计 `src/` 都没有实现，出自 ai-agent-book 和厂商文档，也未经下面表格的系统证实。
 
 **catalog 要花多少成本：**progressive disclosure 让一个很大的 skill store 变便宜，但没有让它变免费。
 catalog 就在 prefix 里，prefill 时要被读一次，之后每个 turn 都要再送一次。

--- a/sections/07-skills/README.zh-CN.md
+++ b/sections/07-skills/README.zh-CN.md
@@ -36,6 +36,20 @@ skill 使用 progressive disclosure。模型只会看到刚好足够的信息，
 
 不需要专门的 skill tool。只要 catalog 列出每个 skill 的名称和路径，agent 就用普通的 Read tool 去读那个文件来加载 skill。L2 和 L3 都只是读文件而已。
 
+有三件事会决定 progressive disclosure 到底管不管用。
+
+- **description 是路由条件，不是摘要。** 模型在决定要不要加载之前，只看得到 catalog 那一行。
+  所以要写清楚什么时候该用、什么时候不该用，最好附一个反例。只写主题名称的描述，等于叫模型自己猜。
+- **catalog 放哪里是可以选的。** 这份列表可以放在 system prompt，也可以塞进某个启用用 tool 的 description 里。
+  open standard 两种都允许。放 system prompt，每个 session 的 prefix 都要付这笔 token；放进 tool，prefix 比较小，列表变成 tool schema 的一部分。
+- **progressive disclosure 是便宜，不是免费。** catalog 至少要被 prefill 一次，加载的正文在被压缩之前也一直占着 context。
+  第一个 turn 之后 prefix 就被缓存住，后面的成本很低。所以真正要抓的预算是 catalog 挂了几个 skill，而不是正文被读了几次。
+
+同一套做法现在也长到 tool 这一层了。与其把每个 tool schema 都塞进 prefix，harness 只留名称和一行描述，完整 schema 等模型要用的时候再拉。
+OpenAI 的 Responses API 用 `defer_loading` 标记 tool，Claude Code 把 tool search 用在 MCP server 上，Codex CLI 则用 BM25 对自己的 tool 列表排序。
+拉进来的 schema 会接在 context 尾端，所以缓存住的 prefix 不会被打掉。
+skill 是这个 repo 第一次碰到 progressive disclosure 的地方，现在 tool 定义本身也内建了这件事（第 2 章）。
+
 ### New: scan the skills and list them in the prompt
 
 ```python
@@ -111,6 +125,28 @@ def stale_skills(skills_dir, skills, now=None, stale_after=STALE_AFTER) -> list[
 - `stale_skills` 是一份报告，不是一个动作。怎么处理是 curator 的工作；Hermes 用一个后台 curator agent 处理同样的信号（归档、合并、固定（pin））。
 - 数据流是一个跨运行的 loop：读取更新 `.usage.json`，curator 读它，catalog 反映留下来的 skill，`WriteSkill` 再补进新条目。
 
+**什么时候该写。** demo 的做法是一次成功就写：跑完一段流程，调用一次 `WriteSkill`，下一次扫描就把它编进 catalog。
+这是能把整个 loop 演出来的最小规则，也是可执行代码实际在做的事。
+
+书里的门槛更高。要成为正式能力，证据得重复出现，至少两次没有失败的运行呈现同一个模式，而且验证那一步不能来自提出它的那次运行。
+Voyager 也是同一套规则：环境确认这个 skill 真的有用，它才进得了 library。
+写之前先搜一下 store，找得到相近的就去改它，不要再开一个重复的。正文里也要留下这次踩到的坑，而不是只留走得通的那条路。
+两种立场都成立。一次成功比较好教机制，demo 也短。门槛则是在 store 长到几百个的时候，挡住那些只用过一次的笔记。
+
+中间插一个 candidate 步骤，可以两边兼顾。沉淀出来的流程先落成 candidate，不直接进 catalog，经过起草、测试、评估、修订才升级。
+Anthropic 的 Skill Creator 就是跑这个 loop。放到这一章的代码里，就是多一个暂存文件夹，`load_skills` 先跳过它，等 curator 升级才收。
+
+**合并整理是离线做的。** curator 是排程跑的，不是实时跑的。书里叫它 sleep-time learning，分成五步：
+
+1. **触发。** 排程时间到、系统空闲，或 store 大小超过门槛。
+2. **定位。** 先对 store 做一次快照，后面每一步才都能回滚。
+3. **收集与合并。** 读使用记录和最近几次运行，把几乎重复的 skill 并成一个，顺便把 candidate 收进来。
+4. **验证与核准。** 拿产生它们的那几次运行去检查合并后的正文。没过的就不收。
+5. **修剪与建索引。** 按固定规则归档过期 skill，然后重建 catalog。
+
+放在离线做，本身就是一条安全边界。线上 loop 只负责运行和记录，跑到一半绝不去动 store。
+一次刚好成功的运行没办法把自己升级，agent 从外面读进来的文本，也没办法在两个 turn 之间变成永久指令。
+
 ### How it integrates
 
 loop 不用改。读取 skill 就是一次普通的工具调用，tool 结果照样进入 `messages[]`。
@@ -143,6 +179,12 @@ loop 不用改。读取 skill 就是一次普通的工具调用，tool 结果照
 - **压缩后正文丢失：**重新读取该 skill 文件，或让正文保持简短。
 - **Path traversal：**catalog 会把路径交给模型。把 Read tool 的范围限制在 skills 目录，让 `../` 无法逃出去。
 - **forked skill 失去即时情境：**只在自成一体的工作上使用 forked skill。
+- **供应链里的毒 skill：**装进来的第三方 skill 本质是外部内容，却是当成指令加载的，杀伤力比一个被下毒的网页还大，因为 catalog 已经替它背书了。
+  安装前把正文和附带的 script 都读过，版本要固定，更新时再看一次。
+- **注入的文本变成永久的：**`messages[]` 里的 prompt injection，session 结束就没了；同一段文本沉淀进 `SKILL.md`，之后每次运行都会加载。
+  没审过的外部内容绝不能喂给 `WriteSkill`。新 skill 先当 candidate 放着，等另一道流程核准；也绝不让 skill 去改那道核准闸门。
+- **使用次数会高估学习成效：**加载不等于照做。次数只说明 catalog 路由对了，不代表这个 skill 改变了结果。
+  skill 有没有被触发、那次运行有没有变好，要当成两个数字分开看。
 
 ---
 
@@ -165,7 +207,16 @@ uv run python sections/07-skills/src/demo.py  # live demo, needs a key
 
 ## 出处
 
-- [Claude Code 源码](https://github.com/yasasbanukaofficial/claude-code)：`skills/loadSkillsDir.ts`、`skills/bundledSkills.ts`、`skills/mcpSkillBuilders.ts`、`tools/SkillTool/SkillTool.ts`、`tools/SkillTool/prompt.ts`。
-- [Hermes Agent 源码](https://github.com/NousResearch/hermes-agent)：`tools/skills_tool.py`（`skills_list`、`skill_view`）、`tools/skill_usage.py`、`hermes_cli/curator.py`、`tools/skills_hub.py`、`tools/skills_ast_audit.py`。
+- [Claude Code 源码](https://github.com/yasasbanukaofficial/claude-code)：
+  `skills/loadSkillsDir.ts`、`skills/bundledSkills.ts`、`skills/mcpSkillBuilders.ts`、`tools/SkillTool/SkillTool.ts`、`tools/SkillTool/prompt.ts`。
+- [Hermes Agent 源码](https://github.com/NousResearch/hermes-agent)：
+  `tools/skills_tool.py`（`skills_list`、`skill_view`）、`tools/skill_usage.py`、`hermes_cli/curator.py`、`tools/skills_hub.py`、`tools/skills_ast_audit.py`。
 - [Anthropic Agent Skills best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices)：progressive disclosure 的层级。
 - [learn-claude-code · s07_skill_loading](https://github.com/shareAI-lab/learn-claude-code)：章节框架。
+- [ai-agent-book](https://github.com/bojieli/ai-agent-book)：`book/chapter2.md`、`book/chapter8.md`，以中文原版为准。
+- [Agent Skills open standard](https://agentskills.io)：catalog 放哪里，system prompt 或启用用 tool 的 description。
+- Deferred tool loading：OpenAI Responses API tool search（`defer_loading`）、Claude Code MCP tool search、Codex CLI `search_tool`。
+- [Claude Code · prompt caching](https://code.claude.com/docs/en/prompt-caching)：加载的 skill 正文会落在哪里、成本是多少。
+- [Voyager](https://arxiv.org/abs/2305.16291)：环境验证过，skill 才进得了 library。
+- [Anthropic Skill Creator](https://github.com/anthropics/skills)：升级之前先起草、测试、评估、修订。
+- Lin et al.，[arXiv:2605.30621](https://arxiv.org/abs/2605.30621)，转引自书：更新有没有落地、有没有帮上忙，是两个要分开量的数字。

--- a/sections/07-skills/README.zh-CN.md
+++ b/sections/07-skills/README.zh-CN.md
@@ -36,19 +36,9 @@ skill 使用 progressive disclosure。模型只会看到刚好足够的信息，
 
 不需要专门的 skill tool。只要 catalog 列出每个 skill 的名称和路径，agent 就用普通的 Read tool 去读那个文件来加载 skill。L2 和 L3 都只是读文件而已。
 
-有三件事会决定 progressive disclosure 到底管不管用。
-
-- **description 是路由条件，不是摘要。** 模型在决定要不要加载之前，只看得到 catalog 那一行。
-  所以要写清楚什么时候该用、什么时候不该用，最好附一个反例。只写主题名称的描述，等于叫模型自己猜。
-- **catalog 放哪里是可以选的。** 这份列表可以放在 system prompt，也可以塞进某个启用用 tool 的 description 里。
-  open standard 两种都允许。放 system prompt，每个 session 的 prefix 都要付这笔 token；放进 tool，prefix 比较小，列表变成 tool schema 的一部分。
-- **progressive disclosure 是便宜，不是免费。** catalog 至少要被 prefill 一次，加载的正文在被压缩之前也一直占着 context。
-  第一个 turn 之后 prefix 就被缓存住，后面的成本很低。所以真正要抓的预算是 catalog 挂了几个 skill，而不是正文被读了几次。
-
-同一套做法现在也长到 tool 这一层了。与其把每个 tool schema 都塞进 prefix，harness 只留名称和一行描述，完整 schema 等模型要用的时候再拉。
-OpenAI 的 Responses API 用 `defer_loading` 标记 tool，Claude Code 把 tool search 用在 MCP server 上，Codex CLI 则用 BM25 对自己的 tool 列表排序。
-拉进来的 schema 会接在 context 尾端，所以缓存住的 prefix 不会被打掉。
-skill 是这个 repo 第一次碰到 progressive disclosure 的地方，现在 tool 定义本身也内建了这件事（第 2 章）。
+description 这一行最关键。它是路由条件，不是摘要。
+模型在决定要不要加载之前，就只看得到这一行。所以要写清楚什么时候该用，也要写什么时候不该用。
+最好再附一个反例。只写个主题名称，模型只能靠猜。
 
 ### New: scan the skills and list them in the prompt
 
@@ -125,28 +115,6 @@ def stale_skills(skills_dir, skills, now=None, stale_after=STALE_AFTER) -> list[
 - `stale_skills` 是一份报告，不是一个动作。怎么处理是 curator 的工作；Hermes 用一个后台 curator agent 处理同样的信号（归档、合并、固定（pin））。
 - 数据流是一个跨运行的 loop：读取更新 `.usage.json`，curator 读它，catalog 反映留下来的 skill，`WriteSkill` 再补进新条目。
 
-**什么时候该写。** demo 的做法是一次成功就写：跑完一段流程，调用一次 `WriteSkill`，下一次扫描就把它编进 catalog。
-这是能把整个 loop 演出来的最小规则，也是可执行代码实际在做的事。
-
-书里的门槛更高。要成为正式能力，证据得重复出现，至少两次没有失败的运行呈现同一个模式，而且验证那一步不能来自提出它的那次运行。
-Voyager 也是同一套规则：环境确认这个 skill 真的有用，它才进得了 library。
-写之前先搜一下 store，找得到相近的就去改它，不要再开一个重复的。正文里也要留下这次踩到的坑，而不是只留走得通的那条路。
-两种立场都成立。一次成功比较好教机制，demo 也短。门槛则是在 store 长到几百个的时候，挡住那些只用过一次的笔记。
-
-中间插一个 candidate 步骤，可以两边兼顾。沉淀出来的流程先落成 candidate，不直接进 catalog，经过起草、测试、评估、修订才升级。
-Anthropic 的 Skill Creator 就是跑这个 loop。放到这一章的代码里，就是多一个暂存文件夹，`load_skills` 先跳过它，等 curator 升级才收。
-
-**合并整理是离线做的。** curator 是排程跑的，不是实时跑的。书里叫它 sleep-time learning，分成五步：
-
-1. **触发。** 排程时间到、系统空闲，或 store 大小超过门槛。
-2. **定位。** 先对 store 做一次快照，后面每一步才都能回滚。
-3. **收集与合并。** 读使用记录和最近几次运行，把几乎重复的 skill 并成一个，顺便把 candidate 收进来。
-4. **验证与核准。** 拿产生它们的那几次运行去检查合并后的正文。没过的就不收。
-5. **修剪与建索引。** 按固定规则归档过期 skill，然后重建 catalog。
-
-放在离线做，本身就是一条安全边界。线上 loop 只负责运行和记录，跑到一半绝不去动 store。
-一次刚好成功的运行没办法把自己升级，agent 从外面读进来的文本，也没办法在两个 turn 之间变成永久指令。
-
 ### How it integrates
 
 loop 不用改。读取 skill 就是一次普通的工具调用，tool 结果照样进入 `messages[]`。
@@ -154,6 +122,50 @@ loop 不用改。读取 skill 就是一次普通的工具调用，tool 结果照
 三层各有位置：catalog 放在 system prompt。skill 正文要等模型读了 `SKILL.md`，才会进到对话里。resource 文件则等到真的用到时才读。
 
 加载后的 skill 文本就在 `messages[]` 里，所以之后 context 不够用时，它会跟其他消息一起被压缩（第 8 章）。skill 正文要写短，大型参考资料改成指向文件。
+
+### 延伸阅读
+
+下面这些做法，`src/` 都没有实现。它们来自 ai-agent-book 对正式环境 agent 的梳理，还有一些厂商文档。
+上面各系统表格里的那两套系统，也没有被证实就是这样做的。
+
+**progressive disclosure 的成本。** 它是便宜，不是免费。catalog 在 prefill 阶段还是要被读一次。
+加载的正文也会一直占着 context，直到有东西来压缩它。第一个 turn 之后 prefix 就被缓存住，后面每一次的成本都很低。
+所以真正要盯的数字是 catalog 挂了几个 skill，而不是正文被读了几次。
+
+**catalog 放在哪。** 这份列表可以放在 system prompt，`src/` 就是这样做的。
+它也可以塞进某一个启用用 tool 的 description 里，open standard 两种都允许。
+放 system prompt，每个 session 的 prefix 都要付这笔 token；放进 tool，prefix 就小一些。
+
+**Deferred tool loading。** tool 也可以学同一招。prefix 里只留 tool 名称和一行描述。
+模型要用到某个 tool 时才去要完整 schema，要来的 schema 接在 context 尾端。
+缓存住的 prefix 完全没被动到，前面的东西都不用重算。
+skill 是这个 repo 第一次碰到 progressive disclosure 的地方；照书上说，同一套做法现在也长到 tool 这一层了（第 2 章）。
+
+**什么时候该写一个 skill。** 这里的 demo 是一次成功就写：一段流程跑完，agent 调用一次 `WriteSkill`，下一次扫描就把它编进 catalog。
+这是能把整个 loop 演出来的最小规则，也是可执行代码实际在做的事。
+
+书里的门槛更高。它认为一次运行不算证据。
+它要求同一个模式至少在两次没有失败的运行里出现过，而且验证那一步不能来自提出这个 skill 的那次运行。
+Voyager 也是这样做：环境确认过，skill 才进得了 library。
+写之前先搜一下 store。如果已经有很像的，就去改它，不要再多开一个重复的。
+正文里也要留下这次踩到的坑，不要只留走得通的那条路。
+
+两种规则都说得通。一次成功比较好教机制，demo 也短。
+门槛则是在 store 长到几百个的时候，挡住那些只用过一次的笔记。
+中间还可以插一个 candidate 步骤。沉淀出来的流程先落成 candidate，不直接进 catalog。
+它会经过起草、测试、评估、修订，才被升级。Anthropic 的 Skill Creator 就是跑这个 loop。
+放到这一章的代码里，就是多一个暂存文件夹，`load_skills` 先跳过它，等 curator 升级才收。
+
+**合并整理是离线做的。** curator 是排程跑的，不是实时跑的。书里叫它 sleep-time learning，分成五步：
+
+1. **触发。** 排程时间到、系统空闲，或 store 大小超过上限。
+2. **定位。** 先对 store 做一次快照，后面每一步才都能回滚。
+3. **收集与合并。** 读使用记录和最近几次运行，把几乎重复的 skill 并成一个，再把 candidate 收进来。
+4. **验证与核准。** 拿产生它们的那几次运行，去检查合并后的正文。没过的就不收。
+5. **修剪与建索引。** 按固定规则归档过期的 skill，然后重建 catalog。
+
+离线做这件事，本身就是一条安全边界。线上 loop 只负责运行和记录，跑到一半绝不去动 store。
+所以一次刚好成功的运行没办法把自己升级，agent 从外面读进来的文本，也没办法在两个 turn 之间变成永久指令。
 
 ---
 
@@ -179,12 +191,12 @@ loop 不用改。读取 skill 就是一次普通的工具调用，tool 结果照
 - **压缩后正文丢失：**重新读取该 skill 文件，或让正文保持简短。
 - **Path traversal：**catalog 会把路径交给模型。把 Read tool 的范围限制在 skills 目录，让 `../` 无法逃出去。
 - **forked skill 失去即时情境：**只在自成一体的工作上使用 forked skill。
-- **供应链里的毒 skill：**装进来的第三方 skill 本质是外部内容，却是当成指令加载的，杀伤力比一个被下毒的网页还大，因为 catalog 已经替它背书了。
-  安装前把正文和附带的 script 都读过，版本要固定，更新时再看一次。
-- **注入的文本变成永久的：**`messages[]` 里的 prompt injection，session 结束就没了；同一段文本沉淀进 `SKILL.md`，之后每次运行都会加载。
-  没审过的外部内容绝不能喂给 `WriteSkill`。新 skill 先当 candidate 放着，等另一道流程核准；也绝不让 skill 去改那道核准闸门。
+- **供应链里的毒 skill：**装进来的第三方 skill 本质是外部内容，却是当成指令加载的。
+  这比一个被下毒的网页还危险，因为 catalog 已经替它背书了。安装前先把正文和附带的 script 都读过，版本要固定，更新时再看一次。
+- **注入的文本变成永久的：**`messages[]` 里的 prompt injection，session 结束就没了；同一段文本写进 `SKILL.md`，之后每次运行都会加载。
+  所以没审过的外部内容，绝不能喂给 `WriteSkill`。新 skill 先当 candidate 放着，等另一道流程核准。也绝不让 skill 去改那道核准闸门。
 - **使用次数会高估学习成效：**加载不等于照做。次数只说明 catalog 路由对了，不代表这个 skill 改变了结果。
-  skill 有没有被触发、那次运行有没有变好，要当成两个数字分开看。
+  要看两个数字：skill 有没有被触发，以及那次运行有没有变好。
 
 ---
 
@@ -215,7 +227,6 @@ uv run python sections/07-skills/src/demo.py  # live demo, needs a key
 - [learn-claude-code · s07_skill_loading](https://github.com/shareAI-lab/learn-claude-code)：章节框架。
 - [ai-agent-book](https://github.com/bojieli/ai-agent-book)：`book/chapter2.md`、`book/chapter8.md`，以中文原版为准。
 - [Agent Skills open standard](https://agentskills.io)：catalog 放哪里，system prompt 或启用用 tool 的 description。
-- Deferred tool loading：OpenAI Responses API tool search（`defer_loading`）、Claude Code MCP tool search、Codex CLI `search_tool`。
 - [Claude Code · prompt caching](https://code.claude.com/docs/en/prompt-caching)：加载的 skill 正文会落在哪里、成本是多少。
 - [Voyager](https://arxiv.org/abs/2305.16291)：环境验证过，skill 才进得了 library。
 - [Anthropic Skill Creator](https://github.com/anthropics/skills)：升级之前先起草、测试、评估、修订。

--- a/sections/07-skills/README.zh-TW.md
+++ b/sections/07-skills/README.zh-TW.md
@@ -128,35 +128,41 @@ loop 不用改。讀取 skill 就是一次普通的工具呼叫，tool 結果照
 底下這些做法，`src/` 都沒有實作。它們來自 ai-agent-book 對正式環境 agent 的整理，還有一些廠商文件。
 上面各系統表格裡的那兩套系統，也沒有被證實就是這樣做的。
 
-**progressive disclosure 的成本。** 它是便宜，不是免費。catalog 在 prefill 階段還是要被讀一次。
-載入的本文也會一直佔著 context，直到有東西來壓縮它。第一個 turn 之後 prefix 就被快取住，後面每一次的成本都很低。
+**catalog 要花多少成本：**progressive disclosure 讓一個很大的 skill store 變便宜，但沒有讓它變免費。
+catalog 就在 prefix 裡，prefill 時要被讀一次，之後每個 turn 都要再送一次。
+第一個 turn 之後那段 prefix 就被快取住，所以重送的成本很低。
+載入本文比較貴，而且本文會一直佔著 context，直到有東西來壓縮它。
 所以真正要盯的數字是 catalog 掛了幾個 skill，而不是本文被讀了幾次。
 
-**catalog 放在哪。** 這份列表可以放在 system prompt，`src/` 就是這樣做的。
+**catalog 放在哪：**這份列表可以放在 system prompt，`src/` 就是這樣做的。
 它也可以塞進某一個啟用用 tool 的 description 裡，open standard 兩種都允許。
-放 system prompt，每個 session 的 prefix 都要付這筆 token；放進 tool，prefix 就小一些。
+差別在這筆 token 算到哪邊。放 system prompt，它就是每個 session prefix 的一部分。
+放進 tool description，prefix 就小一些，模型改成透過那個 tool 去看這份列表。
 
-**Deferred tool loading。** tool 也可以學同一招。prefix 裡只留 tool 名稱和一行描述。
-模型要用到某個 tool 時才去要完整 schema，要來的 schema 接在 context 尾端。
-快取住的 prefix 完全沒被動到，前面的東西都不用重算。
+**Deferred tool loading：**tool 也可以用同一套做法，理由也一樣：schema 很大，但大部分 turn 根本用不到。
+prefix 裡只留 tool 名稱和一行描述，模型要用到某個 tool 時，才去要完整 schema。
+要來的 schema 接在 context 尾端，所以快取住的 prefix 完全沒被動到，前面的東西也都不用重算。
 skill 是這個 repo 第一次碰到 progressive disclosure 的地方；照書上說，同一套做法現在也長到 tool 這一層了（第 2 章）。
 
-**什麼時候該寫一個 skill。** 這裡的 demo 是一次成功就寫：一段流程跑完，agent 呼叫一次 `WriteSkill`，下一次掃描就把它編進 catalog。
+**什麼時候該寫一個 skill：**假設某一趟執行第一次把一段長流程跑對了，這該不該存成 skill？
+這裡的 demo 說該。流程一跑完，agent 就呼叫一次 `WriteSkill`，下一次掃描把它編進 catalog。
 這是能把整個 loop 演出來的最小規則，也是可執行程式碼實際在做的事。
 
-書裡的門檻更高。它認為一次執行不算證據。
-它要求同一個模式至少在兩次沒有失敗的執行裡出現過，而且驗證那一步不能來自提出這個 skill 的那次執行。
-Voyager 也是這樣做：環境確認過，skill 才進得了 library。
-寫之前先搜一下 store。如果已經有很像的，就去改它，不要再多開一個重複的。
-本文裡也要留下這次踩到的坑，不要只留走得通的那條路。
+**書裡的門檻更高：**書的答案是不該，因為一趟執行不算證據。
+要讓一個 skill 變成正式能力，書要求四件事：
 
-兩種規則都說得通。一次成功比較好教機制，demo 也短。
-門檻則是在 store 長到幾百個的時候，擋住那些只用過一次的筆記。
+- 同一個模式至少在兩趟沒有失敗的執行裡出現過。
+- 驗證那一步不能來自提出這個 skill 的那趟執行。Voyager 也是這樣做：環境確認過，skill 才進得了 library。
+- 動手寫之前先搜一下 store。如果已經有很像的，就去改它，不要再多開一個重複的。
+- 這趟踩到的坑要留在本文裡，不要只留走得通的那條路。
+
+**該選哪一種：**兩種都說得通，因為它們回答的不是同一個問題。
+一次成功比較好教機制，demo 也短。門檻則是在 store 長到幾百個的時候，擋住那些只用過一次的筆記。
 中間還可以插一個 candidate 步驟。沉澱出來的流程先落成 candidate，不直接進 catalog。
 它會經過起草、測試、評估、修訂，才被升級。Anthropic 的 Skill Creator 就是跑這個 loop。
 放到這一章的程式碼裡，就是多一個暫存資料夾，`load_skills` 先跳過它，等 curator 升級才收。
 
-**整併是離線做的。** curator 是排程跑的，不是即時跑的。書裡叫它 sleep-time learning，分成五步：
+**整併是離線做的：**curator 是排程跑的，不是即時跑的。書裡叫它 sleep-time learning，分成五步：
 
 1. **觸發。** 排程時間到、系統閒置，或 store 大小超過上限。
 2. **定位。** 先對 store 做一次快照，後面每一步才都能回滾。
@@ -164,8 +170,8 @@ Voyager 也是這樣做：環境確認過，skill 才進得了 library。
 4. **驗證與核准。** 拿產生它們的那幾次執行，去檢查合併後的本文。沒過的就不收。
 5. **修剪與建索引。** 依固定規則封存過期的 skill，然後重建 catalog。
 
-離線做這件事，本身就是一條安全邊界。線上 loop 只負責執行和記錄，跑到一半絕不去動 store。
-所以一次剛好成功的執行沒辦法把自己升級，agent 從外面讀進來的文字，也沒辦法在兩個 turn 之間變成永久指令。
+**為什麼一定要離線：**把 curator 放在離線跑，本身就是一條安全邊界。線上 loop 只負責執行和記錄，跑到一半絕不去動 store。
+所以一趟剛好成功的執行沒辦法把自己升級，agent 從外面讀進來的文字，也沒辦法在兩個 turn 之間變成永久指令。
 
 ---
 

--- a/sections/07-skills/README.zh-TW.md
+++ b/sections/07-skills/README.zh-TW.md
@@ -125,8 +125,7 @@ loop 不用改。讀取 skill 就是一次普通的工具呼叫，tool 結果照
 
 ### 延伸閱讀
 
-底下這些做法，`src/` 都沒有實作。它們來自 ai-agent-book 對正式環境 agent 的整理，還有一些廠商文件。
-上面各系統表格裡的那兩套系統，也沒有被證實就是這樣做的。
+以下設計 `src/` 都沒有實作，出自 ai-agent-book 和廠商文件，也未經下面表格的系統證實。
 
 **catalog 要花多少成本：**progressive disclosure 讓一個很大的 skill store 變便宜，但沒有讓它變免費。
 catalog 就在 prefix 裡，prefill 時要被讀一次，之後每個 turn 都要再送一次。

--- a/sections/07-skills/README.zh-TW.md
+++ b/sections/07-skills/README.zh-TW.md
@@ -36,19 +36,9 @@ skill 使用 progressive disclosure。模型只會看到剛好足夠的資訊，
 
 不需要專門的 skill tool。只要 catalog 列出每個 skill 的名稱和路徑，agent 就用一般的 Read tool 去讀那個檔案來載入 skill。L2 和 L3 都只是讀檔而已。
 
-有三件事會決定 progressive disclosure 到底管不管用。
-
-- **description 是路由條件，不是摘要。** 模型在決定要不要載入之前，只看得到 catalog 那一行。
-  所以要寫清楚什麼時候該用、什麼時候不該用，最好附一個反例。只寫主題名稱的描述，等於叫模型自己猜。
-- **catalog 放哪裡是可以選的。** 這份列表可以放在 system prompt，也可以塞進某個啟用用 tool 的 description 裡。
-  open standard 兩種都允許。放 system prompt，每個 session 的 prefix 都要付這筆 token；放進 tool，prefix 比較小，列表變成 tool schema 的一部分。
-- **progressive disclosure 是便宜，不是免費。** catalog 至少要被 prefill 一次，載入的本文在被壓縮之前也一直佔著 context。
-  第一個 turn 之後 prefix 就被快取住，後面的成本很低。所以真正要抓的預算是 catalog 掛了幾個 skill，而不是本文被讀了幾次。
-
-同一套做法現在也長到 tool 這一層了。與其把每個 tool schema 都塞進 prefix，harness 只留名稱和一行描述，完整 schema 等模型要用的時候再拉。
-OpenAI 的 Responses API 用 `defer_loading` 標記 tool，Claude Code 把 tool search 用在 MCP server 上，Codex CLI 則用 BM25 對自己的 tool 列表排序。
-拉進來的 schema 會接在 context 尾端，所以快取住的 prefix 不會被打掉。
-skill 是這個 repo 第一次碰到 progressive disclosure 的地方，現在 tool 定義本身也內建了這件事（第 2 章）。
+description 這一行最關鍵。它是路由條件，不是摘要。
+模型在決定要不要載入之前，就只看得到這一行。所以要寫清楚什麼時候該用，也要寫什麼時候不該用。
+最好再附一個反例。只寫個主題名稱，模型只能用猜的。
 
 ### New: scan the skills and list them in the prompt
 
@@ -125,28 +115,6 @@ def stale_skills(skills_dir, skills, now=None, stale_after=STALE_AFTER) -> list[
 - `stale_skills` 是一份報告，不是一個動作。要怎麼處理是 curator 的工作；Hermes 用一個背景 curator agent 處理同樣的訊號（封存、整併、釘選）。
 - 資料流是一個跨執行的 loop：讀取更新 `.usage.json`，curator 讀它，catalog 反映留下來的 skill，`WriteSkill` 再補進新條目。
 
-**什麼時候該寫。** demo 的做法是一次成功就寫：跑完一段流程，呼叫一次 `WriteSkill`，下一次掃描就把它編進 catalog。
-這是能把整個 loop 演出來的最小規則，也是可執行程式碼實際在做的事。
-
-書裡的門檻更高。要成為正式能力，證據得重複出現，至少兩次沒有失敗的執行呈現同一個模式，而且驗證那一步不能來自提出它的那次執行。
-Voyager 也是同一套規則：環境確認這個 skill 真的有用，它才進得了 library。
-寫之前先搜一下 store，找得到相近的就去改它，不要再開一個重複的。本文裡也要留下這次踩到的坑，而不是只留走得通的那條路。
-兩種立場都成立。一次成功比較好教機制，demo 也短。門檻則是在 store 長到幾百個的時候，擋住那些只用過一次的筆記。
-
-中間插一個 candidate 步驟，可以兩邊兼顧。沉澱出來的流程先落成 candidate，不直接進 catalog，經過起草、測試、評估、修訂才升級。
-Anthropic 的 Skill Creator 就是跑這個 loop。放到這一章的程式碼裡，就是多一個暫存資料夾，`load_skills` 先跳過它，等 curator 升級才收。
-
-**整併是離線做的。** curator 是排程跑的，不是即時跑的。書裡叫它 sleep-time learning，分成五步：
-
-1. **觸發。** 排程時間到、系統閒置，或 store 大小超過門檻。
-2. **定位。** 先對 store 做一次快照，後面每一步才都能回滾。
-3. **蒐集與合併。** 讀使用記錄和最近幾次執行，把幾乎重複的 skill 併成一個，順便把 candidate 收進來。
-4. **驗證與核准。** 拿產生它們的那幾次執行去檢查合併後的本文。沒過的就不收。
-5. **修剪與建索引。** 依固定規則封存過期 skill，然後重建 catalog。
-
-放在離線做，本身就是一條安全邊界。線上 loop 只負責執行和記錄，跑到一半絕不去動 store。
-一次剛好成功的執行沒辦法把自己升級，agent 從外面讀進來的文字，也沒辦法在兩個 turn 之間變成永久指令。
-
 ### How it integrates
 
 loop 不用改。讀取 skill 就是一次普通的工具呼叫，tool 結果照樣進入 `messages[]`。
@@ -154,6 +122,50 @@ loop 不用改。讀取 skill 就是一次普通的工具呼叫，tool 結果照
 三層各有位置：catalog 放在 system prompt。skill 本文要等模型讀了 `SKILL.md`，才會進到對話裡。resource 檔案則等到真的用到時才讀。
 
 載入後的 skill 文字就在 `messages[]` 裡，所以之後 context 不夠用時，它會跟其他訊息一起被壓縮（第 8 章）。skill 本文要寫短，大型參考資料改成指向檔案。
+
+### 延伸閱讀
+
+底下這些做法，`src/` 都沒有實作。它們來自 ai-agent-book 對正式環境 agent 的整理，還有一些廠商文件。
+上面各系統表格裡的那兩套系統，也沒有被證實就是這樣做的。
+
+**progressive disclosure 的成本。** 它是便宜，不是免費。catalog 在 prefill 階段還是要被讀一次。
+載入的本文也會一直佔著 context，直到有東西來壓縮它。第一個 turn 之後 prefix 就被快取住，後面每一次的成本都很低。
+所以真正要盯的數字是 catalog 掛了幾個 skill，而不是本文被讀了幾次。
+
+**catalog 放在哪。** 這份列表可以放在 system prompt，`src/` 就是這樣做的。
+它也可以塞進某一個啟用用 tool 的 description 裡，open standard 兩種都允許。
+放 system prompt，每個 session 的 prefix 都要付這筆 token；放進 tool，prefix 就小一些。
+
+**Deferred tool loading。** tool 也可以學同一招。prefix 裡只留 tool 名稱和一行描述。
+模型要用到某個 tool 時才去要完整 schema，要來的 schema 接在 context 尾端。
+快取住的 prefix 完全沒被動到，前面的東西都不用重算。
+skill 是這個 repo 第一次碰到 progressive disclosure 的地方；照書上說，同一套做法現在也長到 tool 這一層了（第 2 章）。
+
+**什麼時候該寫一個 skill。** 這裡的 demo 是一次成功就寫：一段流程跑完，agent 呼叫一次 `WriteSkill`，下一次掃描就把它編進 catalog。
+這是能把整個 loop 演出來的最小規則，也是可執行程式碼實際在做的事。
+
+書裡的門檻更高。它認為一次執行不算證據。
+它要求同一個模式至少在兩次沒有失敗的執行裡出現過，而且驗證那一步不能來自提出這個 skill 的那次執行。
+Voyager 也是這樣做：環境確認過，skill 才進得了 library。
+寫之前先搜一下 store。如果已經有很像的，就去改它，不要再多開一個重複的。
+本文裡也要留下這次踩到的坑，不要只留走得通的那條路。
+
+兩種規則都說得通。一次成功比較好教機制，demo 也短。
+門檻則是在 store 長到幾百個的時候，擋住那些只用過一次的筆記。
+中間還可以插一個 candidate 步驟。沉澱出來的流程先落成 candidate，不直接進 catalog。
+它會經過起草、測試、評估、修訂，才被升級。Anthropic 的 Skill Creator 就是跑這個 loop。
+放到這一章的程式碼裡，就是多一個暫存資料夾，`load_skills` 先跳過它，等 curator 升級才收。
+
+**整併是離線做的。** curator 是排程跑的，不是即時跑的。書裡叫它 sleep-time learning，分成五步：
+
+1. **觸發。** 排程時間到、系統閒置，或 store 大小超過上限。
+2. **定位。** 先對 store 做一次快照，後面每一步才都能回滾。
+3. **蒐集與合併。** 讀使用記錄和最近幾次執行，把幾乎重複的 skill 併成一個，再把 candidate 收進來。
+4. **驗證與核准。** 拿產生它們的那幾次執行，去檢查合併後的本文。沒過的就不收。
+5. **修剪與建索引。** 依固定規則封存過期的 skill，然後重建 catalog。
+
+離線做這件事，本身就是一條安全邊界。線上 loop 只負責執行和記錄，跑到一半絕不去動 store。
+所以一次剛好成功的執行沒辦法把自己升級，agent 從外面讀進來的文字，也沒辦法在兩個 turn 之間變成永久指令。
 
 ---
 
@@ -179,12 +191,12 @@ loop 不用改。讀取 skill 就是一次普通的工具呼叫，tool 結果照
 - **壓縮後本文遺失：**重新讀取該 skill 檔案，或讓本文保持簡短。
 - **Path traversal：**catalog 會把路徑交給模型。把 Read tool 的範圍限制在 skills 目錄，讓 `../` 無法逃出去。
 - **forked skill 失去即時情境：**只在自成一體的工作上使用 forked skill。
-- **供應鏈裡的毒 skill：**裝進來的第三方 skill 本質是外部內容，卻是當成指令載入的，殺傷力比一個被下毒的網頁還大，因為 catalog 已經替它背書了。
-  安裝前把本文和附帶的 script 都讀過，版本要釘住，更新時再看一次。
-- **注入的文字變成永久的：**`messages[]` 裡的 prompt injection，session 結束就沒了；同一段文字沉澱進 `SKILL.md`，之後每次執行都會載入。
-  沒審過的外部內容絕不能餵給 `WriteSkill`。新 skill 先當 candidate 放著，等另一道流程核准；也絕不讓 skill 去改那道核准閘門。
+- **供應鏈裡的毒 skill：**裝進來的第三方 skill 本質是外部內容，卻是當成指令載入的。
+  這比一個被下毒的網頁還危險，因為 catalog 已經替它背書了。安裝前先把本文和附帶的 script 都讀過，版本要釘住，更新時再看一次。
+- **注入的文字變成永久的：**`messages[]` 裡的 prompt injection，session 結束就沒了；同一段文字寫進 `SKILL.md`，之後每次執行都會載入。
+  所以沒審過的外部內容，絕不能餵給 `WriteSkill`。新 skill 先當 candidate 放著，等另一道流程核准。也絕不讓 skill 去改那道核准閘門。
 - **使用次數會高估學習成效：**載入不等於照做。次數只說明 catalog 路由對了，不代表這個 skill 改變了結果。
-  skill 有沒有被觸發、那次執行有沒有變好，要當成兩個數字分開看。
+  要看兩個數字：skill 有沒有被觸發，以及那次執行有沒有變好。
 
 ---
 
@@ -215,7 +227,6 @@ uv run python sections/07-skills/src/demo.py  # live demo, needs a key
 - [learn-claude-code · s07_skill_loading](https://github.com/shareAI-lab/learn-claude-code)：章節框架。
 - [ai-agent-book](https://github.com/bojieli/ai-agent-book)：`book/chapter2.md`、`book/chapter8.md`，以中文原版為準。
 - [Agent Skills open standard](https://agentskills.io)：catalog 放哪裡，system prompt 或啟用用 tool 的 description。
-- Deferred tool loading：OpenAI Responses API tool search（`defer_loading`）、Claude Code MCP tool search、Codex CLI `search_tool`。
 - [Claude Code · prompt caching](https://code.claude.com/docs/en/prompt-caching)：載入的 skill 本文會落在哪裡、成本是多少。
 - [Voyager](https://arxiv.org/abs/2305.16291)：環境驗證過，skill 才進得了 library。
 - [Anthropic Skill Creator](https://github.com/anthropics/skills)：升級之前先起草、測試、評估、修訂。

--- a/sections/07-skills/README.zh-TW.md
+++ b/sections/07-skills/README.zh-TW.md
@@ -36,6 +36,20 @@ skill 使用 progressive disclosure。模型只會看到剛好足夠的資訊，
 
 不需要專門的 skill tool。只要 catalog 列出每個 skill 的名稱和路徑，agent 就用一般的 Read tool 去讀那個檔案來載入 skill。L2 和 L3 都只是讀檔而已。
 
+有三件事會決定 progressive disclosure 到底管不管用。
+
+- **description 是路由條件，不是摘要。** 模型在決定要不要載入之前，只看得到 catalog 那一行。
+  所以要寫清楚什麼時候該用、什麼時候不該用，最好附一個反例。只寫主題名稱的描述，等於叫模型自己猜。
+- **catalog 放哪裡是可以選的。** 這份列表可以放在 system prompt，也可以塞進某個啟用用 tool 的 description 裡。
+  open standard 兩種都允許。放 system prompt，每個 session 的 prefix 都要付這筆 token；放進 tool，prefix 比較小，列表變成 tool schema 的一部分。
+- **progressive disclosure 是便宜，不是免費。** catalog 至少要被 prefill 一次，載入的本文在被壓縮之前也一直佔著 context。
+  第一個 turn 之後 prefix 就被快取住，後面的成本很低。所以真正要抓的預算是 catalog 掛了幾個 skill，而不是本文被讀了幾次。
+
+同一套做法現在也長到 tool 這一層了。與其把每個 tool schema 都塞進 prefix，harness 只留名稱和一行描述，完整 schema 等模型要用的時候再拉。
+OpenAI 的 Responses API 用 `defer_loading` 標記 tool，Claude Code 把 tool search 用在 MCP server 上，Codex CLI 則用 BM25 對自己的 tool 列表排序。
+拉進來的 schema 會接在 context 尾端，所以快取住的 prefix 不會被打掉。
+skill 是這個 repo 第一次碰到 progressive disclosure 的地方，現在 tool 定義本身也內建了這件事（第 2 章）。
+
 ### New: scan the skills and list them in the prompt
 
 ```python
@@ -111,6 +125,28 @@ def stale_skills(skills_dir, skills, now=None, stale_after=STALE_AFTER) -> list[
 - `stale_skills` 是一份報告，不是一個動作。要怎麼處理是 curator 的工作；Hermes 用一個背景 curator agent 處理同樣的訊號（封存、整併、釘選）。
 - 資料流是一個跨執行的 loop：讀取更新 `.usage.json`，curator 讀它，catalog 反映留下來的 skill，`WriteSkill` 再補進新條目。
 
+**什麼時候該寫。** demo 的做法是一次成功就寫：跑完一段流程，呼叫一次 `WriteSkill`，下一次掃描就把它編進 catalog。
+這是能把整個 loop 演出來的最小規則，也是可執行程式碼實際在做的事。
+
+書裡的門檻更高。要成為正式能力，證據得重複出現，至少兩次沒有失敗的執行呈現同一個模式，而且驗證那一步不能來自提出它的那次執行。
+Voyager 也是同一套規則：環境確認這個 skill 真的有用，它才進得了 library。
+寫之前先搜一下 store，找得到相近的就去改它，不要再開一個重複的。本文裡也要留下這次踩到的坑，而不是只留走得通的那條路。
+兩種立場都成立。一次成功比較好教機制，demo 也短。門檻則是在 store 長到幾百個的時候，擋住那些只用過一次的筆記。
+
+中間插一個 candidate 步驟，可以兩邊兼顧。沉澱出來的流程先落成 candidate，不直接進 catalog，經過起草、測試、評估、修訂才升級。
+Anthropic 的 Skill Creator 就是跑這個 loop。放到這一章的程式碼裡，就是多一個暫存資料夾，`load_skills` 先跳過它，等 curator 升級才收。
+
+**整併是離線做的。** curator 是排程跑的，不是即時跑的。書裡叫它 sleep-time learning，分成五步：
+
+1. **觸發。** 排程時間到、系統閒置，或 store 大小超過門檻。
+2. **定位。** 先對 store 做一次快照，後面每一步才都能回滾。
+3. **蒐集與合併。** 讀使用記錄和最近幾次執行，把幾乎重複的 skill 併成一個，順便把 candidate 收進來。
+4. **驗證與核准。** 拿產生它們的那幾次執行去檢查合併後的本文。沒過的就不收。
+5. **修剪與建索引。** 依固定規則封存過期 skill，然後重建 catalog。
+
+放在離線做，本身就是一條安全邊界。線上 loop 只負責執行和記錄，跑到一半絕不去動 store。
+一次剛好成功的執行沒辦法把自己升級，agent 從外面讀進來的文字，也沒辦法在兩個 turn 之間變成永久指令。
+
 ### How it integrates
 
 loop 不用改。讀取 skill 就是一次普通的工具呼叫，tool 結果照樣進入 `messages[]`。
@@ -143,6 +179,12 @@ loop 不用改。讀取 skill 就是一次普通的工具呼叫，tool 結果照
 - **壓縮後本文遺失：**重新讀取該 skill 檔案，或讓本文保持簡短。
 - **Path traversal：**catalog 會把路徑交給模型。把 Read tool 的範圍限制在 skills 目錄，讓 `../` 無法逃出去。
 - **forked skill 失去即時情境：**只在自成一體的工作上使用 forked skill。
+- **供應鏈裡的毒 skill：**裝進來的第三方 skill 本質是外部內容，卻是當成指令載入的，殺傷力比一個被下毒的網頁還大，因為 catalog 已經替它背書了。
+  安裝前把本文和附帶的 script 都讀過，版本要釘住，更新時再看一次。
+- **注入的文字變成永久的：**`messages[]` 裡的 prompt injection，session 結束就沒了；同一段文字沉澱進 `SKILL.md`，之後每次執行都會載入。
+  沒審過的外部內容絕不能餵給 `WriteSkill`。新 skill 先當 candidate 放著，等另一道流程核准；也絕不讓 skill 去改那道核准閘門。
+- **使用次數會高估學習成效：**載入不等於照做。次數只說明 catalog 路由對了，不代表這個 skill 改變了結果。
+  skill 有沒有被觸發、那次執行有沒有變好，要當成兩個數字分開看。
 
 ---
 
@@ -165,7 +207,16 @@ uv run python sections/07-skills/src/demo.py  # live demo, needs a key
 
 ## 出處
 
-- [Claude Code 原始碼](https://github.com/yasasbanukaofficial/claude-code)：`skills/loadSkillsDir.ts`、`skills/bundledSkills.ts`、`skills/mcpSkillBuilders.ts`、`tools/SkillTool/SkillTool.ts`、`tools/SkillTool/prompt.ts`。
-- [Hermes Agent 原始碼](https://github.com/NousResearch/hermes-agent)：`tools/skills_tool.py`（`skills_list`、`skill_view`）、`tools/skill_usage.py`、`hermes_cli/curator.py`、`tools/skills_hub.py`、`tools/skills_ast_audit.py`。
+- [Claude Code 原始碼](https://github.com/yasasbanukaofficial/claude-code)：
+  `skills/loadSkillsDir.ts`、`skills/bundledSkills.ts`、`skills/mcpSkillBuilders.ts`、`tools/SkillTool/SkillTool.ts`、`tools/SkillTool/prompt.ts`。
+- [Hermes Agent 原始碼](https://github.com/NousResearch/hermes-agent)：
+  `tools/skills_tool.py`（`skills_list`、`skill_view`）、`tools/skill_usage.py`、`hermes_cli/curator.py`、`tools/skills_hub.py`、`tools/skills_ast_audit.py`。
 - [Anthropic Agent Skills best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices)：progressive disclosure 的層級。
 - [learn-claude-code · s07_skill_loading](https://github.com/shareAI-lab/learn-claude-code)：章節框架。
+- [ai-agent-book](https://github.com/bojieli/ai-agent-book)：`book/chapter2.md`、`book/chapter8.md`，以中文原版為準。
+- [Agent Skills open standard](https://agentskills.io)：catalog 放哪裡，system prompt 或啟用用 tool 的 description。
+- Deferred tool loading：OpenAI Responses API tool search（`defer_loading`）、Claude Code MCP tool search、Codex CLI `search_tool`。
+- [Claude Code · prompt caching](https://code.claude.com/docs/en/prompt-caching)：載入的 skill 本文會落在哪裡、成本是多少。
+- [Voyager](https://arxiv.org/abs/2305.16291)：環境驗證過，skill 才進得了 library。
+- [Anthropic Skill Creator](https://github.com/anthropics/skills)：升級之前先起草、測試、評估、修訂。
+- Lin et al.，[arXiv:2605.30621](https://arxiv.org/abs/2605.30621)，轉引自書：更新有沒有落地、有沒有幫上忙，是兩個要分開量的數字。


### PR DESCRIPTION
Implements #32. Part of #24.

## What landed

Deferred tool loading as native progressive disclosure, the supply-chain injection failure mode, disclosure sharpening, the sleep-time consolidation cycle, and safety boundaries. First-success promotion vs cross-trajectory support threshold is presented both ways. One Sources bullet with no link was dropped along with the vendor names it carried.

Book material lands as mechanism text, failure modes, and Sources only. No per-system table columns were added.
Designs this section's `src/` does not implement sit under a `Further reading` subsection after `How it integrates`, behind a one-line caveat.

## Checks

- No line over 180 characters (counted as characters for the zh files), no em or en dashes.
- zh-TW and zh-CN mirror the English edits; heading counts equal across the three languages; switcher line untouched.
- Per-system table columns unchanged. `src/` untouched. Offline test suites 23/23.
- `research/*` branches untouched, read via `git show` only.

` 3 files changed, 208 insertions(+), 5 deletions(-)`

Closes #32