### PR TITLE
docs: separate MCP adoption from schema exposure in section 19

### DIFF
--- a/sections/19-mcp-plugins-channels/README.md
+++ b/sections/19-mcp-plugins-channels/README.md
@@ -31,15 +31,6 @@ Names are namespaced `mcp__<server>__<tool>` so two servers never collide. The l
 - Each tool's MCP annotations (`readOnlyHint`, `destructiveHint`) become the permission hints the gate reads (section 3).
 - Merged into the one `Registry`, the model sees MCP tools and built-ins in the same list.
 
-A server can advertise three kinds of primitive, and only one of them lands in that pool.
-
-- **Tools** are actions the model picks and calls. These are what `tools/list` returns and what the wrapping below turns into a `Tool`.
-- **Resources** are readable data addressed by URI: a file, a table, a wiki page. The client fetches one and puts the content in context. The model does not call it as an action.
-- **Prompts** are named templates the server supplies. They usually surface to the user as a command rather than being picked by the model.
-
-Claude Code reaches resources through two built-in tools of its own, one to list and one to read, instead of advertising each resource separately.
-So a server holding a thousand documents still costs two entries in the tool list.
-
 ### The wire protocol under it
 
 The 2026-07-28 spec revision made the wire stateless. Every request now stands alone, so any server replica can answer it.
@@ -62,22 +53,6 @@ The harness side above (discover, wrap, merge) does not change. What changed on 
 For someone using an agent, nothing changes on screen: old servers keep working, and v1 SDKs stay maintained.
 The gains land underneath: remote servers scale behind a load balancer, the first call skips a round trip, and a cached tool list saves tokens.
 Servers on a deprecated feature get a twelve-month window to migrate. That work falls on the server author, not the user.
-
-### Adopting MCP and exposing schemas are two decisions
-
-Connecting to a server and advertising all of its tools are separate choices. The first one buys interop. The second one spends context.
-
-Every advertised tool costs tokens on every request: its name, its description, and its full input schema, before the model reads a word of the task.
-A handful of servers can add more text than the task itself, and a longer list also makes tool selection worse (section 2).
-
-So the harness picks an exposure level per server, not one setting for all of them:
-
-- **All schemas up front.** Simplest, and right for a server the session uses on almost every turn.
-- **An index first.** Advertise names and one-line summaries, then load a full schema when the model asks for that tool (section 2 covers the discovery side).
-- **One door.** Advertise a single tool that takes a server name and a tool name as arguments, and keep the rest behind it. The agent pays for one schema instead of fifty.
-
-None of this is in the protocol. The spec says how to list and call tools. How many of those reach the prompt is client policy,
-so deferred loading is a setting to check per harness, not something a server can count on.
 
 ### New: wrapping a discovered tool
 
@@ -174,6 +149,35 @@ run_turn([...goal...], model, reg, Session(mode=DEFAULT))   # the one agent call
 - The tool is read-only, so the gate allows it with no prompt. A destructive tool would ask, or be pre-approved by a rule keyed on the qualified name.
 - The loop does not change. MCP adds tools to the pool; everything downstream is section-2 dispatch and section-3 gating.
 
+### Further reading
+
+What follows is design, not code. It comes from the MCP specification and from ai-agent-book's account of how production agents run MCP.
+`src/` implements none of it. Nothing here is confirmed behaviour of the systems in the table below, so check the sources at the end before relying on it.
+
+**Three primitives, one pool.** A server can offer three kinds of thing. Only tools reach the pool above.
+
+- **Tools** are actions. The model picks one and calls it. `tools/list` returns these, and the code above wraps them.
+- **Resources** are data the client can read, each with a URI: a file, a table, a wiki page. The client fetches one and puts the text in context. The model never calls it.
+- **Prompts** are templates the server hands over. They usually show up as a command the user runs, not as something the model picks.
+
+Claude Code does not advertise resources one by one. It ships two tools, one that lists resources and one that reads them.
+So a server holding a thousand documents still costs two entries in the tool list.
+
+**Connecting and advertising are two decisions.** Connecting to a server buys interop. Advertising its tools spends context.
+You can do the first without doing all of the second.
+
+Each advertised tool costs tokens on every request. Name, description, and the full input schema, all of it sits in front of the task.
+Five servers can add more text than the task itself. A long list also makes the model pick the wrong tool more often (section 2).
+
+So decide per server how much to advertise, not once for all of them:
+
+- **Everything.** Simplest. Right for a server the session uses almost every turn.
+- **An index.** Advertise names and one-line summaries. Load the full schema when the model asks for that tool (section 2 covers the discovery side).
+- **One door.** Advertise one tool that takes a server name and a tool name. The rest stays behind it. The agent pays for one schema, not fifty.
+
+The protocol says nothing about this. It says how to list tools and how to call them. How many of them reach the prompt is up to the client.
+So deferred loading is a setting to check in your own harness. A server cannot assume it is on.
+
 ---
 
 ## Per system
@@ -195,20 +199,20 @@ How the harness reaches outside itself.
 
 - **Name collisions.** Two servers both expose `search`. The `mcp__server__tool` namespace prevents clashes; a server name with `__` still parses wrong, so keep names simple.
 - **Tool-list bloat.** Many servers make a large tool list that costs tokens and confuses selection (section 2).
-  Mitigation: truncate descriptions, and pick an exposure level per server instead of advertising every schema on every request.
+  Mitigation: truncate descriptions, and decide per server how much to advertise instead of sending every schema on every request.
 - **Stale pool after connect.** A server added mid-session is not in the cached tool list, so the model never sees it.
   Mitigation: rebuild pool and prompt on change (section 8); the 2026-07-28 spec adds `toolsListChanged` over `subscriptions/listen` and `ttlMs` hints for this.
 - **Connection churn.** A flaky server times out, resets, or expires its token. Mitigation: reconnect after repeated failures, re-auth on `401`, time out each call (section 11).
   The stateless revision drops stream resumability, so a broken in-flight request is re-issued as a new one, not resumed.
 - **Over-trusted side effects.** A server marks a destructive tool `readOnlyHint: true` to skip the prompt. Mitigation: a rule on the qualified name gates it anyway (section 3).
-- **Description poisoning.** A tool description is untrusted text that reaches the model as instructions. A server can bury a directive in it,
-  for example telling the model to read the user's key file first and pass it along, and the model may follow it while doing something unrelated.
-  Mitigation: read descriptions before installing a server, and treat a changed description as changed code.
-- **Tool shadowing.** All servers share one prompt, so one server's description can talk about another server's tools
-  (the payment tool is broken, use ours instead) and pull calls away from the trusted one.
-  Mitigation: namespacing stops name clashes, not influence. Keep unreviewed servers out of sessions that hold real credentials.
-- **Hijacked updates.** A server that was safe when reviewed ships new code and new descriptions on the next start, and nothing in the protocol re-asks the user.
-  Mitigation: pin a version, re-review on upgrade, and give each server its own least-privilege credential so one compromise cannot reach another server's scope.
+- **Description poisoning.** A tool description is text the server wrote, and the model reads it as instructions.
+  A server can hide an order in there, such as read the user's key file first and send it along. The model may do it.
+  Mitigation: read the descriptions before installing a server. When one changes, review it like changed code.
+- **Tool shadowing.** All servers share one prompt. So one server's description can talk about another server's tools,
+  claim the payment tool is broken, and pull the call to itself.
+  Mitigation: namespacing stops name clashes. It does not stop this. Keep unreviewed servers out of sessions that hold real credentials.
+- **Hijacked updates.** A server passes review, then ships new code and new descriptions on the next start. The protocol never asks the user again.
+  Mitigation: pin a version. Read the descriptions again after an upgrade. Give each server its own least-privilege credential, so one bad server cannot reach another one's scope.
 
 ---
 

--- a/sections/19-mcp-plugins-channels/README.md
+++ b/sections/19-mcp-plugins-channels/README.md
@@ -160,22 +160,22 @@ What follows is design, not code. It comes from the MCP specification and from a
 - **Resources** are data the client can read, each with a URI: a file, a table, a wiki page. The client fetches one and puts the text in context. The model never calls it.
 - **Prompts** are templates the server hands over. They usually show up as a command the user runs, not as something the model picks.
 
-Claude Code does not advertise resources one by one. It ships two tools, one that lists resources and one that reads them.
+**Resources stay off the tool list.** Claude Code does not advertise them one by one. It ships two tools, one that lists resources and one that reads them.
 So a server holding a thousand documents still costs two entries in the tool list.
 
 **Connecting and advertising are two decisions.** Connecting to a server buys interop. Advertising its tools spends context.
 You can do the first without doing all of the second.
 
-Each advertised tool costs tokens on every request. Name, description, and the full input schema, all of it sits in front of the task.
+**What advertising costs.** Each advertised tool costs tokens on every request. Name, description, and the full input schema, all of it sits in front of the task.
 Five servers can add more text than the task itself. A long list also makes the model pick the wrong tool more often (section 2).
 
-So decide per server how much to advertise, not once for all of them:
+**Three levels to pick from.** Decide per server how much to advertise, not once for all of them:
 
 - **Everything.** Simplest. Right for a server the session uses almost every turn.
 - **An index.** Advertise names and one-line summaries. Load the full schema when the model asks for that tool (section 2 covers the discovery side).
 - **One door.** Advertise one tool that takes a server name and a tool name. The rest stays behind it. The agent pays for one schema, not fifty.
 
-The protocol says nothing about this. It says how to list tools and how to call them. How many of them reach the prompt is up to the client.
+**None of this is in the protocol.** The spec says how to list tools and how to call them. How many of them reach the prompt is up to the client.
 So deferred loading is a setting to check in your own harness. A server cannot assume it is on.
 
 ---

--- a/sections/19-mcp-plugins-channels/README.md
+++ b/sections/19-mcp-plugins-channels/README.md
@@ -151,8 +151,7 @@ run_turn([...goal...], model, reg, Session(mode=DEFAULT))   # the one agent call
 
 ### Further reading
 
-What follows is design, not code. It comes from the MCP specification and from ai-agent-book's account of how production agents run MCP.
-`src/` implements none of it. Nothing here is confirmed behaviour of the systems in the table below, so check the sources at the end before relying on it.
+None of this is in `src/`. It comes from ai-agent-book and the MCP spec, and is not confirmed of the systems in the table.
 
 **Three primitives, one pool.** A server can offer three kinds of thing. Only tools reach the pool above.
 

--- a/sections/19-mcp-plugins-channels/README.md
+++ b/sections/19-mcp-plugins-channels/README.md
@@ -13,7 +13,8 @@ In MCP terms the service is the server, and the harness that connects and calls 
 
 So the agent gains a Jira tool or a deploy tool without anyone editing the harness. Leave MCP out and capability is frozen at whatever shipped in the binary.
 
-Two more pieces build on MCP. A plugin bundles servers with hooks and skills, so they install as one unit. A channel lets a server push messages back in. Both ride the same protocol.
+Two more pieces build on MCP. A plugin bundles servers with hooks and skills, so they install as one unit.
+A channel lets a server push messages back in. Both ride the same protocol.
 
 ---
 
@@ -29,6 +30,15 @@ Names are namespaced `mcp__<server>__<tool>` so two servers never collide. The l
 - The name is namespaced and normalized, so it is unique and matches the API's name pattern.
 - Each tool's MCP annotations (`readOnlyHint`, `destructiveHint`) become the permission hints the gate reads (section 3).
 - Merged into the one `Registry`, the model sees MCP tools and built-ins in the same list.
+
+A server can advertise three kinds of primitive, and only one of them lands in that pool.
+
+- **Tools** are actions the model picks and calls. These are what `tools/list` returns and what the wrapping below turns into a `Tool`.
+- **Resources** are readable data addressed by URI: a file, a table, a wiki page. The client fetches one and puts the content in context. The model does not call it as an action.
+- **Prompts** are named templates the server supplies. They usually surface to the user as a command rather than being picked by the model.
+
+Claude Code reaches resources through two built-in tools of its own, one to list and one to read, instead of advertising each resource separately.
+So a server holding a thousand documents still costs two entries in the tool list.
 
 ### The wire protocol under it
 
@@ -52,6 +62,22 @@ The harness side above (discover, wrap, merge) does not change. What changed on 
 For someone using an agent, nothing changes on screen: old servers keep working, and v1 SDKs stay maintained.
 The gains land underneath: remote servers scale behind a load balancer, the first call skips a round trip, and a cached tool list saves tokens.
 Servers on a deprecated feature get a twelve-month window to migrate. That work falls on the server author, not the user.
+
+### Adopting MCP and exposing schemas are two decisions
+
+Connecting to a server and advertising all of its tools are separate choices. The first one buys interop. The second one spends context.
+
+Every advertised tool costs tokens on every request: its name, its description, and its full input schema, before the model reads a word of the task.
+A handful of servers can add more text than the task itself, and a longer list also makes tool selection worse (section 2).
+
+So the harness picks an exposure level per server, not one setting for all of them:
+
+- **All schemas up front.** Simplest, and right for a server the session uses on almost every turn.
+- **An index first.** Advertise names and one-line summaries, then load a full schema when the model asks for that tool (section 2 covers the discovery side).
+- **One door.** Advertise a single tool that takes a server name and a tool name as arguments, and keep the rest behind it. The agent pays for one schema instead of fifty.
+
+None of this is in the protocol. The spec says how to list and call tools. How many of those reach the prompt is client policy,
+so deferred loading is a setting to check per harness, not something a server can count on.
 
 ### New: wrapping a discovered tool
 
@@ -168,12 +194,21 @@ How the harness reaches outside itself.
 ## Failure modes
 
 - **Name collisions.** Two servers both expose `search`. The `mcp__server__tool` namespace prevents clashes; a server name with `__` still parses wrong, so keep names simple.
-- **Tool-list bloat.** Many servers make a large tool list that costs tokens and confuses selection (section 2). Mitigation: truncate descriptions and defer loading.
+- **Tool-list bloat.** Many servers make a large tool list that costs tokens and confuses selection (section 2).
+  Mitigation: truncate descriptions, and pick an exposure level per server instead of advertising every schema on every request.
 - **Stale pool after connect.** A server added mid-session is not in the cached tool list, so the model never sees it.
   Mitigation: rebuild pool and prompt on change (section 8); the 2026-07-28 spec adds `toolsListChanged` over `subscriptions/listen` and `ttlMs` hints for this.
 - **Connection churn.** A flaky server times out, resets, or expires its token. Mitigation: reconnect after repeated failures, re-auth on `401`, time out each call (section 11).
   The stateless revision drops stream resumability, so a broken in-flight request is re-issued as a new one, not resumed.
 - **Over-trusted side effects.** A server marks a destructive tool `readOnlyHint: true` to skip the prompt. Mitigation: a rule on the qualified name gates it anyway (section 3).
+- **Description poisoning.** A tool description is untrusted text that reaches the model as instructions. A server can bury a directive in it,
+  for example telling the model to read the user's key file first and pass it along, and the model may follow it while doing something unrelated.
+  Mitigation: read descriptions before installing a server, and treat a changed description as changed code.
+- **Tool shadowing.** All servers share one prompt, so one server's description can talk about another server's tools
+  (the payment tool is broken, use ours instead) and pull calls away from the trusted one.
+  Mitigation: namespacing stops name clashes, not influence. Keep unreviewed servers out of sessions that hold real credentials.
+- **Hijacked updates.** A server that was safe when reviewed ships new code and new descriptions on the next start, and nothing in the protocol re-asks the user.
+  Mitigation: pin a version, re-review on upgrade, and give each server its own least-privilege credential so one compromise cannot reach another server's scope.
 
 ---
 
@@ -204,7 +239,10 @@ uv run python sections/19-mcp-plugins-channels/src/demo.py  # live demo, needs a
 - [Hermes Agent source](https://github.com/NousResearch/hermes-agent):
   `mcp_serve.py`, `hermes_cli/plugins.py` (`PluginManager`, `VALID_HOOKS`), `gateway/platforms/`, `gateway/platform_registry.py`, `plugins/platforms/`.
 - [MCP specification 2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28) and its
-  [changelog](https://modelcontextprotocol.io/specification/2026-07-28/changelog): stateless protocol, `server/discover`, `subscriptions/listen`, MRTR, deprecations.
+  [changelog](https://modelcontextprotocol.io/specification/2026-07-28/changelog): stateless protocol, the three primitives (tools, resources, prompts),
+  `server/discover`, `subscriptions/listen`, MRTR, deprecations.
 - MCP blog: [the future of transports](https://blog.modelcontextprotocol.io/posts/2025-12-19-mcp-transport-future/) (why the protocol went stateless),
   [SDK betas for 2026-07-28](https://blog.modelcontextprotocol.io/posts/sdk-betas-2026-07-28/) (v2 SDKs, backward compatibility).
+- [ai-agent-book](https://github.com/bojieli/ai-agent-book): `book/chapter4.md`, Chinese original canonical. The tool ecosystem section:
+  MCP primitives, context overhead of advertised schemas, and the trust model (description poisoning, tool shadowing, hijacked updates, credential scope).
 - Framing: [learn-claude-code · s19_mcp_plugin](https://github.com/shareAI-lab/learn-claude-code).

--- a/sections/19-mcp-plugins-channels/README.zh-CN.md
+++ b/sections/19-mcp-plugins-channels/README.zh-CN.md
@@ -148,8 +148,7 @@ run_turn([...goal...], model, reg, Session(mode=DEFAULT))   # the one agent call
 
 ### 延伸阅读
 
-下面这段讲的是设计，不是代码。它出自 MCP 的 spec，以及 ai-agent-book 对正式环境的 agent 怎么用 MCP 的描述。
-`src/` 一个都没实现。这里写的也不等于下面表格那些系统确认过的行为，真要依赖之前，先看最后的来源。
+以下设计 `src/` 都没有实现，出自 ai-agent-book 和 MCP spec，也未经下面表格的系统证实。
 
 **三种 primitive，只有一种进池子：**一个 server 可以提供三种东西，但只有 tool 会进到上面那个池子。
 

--- a/sections/19-mcp-plugins-channels/README.zh-CN.md
+++ b/sections/19-mcp-plugins-channels/README.zh-CN.md
@@ -30,6 +30,15 @@ MCP 之外，这一章还讲两个搭在它上面的机制：plugin 把 server �
 - 每个工具的 MCP annotation（`readOnlyHint`、`destructiveHint`）成为 gate 读取的权限提示（第 3 章）。
 - 合并进那一个 `Registry` 之后，模型会在同一份清单里看到 MCP 工具与内建工具。
 
+一个 server 可以公告三种 primitive，但只有一种会进到上面那个池子。
+
+- **Tools** 是模型自己挑、自己调用的动作。`tools/list` 返回的就是它们，下面的包装也是把它们变成 `Tool`。
+- **Resources** 是用 URI 定址的可读数据：一个文件、一张表、一页 wiki。client 抓下来把内容放进 context，模型不会把它当动作来调用。
+- **Prompts** 是 server 提供的具名模板。它通常是给用户当命令用的，不是让模型自己挑的。
+
+Claude Code 是用自己的两个内建工具去碰 resource，一个列清单、一个读内容，而不是把每个 resource 都公告成一项工具。
+所以一个放了上千份文档的 server，在工具清单里仍然只占两格。
+
 ### 底层的 wire protocol
 
 2026-07-28 版的 spec 把 protocol 本身改成了 stateless：每个 request 都是独立的，哪台 server 副本都能接。
@@ -52,6 +61,22 @@ MCP 之外，这一章还讲两个搭在它上面的机制：plugin 把 server �
 对用 agent 的人来说，界面上什么都没变：旧 server 照常运作，v1 SDK 也继续维护。
 好处都出现在用户看不到的地方：远程 server 能挂在 load balancer 后面扩展，第一次调用少一趟来回，cache 住的工具清单也省 token。
 用到 deprecated 功能的 server 有十二个月的窗口可以迁移。那是 server 作者要做的事，不是用户的事。
+
+### 接上 MCP 和公告 schema 是两个决定
+
+连上一个 server，跟把它所有工具都公告给模型，是两件事。前者换到的是互通，后者花掉的是 context。
+
+每一个公告出去的工具，每次 request 都要付 token：名称、描述、完整的 input schema，全都排在模型读到任务之前。
+几个 server 加起来，这段文字可能比任务本身还长；清单一长，模型挑工具也挑得更差（第 2 章）。
+
+所以 harness 是一个 server 一个 server 决定要露出多少，而不是全部套同一个配置：
+
+- **全部 schema 都先给。** 最单纯，适合那种几乎每一轮都会用到的 server。
+- **先给一份索引。** 只公告名称和一句话说明，等模型指名要哪个工具，再把完整的 schema 载进来（探索那一侧在第 2 章）。
+- **只开一扇门。** 只公告一个工具，参数是 server 名称和工具名称，其他全部藏在它后面。agent 只要付一份 schema，不是五十份。
+
+这些都不写在 protocol 里。spec 只规定怎么列工具、怎么调用工具。到底有多少工具会进到 prompt，是 client 自己的策略，
+所以延后载入是每个 harness 要自己确认的配置，server 不能假设它一定开着。
 
 ### New: 包装探索到的工具
 
@@ -166,12 +191,21 @@ harness 如何伸手触及自身之外。
 ## 哪里会出错
 
 - **撞名（Name collisions）：**两个 server 都公开 `search`。`mcp__server__tool` 命名空间避免了冲突；但一个名称含 `__` 的 server 仍会被解析错误，所以名称要保持简单。
-- **工具清单膨胀（Tool-list bloat）：**太多 server 会造成庞大的工具清单，既花 token 又干扰选择（第 2 章）。缓解：截断描述并延后载入。
+- **工具清单膨胀（Tool-list bloat）：**太多 server 会造成庞大的工具清单，既花 token 又干扰选择（第 2 章）。
+  缓解：截断描述，并且一个 server 一个 server 决定要露出多少，而不是每次 request 都把所有 schema 公告一遍。
 - **connect 之后池过时：**一个在 session 中途加入的 server 不在 cache 的工具清单里，于是模型永远看不到它。缓解：变动时重建池并重建 prompt（第 8 章）；
   2026-07-28 版的 spec 为此加了走 `subscriptions/listen` 的 `toolsListChanged` 通知和 `ttlMs` 提示。
 - **连接抖动（Connection churn）：**一个不稳的 server 会超时、重置，或 token 过期。缓解：反复失败后重连、`401` 时重新验证、为每次调用设超时（第 11 章）。
   stateless 版拿掉了 stream 续传，所以中断的 request 要当成一个新 request 重发，不是接着传。
 - **被过度信任的副作用：**一个 server 把具破坏性的工具标成 `readOnlyHint: true` 以跳过提示。缓解：以完整名称设一条规则照样 gate 它（第 3 章）。
+- **描述投毒（Description poisoning）：**工具描述是不可信的文字，却会以指令的形式送到模型面前。server 可以在里面埋一句话，
+  例如叫模型先读用户的密钥文件、再一起传过来，模型很可能在做别的事的时候就顺手照做了。
+  缓解：装一个 server 之前先把描述读过，描述改了就当成代码改了来看。
+- **工具遮蔽（Tool shadowing）：**所有 server 共用同一份 prompt，所以一个 server 的描述可以讲到另一个 server 的工具
+  （付款工具坏了，改用我们的），把调用从可信的那个拉走。
+  缓解：命名空间挡得住撞名，挡不住影响。没审过的 server，就别放进握有真实凭证的 session。
+- **被劫持的更新（Hijacked updates）：**一个当初审过、确认安全的 server，下次启动时换上新的代码和新的描述，而 protocol 不会再问用户一次。
+  缓解：把版本钉住、升级时重审，并且让每个 server 各自持有最小权限的凭证，这样一个被攻破，也伸不到别的 server 的范围。
 
 ---
 
@@ -194,12 +228,18 @@ uv run python sections/19-mcp-plugins-channels/src/demo.py  # live demo, needs a
 
 ## 来源
 
-- [Claude Code MCP transport](https://github.com/yasasbanukaofficial/claude-code)：`services/mcp/types.ts`（`TransportSchema`）、`client.ts`（`MCPTool` cloning、`buildMcpToolName`）、`normalization.ts`（`normalizeNameForMCP`）。
-- [Claude Code MCP config and channels](https://github.com/yasasbanukaofficial/claude-code)：`config.ts`（precedence）、`channelNotification.ts`（`CHANNEL_TAG`），加上 `McpAuthTool`、`ListMcpResourcesTool`、`ReadMcpResourceTool`。
+- [Claude Code MCP transport](https://github.com/yasasbanukaofficial/claude-code)：
+  `services/mcp/types.ts`（`TransportSchema`）、`client.ts`（`MCPTool` cloning、`buildMcpToolName`）、`normalization.ts`（`normalizeNameForMCP`）。
+- [Claude Code MCP config and channels](https://github.com/yasasbanukaofficial/claude-code)：
+  `config.ts`（precedence）、`channelNotification.ts`（`CHANNEL_TAG`），加上 `McpAuthTool`、`ListMcpResourcesTool`、`ReadMcpResourceTool`。
 - [Claude Code plugins](https://github.com/yasasbanukaofficial/claude-code)：`plugins/builtinPlugins.ts`、`plugins/bundled/`、`types/plugin.ts`，加上 `remote/` 与 `bridge/`。
-- [Hermes Agent 源码](https://github.com/NousResearch/hermes-agent)：`mcp_serve.py`、`hermes_cli/plugins.py`（`PluginManager`、`VALID_HOOKS`）、`gateway/platforms/`、`gateway/platform_registry.py`、`plugins/platforms/`。
+- [Hermes Agent 源码](https://github.com/NousResearch/hermes-agent)：
+  `mcp_serve.py`、`hermes_cli/plugins.py`（`PluginManager`、`VALID_HOOKS`）、`gateway/platforms/`、`gateway/platform_registry.py`、`plugins/platforms/`。
 - [MCP specification 2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28) 与它的
-  [changelog](https://modelcontextprotocol.io/specification/2026-07-28/changelog)：stateless protocol、`server/discover`、`subscriptions/listen`、MRTR、deprecation 清单。
+  [changelog](https://modelcontextprotocol.io/specification/2026-07-28/changelog)：stateless protocol、tools / resources / prompts 三种 primitive、
+  `server/discover`、`subscriptions/listen`、MRTR、deprecation 清单。
 - MCP blog：[the future of transports](https://blog.modelcontextprotocol.io/posts/2025-12-19-mcp-transport-future/)（protocol 为什么走向 stateless）、
   [SDK betas for 2026-07-28](https://blog.modelcontextprotocol.io/posts/sdk-betas-2026-07-28/)（v2 SDK 与向后兼容）。
+- [ai-agent-book](https://github.com/bojieli/ai-agent-book)：`book/chapter4.md`，以中文原版为准。工具生态那一节：
+  MCP 的 primitive、公告 schema 的 context 开销，以及信任模型（描述投毒、工具遮蔽、被劫持的更新、凭证范围）。
 - 章节定位：[learn-claude-code · s19_mcp_plugin](https://github.com/shareAI-lab/learn-claude-code)。

--- a/sections/19-mcp-plugins-channels/README.zh-CN.md
+++ b/sections/19-mcp-plugins-channels/README.zh-CN.md
@@ -151,28 +151,28 @@ run_turn([...goal...], model, reg, Session(mode=DEFAULT))   # the one agent call
 下面这段讲的是设计，不是代码。它出自 MCP 的 spec，以及 ai-agent-book 对正式环境的 agent 怎么用 MCP 的描述。
 `src/` 一个都没实现。这里写的也不等于下面表格那些系统确认过的行为，真要依赖之前，先看最后的来源。
 
-**三种 primitive，只有一种进池子。** 一个 server 可以提供三种东西，但只有 tool 会进到上面那个池子。
+**三种 primitive，只有一种进池子：**一个 server 可以提供三种东西，但只有 tool 会进到上面那个池子。
 
 - **Tools** 是动作。模型自己挑一个来调用。`tools/list` 返回的就是这些，上面的代码包的也是它们。
 - **Resources** 是可以读的数据，每一条都有一个 URI：一个文件、一张表、一页 wiki。client 把它抓下来，把内容放进 context。模型不会去调用它。
 - **Prompts** 是 server 给的模板。它通常是用户可以下的一个命令，不是模型自己挑的东西。
 
-Claude Code 不会把 resource 一个一个公告出去。它只放两个工具，一个列出 resource，一个把 resource 读出来。
+**resource 不会出现在工具清单上：**Claude Code 不会把它们一个一个公告出去，它只放两个工具，一个列出 resource，一个把 resource 读出来。
 所以一个放了上千份文档的 server，在工具清单里还是只占两格。
 
-**连上去和公告出去，是两个决定。** 连上一个 server，换到的是互通；把它的工具公告给模型，花掉的是 context。
+**连上去和公告出去，是两个决定：**连上一个 server，换到的是互通；把它的工具公告给模型，花掉的是 context。
 前面那件事可以做，后面那件事不一定要做满。
 
-每一个公告出去的工具，每次 request 都在花 token。名称、描述、完整的 input schema，全都排在任务前面。
+**公告出去要付什么代价：**每一个公告出去的工具，每次 request 都在花 token。名称、描述、完整的 input schema，全都排在任务前面。
 五个 server 加起来，这段文字可能比任务本身还长。清单一长，模型也更容易挑错工具（第 2 章）。
 
-所以要一个 server 一个 server 决定公告多少，不是全部一起套：
+**公告的程度有三种可以挑：**一个 server 一个 server 决定公告多少，不是全部一起套。
 
 - **全部都公告。** 最单纯。适合那种几乎每一轮都会用到的 server。
 - **只公告一份索引。** 先给名称和一句话说明。等模型指名要哪个工具，再把完整的 schema 载进来（探索那一侧在第 2 章）。
 - **只开一扇门。** 只公告一个工具，参数是 server 名称和工具名称，其他都放在它后面。agent 只要付一份 schema，不用付五十份。
 
-protocol 完全没管这件事。它只规定工具怎么列、怎么调用。有多少工具会进到 prompt，是 client 自己决定的。
+**protocol 完全没管这件事：**它只规定工具怎么列、怎么调用。有多少工具会进到 prompt，是 client 自己决定的。
 所以延后载入是你要去自己的 harness 里确认的配置，server 不能假设它一定开着。
 
 ---

--- a/sections/19-mcp-plugins-channels/README.zh-CN.md
+++ b/sections/19-mcp-plugins-channels/README.zh-CN.md
@@ -30,15 +30,6 @@ MCP 之外，这一章还讲两个搭在它上面的机制：plugin 把 server �
 - 每个工具的 MCP annotation（`readOnlyHint`、`destructiveHint`）成为 gate 读取的权限提示（第 3 章）。
 - 合并进那一个 `Registry` 之后，模型会在同一份清单里看到 MCP 工具与内建工具。
 
-一个 server 可以公告三种 primitive，但只有一种会进到上面那个池子。
-
-- **Tools** 是模型自己挑、自己调用的动作。`tools/list` 返回的就是它们，下面的包装也是把它们变成 `Tool`。
-- **Resources** 是用 URI 定址的可读数据：一个文件、一张表、一页 wiki。client 抓下来把内容放进 context，模型不会把它当动作来调用。
-- **Prompts** 是 server 提供的具名模板。它通常是给用户当命令用的，不是让模型自己挑的。
-
-Claude Code 是用自己的两个内建工具去碰 resource，一个列清单、一个读内容，而不是把每个 resource 都公告成一项工具。
-所以一个放了上千份文档的 server，在工具清单里仍然只占两格。
-
 ### 底层的 wire protocol
 
 2026-07-28 版的 spec 把 protocol 本身改成了 stateless：每个 request 都是独立的，哪台 server 副本都能接。
@@ -61,22 +52,6 @@ Claude Code 是用自己的两个内建工具去碰 resource，一个列清单�
 对用 agent 的人来说，界面上什么都没变：旧 server 照常运作，v1 SDK 也继续维护。
 好处都出现在用户看不到的地方：远程 server 能挂在 load balancer 后面扩展，第一次调用少一趟来回，cache 住的工具清单也省 token。
 用到 deprecated 功能的 server 有十二个月的窗口可以迁移。那是 server 作者要做的事，不是用户的事。
-
-### 接上 MCP 和公告 schema 是两个决定
-
-连上一个 server，跟把它所有工具都公告给模型，是两件事。前者换到的是互通，后者花掉的是 context。
-
-每一个公告出去的工具，每次 request 都要付 token：名称、描述、完整的 input schema，全都排在模型读到任务之前。
-几个 server 加起来，这段文字可能比任务本身还长；清单一长，模型挑工具也挑得更差（第 2 章）。
-
-所以 harness 是一个 server 一个 server 决定要露出多少，而不是全部套同一个配置：
-
-- **全部 schema 都先给。** 最单纯，适合那种几乎每一轮都会用到的 server。
-- **先给一份索引。** 只公告名称和一句话说明，等模型指名要哪个工具，再把完整的 schema 载进来（探索那一侧在第 2 章）。
-- **只开一扇门。** 只公告一个工具，参数是 server 名称和工具名称，其他全部藏在它后面。agent 只要付一份 schema，不是五十份。
-
-这些都不写在 protocol 里。spec 只规定怎么列工具、怎么调用工具。到底有多少工具会进到 prompt，是 client 自己的策略，
-所以延后载入是每个 harness 要自己确认的配置，server 不能假设它一定开着。
 
 ### New: 包装探索到的工具
 
@@ -171,6 +146,35 @@ run_turn([...goal...], model, reg, Session(mode=DEFAULT))   # the one agent call
 - 这个工具是只读的，所以 gate 不提示就放行。一个具破坏性的工具则会询问，或由一条以完整名称为键的规则预先核准。
 - loop 不变。MCP 只是往池里加工具；下游的一切都是第 2 章的 dispatch 与第 3 章的 gating。
 
+### 延伸阅读
+
+下面这段讲的是设计，不是代码。它出自 MCP 的 spec，以及 ai-agent-book 对正式环境的 agent 怎么用 MCP 的描述。
+`src/` 一个都没实现。这里写的也不等于下面表格那些系统确认过的行为，真要依赖之前，先看最后的来源。
+
+**三种 primitive，只有一种进池子。** 一个 server 可以提供三种东西，但只有 tool 会进到上面那个池子。
+
+- **Tools** 是动作。模型自己挑一个来调用。`tools/list` 返回的就是这些，上面的代码包的也是它们。
+- **Resources** 是可以读的数据，每一条都有一个 URI：一个文件、一张表、一页 wiki。client 把它抓下来，把内容放进 context。模型不会去调用它。
+- **Prompts** 是 server 给的模板。它通常是用户可以下的一个命令，不是模型自己挑的东西。
+
+Claude Code 不会把 resource 一个一个公告出去。它只放两个工具，一个列出 resource，一个把 resource 读出来。
+所以一个放了上千份文档的 server，在工具清单里还是只占两格。
+
+**连上去和公告出去，是两个决定。** 连上一个 server，换到的是互通；把它的工具公告给模型，花掉的是 context。
+前面那件事可以做，后面那件事不一定要做满。
+
+每一个公告出去的工具，每次 request 都在花 token。名称、描述、完整的 input schema，全都排在任务前面。
+五个 server 加起来，这段文字可能比任务本身还长。清单一长，模型也更容易挑错工具（第 2 章）。
+
+所以要一个 server 一个 server 决定公告多少，不是全部一起套：
+
+- **全部都公告。** 最单纯。适合那种几乎每一轮都会用到的 server。
+- **只公告一份索引。** 先给名称和一句话说明。等模型指名要哪个工具，再把完整的 schema 载进来（探索那一侧在第 2 章）。
+- **只开一扇门。** 只公告一个工具，参数是 server 名称和工具名称，其他都放在它后面。agent 只要付一份 schema，不用付五十份。
+
+protocol 完全没管这件事。它只规定工具怎么列、怎么调用。有多少工具会进到 prompt，是 client 自己决定的。
+所以延后载入是你要去自己的 harness 里确认的配置，server 不能假设它一定开着。
+
 ---
 
 ## 各系统做法
@@ -192,20 +196,20 @@ harness 如何伸手触及自身之外。
 
 - **撞名（Name collisions）：**两个 server 都公开 `search`。`mcp__server__tool` 命名空间避免了冲突；但一个名称含 `__` 的 server 仍会被解析错误，所以名称要保持简单。
 - **工具清单膨胀（Tool-list bloat）：**太多 server 会造成庞大的工具清单，既花 token 又干扰选择（第 2 章）。
-  缓解：截断描述，并且一个 server 一个 server 决定要露出多少，而不是每次 request 都把所有 schema 公告一遍。
+  缓解：截断描述，并且一个 server 一个 server 决定公告多少，不要每次 request 都把所有 schema 送一遍。
 - **connect 之后池过时：**一个在 session 中途加入的 server 不在 cache 的工具清单里，于是模型永远看不到它。缓解：变动时重建池并重建 prompt（第 8 章）；
   2026-07-28 版的 spec 为此加了走 `subscriptions/listen` 的 `toolsListChanged` 通知和 `ttlMs` 提示。
 - **连接抖动（Connection churn）：**一个不稳的 server 会超时、重置，或 token 过期。缓解：反复失败后重连、`401` 时重新验证、为每次调用设超时（第 11 章）。
   stateless 版拿掉了 stream 续传，所以中断的 request 要当成一个新 request 重发，不是接着传。
 - **被过度信任的副作用：**一个 server 把具破坏性的工具标成 `readOnlyHint: true` 以跳过提示。缓解：以完整名称设一条规则照样 gate 它（第 3 章）。
-- **描述投毒（Description poisoning）：**工具描述是不可信的文字，却会以指令的形式送到模型面前。server 可以在里面埋一句话，
-  例如叫模型先读用户的密钥文件、再一起传过来，模型很可能在做别的事的时候就顺手照做了。
-  缓解：装一个 server 之前先把描述读过，描述改了就当成代码改了来看。
-- **工具遮蔽（Tool shadowing）：**所有 server 共用同一份 prompt，所以一个 server 的描述可以讲到另一个 server 的工具
-  （付款工具坏了，改用我们的），把调用从可信的那个拉走。
-  缓解：命名空间挡得住撞名，挡不住影响。没审过的 server，就别放进握有真实凭证的 session。
-- **被劫持的更新（Hijacked updates）：**一个当初审过、确认安全的 server，下次启动时换上新的代码和新的描述，而 protocol 不会再问用户一次。
-  缓解：把版本钉住、升级时重审，并且让每个 server 各自持有最小权限的凭证，这样一个被攻破，也伸不到别的 server 的范围。
+- **描述投毒（Description poisoning）：**工具描述是 server 自己写的文字，模型却把它当成指令在读。
+  server 可以在里面塞一句话，例如叫模型先读用户的密钥文件、再一起传过来。模型真的有可能照做。
+  缓解：装一个 server 之前，先把描述读过一遍。描述改了，就当成代码改了那样审。
+- **工具遮蔽（Tool shadowing）：**所有 server 共用同一份 prompt。所以一个 server 的描述可以讲到另一个 server 的工具，
+  说付款工具坏了，再把调用拉到自己身上。
+  缓解：命名空间挡得住撞名，挡不住这个。没审过的 server，别放进握有真实凭证的 session。
+- **被劫持的更新（Hijacked updates）：**一个 server 审过了，下次启动时却换上新的代码和新的描述。protocol 不会再问用户一次。
+  缓解：把版本钉住。升级之后把描述再读一遍。每个 server 各给一份最小权限的凭证，这样一个 server 坏掉，也伸不到别的 server 的范围。
 
 ---
 

--- a/sections/19-mcp-plugins-channels/README.zh-TW.md
+++ b/sections/19-mcp-plugins-channels/README.zh-TW.md
@@ -30,15 +30,6 @@ MCP 之外，這一章還講兩個搭在它上面的機制：plugin 把 server �
 - 每個工具的 MCP annotation（`readOnlyHint`、`destructiveHint`）成為 gate 讀取的權限提示（第 3 章）。
 - 合併進那一個 `Registry` 之後，模型會在同一份清單裡看到 MCP 工具與內建工具。
 
-一個 server 可以公告三種 primitive，但只有一種會進到上面那個池子。
-
-- **Tools** 是模型自己挑、自己呼叫的動作。`tools/list` 回傳的就是它們，下面的包裝也是把它們變成 `Tool`。
-- **Resources** 是用 URI 定址的可讀資料：一個檔案、一張表、一頁 wiki。client 抓下來把內容放進 context，模型不會把它當動作來呼叫。
-- **Prompts** 是 server 提供的具名範本。它通常是給使用者當指令用的，不是讓模型自己挑的。
-
-Claude Code 是用自己的兩個內建工具去碰 resource，一個列清單、一個讀內容，而不是把每個 resource 都公告成一項工具。
-所以一個放了上千份文件的 server，在工具清單裡仍然只佔兩格。
-
 ### 底層的 wire protocol
 
 2026-07-28 版的 spec 把 protocol 本身改成了 stateless：每個 request 都是獨立的，哪台 server 副本都能接。
@@ -61,22 +52,6 @@ Claude Code 是用自己的兩個內建工具去碰 resource，一個列清單�
 對用 agent 的人來說，畫面上什麼都沒變：舊 server 照常運作，v1 SDK 也繼續維護。
 好處都出現在使用者看不到的地方：遠端 server 能掛在 load balancer 後面擴展，第一次呼叫少一趟來回，cache 住的工具清單也省 token。
 用到 deprecated 功能的 server 有十二個月的窗口可以遷移。那是 server 作者要做的事，不是使用者的事。
-
-### 接上 MCP 和公告 schema 是兩個決定
-
-連上一個 server，跟把它所有工具都公告給模型，是兩件事。前者換到的是互通，後者花掉的是 context。
-
-每一個公告出去的工具，每次 request 都要付 token：名稱、描述、完整的 input schema，全都排在模型讀到任務之前。
-幾個 server 加起來，這段文字可能比任務本身還長；清單一長，模型挑工具也挑得更差（第 2 章）。
-
-所以 harness 是一個 server 一個 server 決定要露出多少，而不是全部套同一個設定：
-
-- **全部 schema 都先給。** 最單純，適合那種幾乎每一輪都會用到的 server。
-- **先給一份索引。** 只公告名稱和一句話說明，等模型指名要哪個工具，再把完整的 schema 載進來（探索那一側在第 2 章）。
-- **只開一扇門。** 只公告一個工具，參數是 server 名稱和工具名稱，其他全部藏在它後面。agent 只要付一份 schema，不是五十份。
-
-這些都不寫在 protocol 裡。spec 只規定怎麼列工具、怎麼呼叫工具。到底有多少工具會進到 prompt，是 client 自己的政策，
-所以延後載入是每個 harness 要自己確認的設定，server 不能假設它一定開著。
 
 ### New: 包裝探索到的工具
 
@@ -171,6 +146,35 @@ run_turn([...goal...], model, reg, Session(mode=DEFAULT))   # the one agent call
 - 這個工具是唯讀的，所以 gate 不提示就放行。一個具破壞性的工具則會詢問，或由一條以完整名稱為鍵的規則預先核准。
 - loop 不變。MCP 只是往池裡加工具；下游的一切都是第 2 章的 dispatch 與第 3 章的 gating。
 
+### 延伸閱讀
+
+底下這段講的是設計，不是程式碼。它出自 MCP 的 spec，以及 ai-agent-book 對正式環境的 agent 怎麼用 MCP 的描述。
+`src/` 一個都沒實作。這裡寫的也不等於下面表格那些系統確認過的行為，真要依賴之前，先看最後的出處。
+
+**三種 primitive，只有一種進池子。** 一個 server 可以提供三種東西，但只有 tool 會進到上面那個池子。
+
+- **Tools** 是動作。模型自己挑一個來呼叫。`tools/list` 回傳的就是這些，上面的程式碼包的也是它們。
+- **Resources** 是可以讀的資料，每一筆都有一個 URI：一個檔案、一張表、一頁 wiki。client 把它抓下來，把內容放進 context。模型不會去呼叫它。
+- **Prompts** 是 server 給的範本。它通常是使用者可以下的一個指令，不是模型自己挑的東西。
+
+Claude Code 不會把 resource 一個一個公告出去。它只放兩個工具，一個列出 resource，一個把 resource 讀出來。
+所以一個放了上千份文件的 server，在工具清單裡還是只佔兩格。
+
+**連上去和公告出去，是兩個決定。** 連上一個 server，換到的是互通；把它的工具公告給模型，花掉的是 context。
+前面那件事可以做，後面那件事不一定要做滿。
+
+每一個公告出去的工具，每次 request 都在花 token。名稱、描述、完整的 input schema，全都排在任務前面。
+五個 server 加起來，這段文字可能比任務本身還長。清單一長，模型也更容易挑錯工具（第 2 章）。
+
+所以要一個 server 一個 server 決定公告多少，不是全部一起套：
+
+- **全部都公告。** 最單純。適合那種幾乎每一輪都會用到的 server。
+- **只公告一份索引。** 先給名稱和一句話說明。等模型指名要哪個工具，再把完整的 schema 載進來（探索那一側在第 2 章）。
+- **只開一扇門。** 只公告一個工具，參數是 server 名稱和工具名稱，其他都放在它後面。agent 只要付一份 schema，不用付五十份。
+
+protocol 完全沒管這件事。它只規定工具怎麼列、怎麼呼叫。有多少工具會進到 prompt，是 client 自己決定的。
+所以延後載入是你要去自己的 harness 裡確認的設定，server 不能假設它一定開著。
+
 ---
 
 ## 各系統做法
@@ -192,20 +196,20 @@ harness 如何伸手觸及自身之外。
 
 - **撞名（Name collisions）：**兩個 server 都公開 `search`。`mcp__server__tool` 命名空間避免了衝突；但一個名稱含 `__` 的 server 仍會被解析錯誤，所以名稱要保持簡單。
 - **工具清單膨脹（Tool-list bloat）：**太多 server 會造成龐大的工具清單，既花 token 又干擾選擇（第 2 章）。
-  緩解：截斷描述，並且一個 server 一個 server 決定要露出多少，而不是每次 request 都把所有 schema 公告一遍。
+  緩解：截斷描述，並且一個 server 一個 server 決定公告多少，不要每次 request 都把所有 schema 送一遍。
 - **connect 之後池過時：**一個在 session 中途加入的 server 不在 cache 的工具清單裡，於是模型永遠看不到它。緩解：變動時重建池並重建 prompt（第 8 章）；
   2026-07-28 版的 spec 為此加了走 `subscriptions/listen` 的 `toolsListChanged` 通知和 `ttlMs` 提示。
 - **連線抖動（Connection churn）：**一個不穩的 server 會逾時、重置，或 token 過期。緩解：反覆失敗後重連、`401` 時重新驗證、為每次呼叫設逾時（第 11 章）。
   stateless 版拿掉了 stream 續傳，所以中斷的 request 要當成一個新 request 重發，不是接著傳。
 - **被過度信任的副作用：**一個 server 把具破壞性的工具標成 `readOnlyHint: true` 以跳過提示。緩解：以完整名稱設一條規則照樣 gate 它（第 3 章）。
-- **描述投毒（Description poisoning）：**工具描述是不可信的文字，卻會以指令的形式送到模型面前。server 可以在裡面埋一句話，
-  例如叫模型先讀使用者的金鑰檔、再一起傳過來，模型很可能在做別的事的時候就順手照做了。
-  緩解：裝一個 server 之前先把描述讀過，描述改了就當成程式碼改了來看。
-- **工具遮蔽（Tool shadowing）：**所有 server 共用同一份 prompt，所以一個 server 的描述可以講到另一個 server 的工具
-  （付款工具壞了，改用我們的），把呼叫從可信的那個拉走。
-  緩解：命名空間擋得住撞名，擋不住影響。沒審過的 server，就別放進握有真實憑證的 session。
-- **被劫持的更新（Hijacked updates）：**一個當初審過、確認安全的 server，下次啟動時換上新的程式碼和新的描述，而 protocol 不會再問使用者一次。
-  緩解：把版本釘住、升級時重審，並且讓每個 server 各自持有最小權限的憑證，這樣一個被攻破，也伸不到別的 server 的範圍。
+- **描述投毒（Description poisoning）：**工具描述是 server 自己寫的文字，模型卻把它當成指令在讀。
+  server 可以在裡面塞一句話，例如叫模型先讀使用者的金鑰檔、再一起傳過來。模型真的有可能照做。
+  緩解：裝一個 server 之前，先把描述讀過一遍。描述改了，就當成程式碼改了那樣審。
+- **工具遮蔽（Tool shadowing）：**所有 server 共用同一份 prompt。所以一個 server 的描述可以講到另一個 server 的工具，
+  說付款工具壞了，再把呼叫拉到自己身上。
+  緩解：命名空間擋得住撞名，擋不住這個。沒審過的 server，別放進握有真實憑證的 session。
+- **被劫持的更新（Hijacked updates）：**一個 server 審過了，下次啟動時卻換上新的程式碼和新的描述。protocol 不會再問使用者一次。
+  緩解：把版本釘住。升級之後把描述再讀一遍。每個 server 各給一份最小權限的憑證，這樣一個 server 壞掉，也伸不到別的 server 的範圍。
 
 ---
 

--- a/sections/19-mcp-plugins-channels/README.zh-TW.md
+++ b/sections/19-mcp-plugins-channels/README.zh-TW.md
@@ -151,28 +151,28 @@ run_turn([...goal...], model, reg, Session(mode=DEFAULT))   # the one agent call
 底下這段講的是設計，不是程式碼。它出自 MCP 的 spec，以及 ai-agent-book 對正式環境的 agent 怎麼用 MCP 的描述。
 `src/` 一個都沒實作。這裡寫的也不等於下面表格那些系統確認過的行為，真要依賴之前，先看最後的出處。
 
-**三種 primitive，只有一種進池子。** 一個 server 可以提供三種東西，但只有 tool 會進到上面那個池子。
+**三種 primitive，只有一種進池子：**一個 server 可以提供三種東西，但只有 tool 會進到上面那個池子。
 
 - **Tools** 是動作。模型自己挑一個來呼叫。`tools/list` 回傳的就是這些，上面的程式碼包的也是它們。
 - **Resources** 是可以讀的資料，每一筆都有一個 URI：一個檔案、一張表、一頁 wiki。client 把它抓下來，把內容放進 context。模型不會去呼叫它。
 - **Prompts** 是 server 給的範本。它通常是使用者可以下的一個指令，不是模型自己挑的東西。
 
-Claude Code 不會把 resource 一個一個公告出去。它只放兩個工具，一個列出 resource，一個把 resource 讀出來。
+**resource 不會出現在工具清單上：**Claude Code 不會把它們一個一個公告出去，它只放兩個工具，一個列出 resource，一個把 resource 讀出來。
 所以一個放了上千份文件的 server，在工具清單裡還是只佔兩格。
 
-**連上去和公告出去，是兩個決定。** 連上一個 server，換到的是互通；把它的工具公告給模型，花掉的是 context。
+**連上去和公告出去，是兩個決定：**連上一個 server，換到的是互通；把它的工具公告給模型，花掉的是 context。
 前面那件事可以做，後面那件事不一定要做滿。
 
-每一個公告出去的工具，每次 request 都在花 token。名稱、描述、完整的 input schema，全都排在任務前面。
+**公告出去要付什麼代價：**每一個公告出去的工具，每次 request 都在花 token。名稱、描述、完整的 input schema，全都排在任務前面。
 五個 server 加起來，這段文字可能比任務本身還長。清單一長，模型也更容易挑錯工具（第 2 章）。
 
-所以要一個 server 一個 server 決定公告多少，不是全部一起套：
+**公告的程度有三種可以挑：**一個 server 一個 server 決定公告多少，不是全部一起套。
 
 - **全部都公告。** 最單純。適合那種幾乎每一輪都會用到的 server。
 - **只公告一份索引。** 先給名稱和一句話說明。等模型指名要哪個工具，再把完整的 schema 載進來（探索那一側在第 2 章）。
 - **只開一扇門。** 只公告一個工具，參數是 server 名稱和工具名稱，其他都放在它後面。agent 只要付一份 schema，不用付五十份。
 
-protocol 完全沒管這件事。它只規定工具怎麼列、怎麼呼叫。有多少工具會進到 prompt，是 client 自己決定的。
+**protocol 完全沒管這件事：**它只規定工具怎麼列、怎麼呼叫。有多少工具會進到 prompt，是 client 自己決定的。
 所以延後載入是你要去自己的 harness 裡確認的設定，server 不能假設它一定開著。
 
 ---

--- a/sections/19-mcp-plugins-channels/README.zh-TW.md
+++ b/sections/19-mcp-plugins-channels/README.zh-TW.md
@@ -30,6 +30,15 @@ MCP 之外，這一章還講兩個搭在它上面的機制：plugin 把 server �
 - 每個工具的 MCP annotation（`readOnlyHint`、`destructiveHint`）成為 gate 讀取的權限提示（第 3 章）。
 - 合併進那一個 `Registry` 之後，模型會在同一份清單裡看到 MCP 工具與內建工具。
 
+一個 server 可以公告三種 primitive，但只有一種會進到上面那個池子。
+
+- **Tools** 是模型自己挑、自己呼叫的動作。`tools/list` 回傳的就是它們，下面的包裝也是把它們變成 `Tool`。
+- **Resources** 是用 URI 定址的可讀資料：一個檔案、一張表、一頁 wiki。client 抓下來把內容放進 context，模型不會把它當動作來呼叫。
+- **Prompts** 是 server 提供的具名範本。它通常是給使用者當指令用的，不是讓模型自己挑的。
+
+Claude Code 是用自己的兩個內建工具去碰 resource，一個列清單、一個讀內容，而不是把每個 resource 都公告成一項工具。
+所以一個放了上千份文件的 server，在工具清單裡仍然只佔兩格。
+
 ### 底層的 wire protocol
 
 2026-07-28 版的 spec 把 protocol 本身改成了 stateless：每個 request 都是獨立的，哪台 server 副本都能接。
@@ -52,6 +61,22 @@ MCP 之外，這一章還講兩個搭在它上面的機制：plugin 把 server �
 對用 agent 的人來說，畫面上什麼都沒變：舊 server 照常運作，v1 SDK 也繼續維護。
 好處都出現在使用者看不到的地方：遠端 server 能掛在 load balancer 後面擴展，第一次呼叫少一趟來回，cache 住的工具清單也省 token。
 用到 deprecated 功能的 server 有十二個月的窗口可以遷移。那是 server 作者要做的事，不是使用者的事。
+
+### 接上 MCP 和公告 schema 是兩個決定
+
+連上一個 server，跟把它所有工具都公告給模型，是兩件事。前者換到的是互通，後者花掉的是 context。
+
+每一個公告出去的工具，每次 request 都要付 token：名稱、描述、完整的 input schema，全都排在模型讀到任務之前。
+幾個 server 加起來，這段文字可能比任務本身還長；清單一長，模型挑工具也挑得更差（第 2 章）。
+
+所以 harness 是一個 server 一個 server 決定要露出多少，而不是全部套同一個設定：
+
+- **全部 schema 都先給。** 最單純，適合那種幾乎每一輪都會用到的 server。
+- **先給一份索引。** 只公告名稱和一句話說明，等模型指名要哪個工具，再把完整的 schema 載進來（探索那一側在第 2 章）。
+- **只開一扇門。** 只公告一個工具，參數是 server 名稱和工具名稱，其他全部藏在它後面。agent 只要付一份 schema，不是五十份。
+
+這些都不寫在 protocol 裡。spec 只規定怎麼列工具、怎麼呼叫工具。到底有多少工具會進到 prompt，是 client 自己的政策，
+所以延後載入是每個 harness 要自己確認的設定，server 不能假設它一定開著。
 
 ### New: 包裝探索到的工具
 
@@ -166,12 +191,21 @@ harness 如何伸手觸及自身之外。
 ## 哪裡會出錯
 
 - **撞名（Name collisions）：**兩個 server 都公開 `search`。`mcp__server__tool` 命名空間避免了衝突；但一個名稱含 `__` 的 server 仍會被解析錯誤，所以名稱要保持簡單。
-- **工具清單膨脹（Tool-list bloat）：**太多 server 會造成龐大的工具清單，既花 token 又干擾選擇（第 2 章）。緩解：截斷描述並延後載入。
+- **工具清單膨脹（Tool-list bloat）：**太多 server 會造成龐大的工具清單，既花 token 又干擾選擇（第 2 章）。
+  緩解：截斷描述，並且一個 server 一個 server 決定要露出多少，而不是每次 request 都把所有 schema 公告一遍。
 - **connect 之後池過時：**一個在 session 中途加入的 server 不在 cache 的工具清單裡，於是模型永遠看不到它。緩解：變動時重建池並重建 prompt（第 8 章）；
   2026-07-28 版的 spec 為此加了走 `subscriptions/listen` 的 `toolsListChanged` 通知和 `ttlMs` 提示。
 - **連線抖動（Connection churn）：**一個不穩的 server 會逾時、重置，或 token 過期。緩解：反覆失敗後重連、`401` 時重新驗證、為每次呼叫設逾時（第 11 章）。
   stateless 版拿掉了 stream 續傳，所以中斷的 request 要當成一個新 request 重發，不是接著傳。
 - **被過度信任的副作用：**一個 server 把具破壞性的工具標成 `readOnlyHint: true` 以跳過提示。緩解：以完整名稱設一條規則照樣 gate 它（第 3 章）。
+- **描述投毒（Description poisoning）：**工具描述是不可信的文字，卻會以指令的形式送到模型面前。server 可以在裡面埋一句話，
+  例如叫模型先讀使用者的金鑰檔、再一起傳過來，模型很可能在做別的事的時候就順手照做了。
+  緩解：裝一個 server 之前先把描述讀過，描述改了就當成程式碼改了來看。
+- **工具遮蔽（Tool shadowing）：**所有 server 共用同一份 prompt，所以一個 server 的描述可以講到另一個 server 的工具
+  （付款工具壞了，改用我們的），把呼叫從可信的那個拉走。
+  緩解：命名空間擋得住撞名，擋不住影響。沒審過的 server，就別放進握有真實憑證的 session。
+- **被劫持的更新（Hijacked updates）：**一個當初審過、確認安全的 server，下次啟動時換上新的程式碼和新的描述，而 protocol 不會再問使用者一次。
+  緩解：把版本釘住、升級時重審，並且讓每個 server 各自持有最小權限的憑證，這樣一個被攻破，也伸不到別的 server 的範圍。
 
 ---
 
@@ -194,12 +228,18 @@ uv run python sections/19-mcp-plugins-channels/src/demo.py  # live demo, needs a
 
 ## 出處
 
-- [Claude Code MCP transport](https://github.com/yasasbanukaofficial/claude-code)：`services/mcp/types.ts`（`TransportSchema`）、`client.ts`（`MCPTool` cloning、`buildMcpToolName`）、`normalization.ts`（`normalizeNameForMCP`）。
-- [Claude Code MCP config and channels](https://github.com/yasasbanukaofficial/claude-code)：`config.ts`（precedence）、`channelNotification.ts`（`CHANNEL_TAG`），加上 `McpAuthTool`、`ListMcpResourcesTool`、`ReadMcpResourceTool`。
+- [Claude Code MCP transport](https://github.com/yasasbanukaofficial/claude-code)：
+  `services/mcp/types.ts`（`TransportSchema`）、`client.ts`（`MCPTool` cloning、`buildMcpToolName`）、`normalization.ts`（`normalizeNameForMCP`）。
+- [Claude Code MCP config and channels](https://github.com/yasasbanukaofficial/claude-code)：
+  `config.ts`（precedence）、`channelNotification.ts`（`CHANNEL_TAG`），加上 `McpAuthTool`、`ListMcpResourcesTool`、`ReadMcpResourceTool`。
 - [Claude Code plugins](https://github.com/yasasbanukaofficial/claude-code)：`plugins/builtinPlugins.ts`、`plugins/bundled/`、`types/plugin.ts`，加上 `remote/` 與 `bridge/`。
-- [Hermes Agent 原始碼](https://github.com/NousResearch/hermes-agent)：`mcp_serve.py`、`hermes_cli/plugins.py`（`PluginManager`、`VALID_HOOKS`）、`gateway/platforms/`、`gateway/platform_registry.py`、`plugins/platforms/`。
+- [Hermes Agent 原始碼](https://github.com/NousResearch/hermes-agent)：
+  `mcp_serve.py`、`hermes_cli/plugins.py`（`PluginManager`、`VALID_HOOKS`）、`gateway/platforms/`、`gateway/platform_registry.py`、`plugins/platforms/`。
 - [MCP specification 2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28) 與它的
-  [changelog](https://modelcontextprotocol.io/specification/2026-07-28/changelog)：stateless protocol、`server/discover`、`subscriptions/listen`、MRTR、deprecation 清單。
+  [changelog](https://modelcontextprotocol.io/specification/2026-07-28/changelog)：stateless protocol、tools / resources / prompts 三種 primitive、
+  `server/discover`、`subscriptions/listen`、MRTR、deprecation 清單。
 - MCP blog：[the future of transports](https://blog.modelcontextprotocol.io/posts/2025-12-19-mcp-transport-future/)（protocol 為什麼走向 stateless）、
   [SDK betas for 2026-07-28](https://blog.modelcontextprotocol.io/posts/sdk-betas-2026-07-28/)（v2 SDK 與向後相容）。
+- [ai-agent-book](https://github.com/bojieli/ai-agent-book)：`book/chapter4.md`，以中文原版為準。工具生態那一節：
+  MCP 的 primitive、公告 schema 的 context 開銷，以及信任模型（描述投毒、工具遮蔽、被劫持的更新、憑證範圍）。
 - 章節定位：[learn-claude-code · s19_mcp_plugin](https://github.com/shareAI-lab/learn-claude-code)。

--- a/sections/19-mcp-plugins-channels/README.zh-TW.md
+++ b/sections/19-mcp-plugins-channels/README.zh-TW.md
@@ -148,8 +148,7 @@ run_turn([...goal...], model, reg, Session(mode=DEFAULT))   # the one agent call
 
 ### 延伸閱讀
 
-底下這段講的是設計，不是程式碼。它出自 MCP 的 spec，以及 ai-agent-book 對正式環境的 agent 怎麼用 MCP 的描述。
-`src/` 一個都沒實作。這裡寫的也不等於下面表格那些系統確認過的行為，真要依賴之前，先看最後的出處。
+以下設計 `src/` 都沒有實作，出自 ai-agent-book 和 MCP spec，也未經下面表格的系統證實。
 
 **三種 primitive，只有一種進池子：**一個 server 可以提供三種東西，但只有 tool 會進到上面那個池子。
 


### PR DESCRIPTION
Implements #33. Part of #24.

## What landed

The resources and prompts primitives, adopting MCP versus advertising schemas as two separate decisions with three exposure levels, and the trust-model failure modes (description poisoning, tool shadowing, hijacked updates) with mitigations. The MCP spec revision the section cites is unchanged.

Book material lands as mechanism text, failure modes, and Sources only. No per-system table columns were added.
Designs this section's `src/` does not implement sit under a `Further reading` subsection after `How it integrates`, behind a one-line caveat.

## Checks

- No line over 180 characters (counted as characters for the zh files), no em or en dashes.
- zh-TW and zh-CN mirror the English edits; heading counts equal across the three languages; switcher line untouched.
- Per-system table columns unchanged. `src/` untouched. Offline test suites 23/23.
- `research/*` branches untouched, read via `git show` only.

` 3 files changed, 140 insertions(+), 13 deletions(-)`

Closes #33