### PR TITLE
docs: add phase nodes to section 22

### DIFF
--- a/sections/22-graph-engineering/README.md
+++ b/sections/22-graph-engineering/README.md
@@ -110,8 +110,7 @@ edges = {
 
 ### Further reading
 
-What follows is a design from ai-agent-book, which writes up agents running in production.
-This section's runnable does not build it, and the systems in the table below are not confirmed to work this way.
+None of this is in `src/`. It comes from ai-agent-book, and is not confirmed of the systems in the table.
 
 **Phase node.** A phase node runs one job as a series of stages, and every stage shares one `messages[]`.
 Explore, implement, and review are stages of a single piece of work, not three separate jobs.

--- a/sections/22-graph-engineering/README.md
+++ b/sections/22-graph-engineering/README.md
@@ -59,6 +59,23 @@ so the node sees only what its prompt builder passes it, not the whole run.
 
 The scale is the budget discipline: route with code where the branch is knowable, and spend model calls only inside nodes that need judgment.
 
+### Phase nodes
+
+An agent node starts a fresh `messages[]` on every visit. That is right when the branches are unrelated, and wrong when the nodes are stages of one job.
+
+A phase node is the variant that keeps the trajectory. One `messages[]` runs the whole path.
+On entry to a phase the harness swaps the frame around it: a different system prompt and a different tool set.
+Explore mounts read and search. Implement mounts edit and run. Review mounts read and a verdict tool. The state the phase needs is already in the history, so nothing is repacked.
+
+The model ends a phase by calling a gate tool, such as `finish_exploring`. The harness reads that call as the edge and enters the next phase.
+The gate is the only exit, so the harness decides when a phase ends, not the model's narration.
+The shape is a path with one backward edge: explore, implement, review, and review can route back to implement with its notes already in the history.
+
+Which variant to mount is a context decision (section 8). A fresh `messages[]` keeps each node's window small and its branch independent.
+One trajectory keeps continuity and spends more of the window as the path gets longer.
+The book that documents this shape counts it as multi-agent, because prompt and tools change per phase. This repo counts it as one agent with swapped frames.
+The mechanism is the same, so state which definition you mean when citing. The evidence is the book's own experiment, a single source.
+
 ### Named shapes
 
 The workflow patterns the sources name are graph shapes:
@@ -68,6 +85,9 @@ The workflow patterns the sources name are graph shapes:
 - **Parallelization.** Sibling branches that run at once and merge at one node, either splitting the task (sectioning) or repeating it for votes (voting).
 - **Orchestrator-workers.** A node that decides the fan-out at runtime, then a merge node. The edge set is dynamic; the shape is still a graph.
 - **Evaluator-optimizer.** A worker node and a checker node with one backward edge. This is section 21's verification loop as a subgraph.
+
+The vocabulary is not settled. `ai-agent-book` keeps "collaboration topology" and "orchestration" as its primary terms, and records "graph engineering" only as a term note.
+This section keeps the name, because what it describes is a graph written in code. When you read across sources, match the mechanism, not the word.
 
 ### When not to graph
 
@@ -134,6 +154,10 @@ How each agent decides what runs next.
   Mitigation: strict state boundaries; a node reads the subset it needs and returns only its updates (section 8).
 - **Mid-run death.** A long graph dies at node seven and restarts at node one.
   Mitigation: record each node's output; on resume, replay finished nodes from the record (sections 11, 12).
+- **Phase that never ends.** A phase node whose gate tool is never called keeps working under the same prompt and tools until the budget stops it.
+  Mitigation: make the gate the only exit, give each phase its own step budget, and send a spent budget to the next phase or to escalation.
+- **Trajectory that carries every phase.** One shared trajectory grows with each phase, and it still holds calls to tools the current phase does not mount.
+  Mitigation: name the current phase and its tools in the phase prompt, reject calls to unmounted tools with a clear error, and compact finished phases (section 8).
 
 ---
 
@@ -164,3 +188,6 @@ uv run python sections/22-graph-engineering/src/demo.py  # live demo, needs a ke
   From tool schemas and documented behavior, not the source backup.
 - [Hermes Agent source](https://github.com/NousResearch/hermes-agent): `tools/delegate_tool.py`, `tools/async_delegation.py`, `batch_runner.py`.
 - [mini-swe-agent source](https://github.com/swe-agent/mini-swe-agent): the run loop and budgets in `agents/default.py`, `run/benchmarks/swebench.py`.
+- [ai-agent-book · chapter 10](https://github.com/bojieli/ai-agent-book/blob/main/book/chapter10.md) (《深入理解 AI Agent》, 李博杰, 多 Agent 协作; the Chinese original is canonical):
+  multi-stage role switching over one trajectory, with a per-phase system prompt and tool set, phase gates as tool calls, and review routing back to implementation.
+  The shape rests on the book's own experiment, a single source. The same chapter keeps "collaboration topology" and "orchestration" as its primary terms.

--- a/sections/22-graph-engineering/README.md
+++ b/sections/22-graph-engineering/README.md
@@ -59,23 +59,6 @@ so the node sees only what its prompt builder passes it, not the whole run.
 
 The scale is the budget discipline: route with code where the branch is knowable, and spend model calls only inside nodes that need judgment.
 
-### Phase nodes
-
-An agent node starts a fresh `messages[]` on every visit. That is right when the branches are unrelated, and wrong when the nodes are stages of one job.
-
-A phase node is the variant that keeps the trajectory. One `messages[]` runs the whole path.
-On entry to a phase the harness swaps the frame around it: a different system prompt and a different tool set.
-Explore mounts read and search. Implement mounts edit and run. Review mounts read and a verdict tool. The state the phase needs is already in the history, so nothing is repacked.
-
-The model ends a phase by calling a gate tool, such as `finish_exploring`. The harness reads that call as the edge and enters the next phase.
-The gate is the only exit, so the harness decides when a phase ends, not the model's narration.
-The shape is a path with one backward edge: explore, implement, review, and review can route back to implement with its notes already in the history.
-
-Which variant to mount is a context decision (section 8). A fresh `messages[]` keeps each node's window small and its branch independent.
-One trajectory keeps continuity and spends more of the window as the path gets longer.
-The book that documents this shape counts it as multi-agent, because prompt and tools change per phase. This repo counts it as one agent with swapped frames.
-The mechanism is the same, so state which definition you mean when citing. The evidence is the book's own experiment, a single source.
-
 ### Named shapes
 
 The workflow patterns the sources name are graph shapes:
@@ -86,8 +69,9 @@ The workflow patterns the sources name are graph shapes:
 - **Orchestrator-workers.** A node that decides the fan-out at runtime, then a merge node. The edge set is dynamic; the shape is still a graph.
 - **Evaluator-optimizer.** A worker node and a checker node with one backward edge. This is section 21's verification loop as a subgraph.
 
-The vocabulary is not settled. `ai-agent-book` keeps "collaboration topology" and "orchestration" as its primary terms, and records "graph engineering" only as a term note.
-This section keeps the name, because what it describes is a graph written in code. When you read across sources, match the mechanism, not the word.
+The names are not settled across sources. `ai-agent-book` covers the same ground under "collaboration topology" and "orchestration",
+and mentions "graph engineering" only in a note on terms. This section keeps its own name, because what it describes is a graph written in code.
+When you read a second source, match it by mechanism, not by the word.
 
 ### When not to graph
 
@@ -124,6 +108,30 @@ edges = {
 }
 ```
 
+### Further reading
+
+What follows is a design from ai-agent-book, which writes up agents running in production.
+This section's runnable does not build it, and the systems in the table below are not confirmed to work this way.
+
+**Phase nodes.** An agent node starts a fresh `messages[]` on every visit. That is right when the branches are unrelated.
+It is wrong when the nodes are stages of one job, because every stage then reads the task from scratch.
+
+A phase node keeps the trajectory instead. One `messages[]` runs the whole path. When a phase starts, the harness swaps two things: the system prompt and the tool set.
+Explore mounts read and search. Implement mounts edit and run. Review mounts read and a verdict tool.
+Nothing gets packed for the next phase, because the history already holds what it needs.
+
+The model ends a phase by calling a gate tool, such as `finish_exploring`. The harness reads that call as the edge and starts the next phase.
+The gate is the only exit, so the harness decides when a phase ends, not the model.
+
+The route is explore, then implement, then review. Review can send the run back to implement. That shape is a path with one backward edge.
+The trip back needs no handoff, because review wrote its notes into the same history.
+
+Which variant to mount is a context question (section 8). A fresh `messages[]` keeps each node's window small and its branch independent.
+One trajectory keeps every earlier finding in view, and it fills more of the window as the path gets longer.
+
+The book counts this as multi-agent, because the prompt and the tools change per phase. This repo counts it as one agent whose prompt and tools change.
+The mechanism is the same either way, so say which definition you mean when you cite it. The only evidence is the book's own experiment.
+
 ---
 
 ## Per system
@@ -154,10 +162,10 @@ How each agent decides what runs next.
   Mitigation: strict state boundaries; a node reads the subset it needs and returns only its updates (section 8).
 - **Mid-run death.** A long graph dies at node seven and restarts at node one.
   Mitigation: record each node's output; on resume, replay finished nodes from the record (sections 11, 12).
-- **Phase that never ends.** A phase node whose gate tool is never called keeps working under the same prompt and tools until the budget stops it.
-  Mitigation: make the gate the only exit, give each phase its own step budget, and send a spent budget to the next phase or to escalation.
-- **Trajectory that carries every phase.** One shared trajectory grows with each phase, and it still holds calls to tools the current phase does not mount.
-  Mitigation: name the current phase and its tools in the phase prompt, reject calls to unmounted tools with a clear error, and compact finished phases (section 8).
+- **Phase that never ends.** The model never calls the gate tool, so the phase keeps working under the same prompt and the same tools. Only the budget stops it.
+  Mitigation: make the gate the only exit; give each phase its own step budget; a spent budget moves to the next phase or escalates.
+- **Trajectory that carries every phase.** One trajectory grows with each phase. It still holds calls to tools the current phase does not mount, and the model may try them again.
+  Mitigation: name the current phase and its tools in the phase prompt; reject a call to an unmounted tool with a clear error; compact finished phases (section 8).
 
 ---
 
@@ -189,5 +197,5 @@ uv run python sections/22-graph-engineering/src/demo.py  # live demo, needs a ke
 - [Hermes Agent source](https://github.com/NousResearch/hermes-agent): `tools/delegate_tool.py`, `tools/async_delegation.py`, `batch_runner.py`.
 - [mini-swe-agent source](https://github.com/swe-agent/mini-swe-agent): the run loop and budgets in `agents/default.py`, `run/benchmarks/swebench.py`.
 - [ai-agent-book · chapter 10](https://github.com/bojieli/ai-agent-book/blob/main/book/chapter10.md) (《深入理解 AI Agent》, 李博杰, 多 Agent 协作; the Chinese original is canonical):
-  multi-stage role switching over one trajectory, with a per-phase system prompt and tool set, phase gates as tool calls, and review routing back to implementation.
-  The shape rests on the book's own experiment, a single source. The same chapter keeps "collaboration topology" and "orchestration" as its primary terms.
+  multi-stage role switching on one trajectory: a system prompt and a tool set per phase, phase gates as tool calls, and review routing back to implementation.
+  The only evidence is the book's own experiment. The same chapter keeps "collaboration topology" and "orchestration" as its primary terms.

--- a/sections/22-graph-engineering/README.md
+++ b/sections/22-graph-engineering/README.md
@@ -113,24 +113,32 @@ edges = {
 What follows is a design from ai-agent-book, which writes up agents running in production.
 This section's runnable does not build it, and the systems in the table below are not confirmed to work this way.
 
-**Phase nodes.** An agent node starts a fresh `messages[]` on every visit. That is right when the branches are unrelated.
-It is wrong when the nodes are stages of one job, because every stage then reads the task from scratch.
+**Phase node.** A phase node runs one job as a series of stages, and every stage shares one `messages[]`.
+Explore, implement, and review are stages of a single piece of work, not three separate jobs.
+The trajectory carries what one stage found into the next, so no stage reads the task again from the top.
 
-A phase node keeps the trajectory instead. One `messages[]` runs the whole path. When a phase starts, the harness swaps two things: the system prompt and the tool set.
-Explore mounts read and search. Implement mounts edit and run. Review mounts read and a verdict tool.
-Nothing gets packed for the next phase, because the history already holds what it needs.
+**Tools per phase.** Each phase gets its own system prompt and its own tool set, and the harness swaps both when the phase changes.
+The history stays where it is, so nothing gets packed for the next phase. The three phases in the book's write-up:
 
-The model ends a phase by calling a gate tool, such as `finish_exploring`. The harness reads that call as the edge and starts the next phase.
-The gate is the only exit, so the harness decides when a phase ends, not the model.
+- **Explore.** Read and search.
+- **Implement.** Edit and run.
+- **Review.** Read, plus a tool that returns a verdict.
 
-The route is explore, then implement, then review. Review can send the run back to implement. That shape is a path with one backward edge.
-The trip back needs no handoff, because review wrote its notes into the same history.
+**Gate tools.** The model leaves a phase by calling a gate tool, such as `finish_exploring`.
+The harness reads that call as the edge and starts the next phase. The gate is the only exit, so the harness decides when a phase ends, not the model.
 
-Which variant to mount is a context question (section 8). A fresh `messages[]` keeps each node's window small and its branch independent.
-One trajectory keeps every earlier finding in view, and it fills more of the window as the path gets longer.
+**The route.** Explore runs first, then implement, then review. A failed review sends the run back to implement,
+which picks up with the review's notes already in the trajectory. In this section's terms that is a path with one backward edge,
+the same shape as evaluator-optimizer above.
 
-The book counts this as multi-agent, because the prompt and the tools change per phase. This repo counts it as one agent whose prompt and tools change.
-The mechanism is the same either way, so say which definition you mean when you cite it. The only evidence is the book's own experiment.
+**Which one to mount.** Use a fresh `messages[]` when the branches are unrelated. Use one trajectory when the nodes are stages of one job.
+A fresh `messages[]` keeps each node's window small and its branch independent.
+One trajectory keeps every earlier finding in view, and it fills more of the window as the path gets longer. The choice is a context question (section 8).
+
+**What counts as multi-agent.** The book calls this design multi-agent, because the prompt and the tools change at every phase.
+This repo calls it one agent whose prompt and tools change. The mechanism is the same under either name, so say which definition you mean when you cite the result.
+
+**One source.** The write-up rests on the book's own experiment. No independent report confirms it.
 
 ---
 

--- a/sections/22-graph-engineering/README.zh-CN.md
+++ b/sections/22-graph-engineering/README.zh-CN.md
@@ -60,22 +60,6 @@ def run_graph(nodes, edges, state, start, budget=20):  # src/graph.py
 
 怎么选？原则就是省 token：分支条件写得出来的，就交给代码；model 调用只留给真的需要判断的 node。
 
-### Phase node
-
-Agent node 每次经过都从全新的 `messages[]` 开始。分支彼此无关的时候这样最好；但几个 node 其实是同一件事的不同阶段，这样就不对了。
-
-Phase node 就是把 trajectory 留下来的那个变体。整条路只有一份 `messages[]`。进到某个 phase 的时候，harness 换掉外面那层框：换一份 system prompt，换一套 tool。
-Explore 挂读取和搜索，implement 挂编辑和执行，review 挂读取和一个下结论的 tool。这个 phase 要的东西 history 里都有，不用再打包一次。
-
-Model 要离开一个 phase，就调用一个 gate tool，例如 `finish_exploring`。harness 把这个调用当成 edge，直接进下一个 phase。
-gate 是唯一的出口，所以一个 phase 什么时候结束由 harness 决定，不是看 model 自己怎么讲。
-形状是一条路加一条往回的 edge：explore、implement、review，而 review 可以把执行送回 implement，笔记本来就留在 history 里。
-
-要挂哪一种，是 context 的取舍（第 8 章）。每个 node 都用全新的 `messages[]`，window 就小，分支之间也彼此独立。
-只留一条 trajectory 则是前后比较连贯，但路越长，吃掉的 window 也越多。
-记载这个做法的书把它算成 multi-agent，理由是每个 phase 的 prompt 和 tool 都不一样；这个 repo 则把它算成同一个 agent 换了外框。
-机制是同一个，所以引用的时候要先讲清楚你用的是哪个定义。这个做法的证据来自书里自己做的实验，只有这一个来源。
-
 ### 常见的图形
 
 出处里叫得出名字的 workflow pattern，其实都是图形：
@@ -86,8 +70,8 @@ gate 是唯一的出口，所以一个 phase 什么时候结束由 harness 决�
 - **Orchestrator-workers**：一个 node 在执行时决定要派出多少工作，再由一个 node 收拢。edge 是动态的，但形状仍然是图。
 - **Evaluator-optimizer**：一个 worker node、一个 checker node，加一条往回的 edge。这就是第 21 章的验证 loop，放进图里变成一个子图。
 
-名字还没有统一。`ai-agent-book` 主要用的词是「collaboration topology」和「orchestration」，「graph engineering」只被它放在一则术语说明里。
-这一章沿用这个名字，因为它讲的东西就是一张写在代码里的图。看不同来源的时候，对得上的是机制，不是那个词。
+各家的讲法还没统一。同样的东西，`ai-agent-book` 用的词是「collaboration topology」和「orchestration」，「graph engineering」它只在术语说明里提了一句。
+这一章还是用自己的名字，因为它讲的就是一张写在代码里的图。你去看别的来源时，对照的是机制，不是那个词。
 
 ### 什么时候不要画图
 
@@ -124,6 +108,30 @@ edges = {
 }
 ```
 
+### 延伸阅读
+
+下面这个做法出自 ai-agent-book，那本书写的是真的跑在产品里的 agent。
+这一章的可执行程序没有做这件事，下面表格里那几个系统，也没有证据说它们是这样做的。
+
+**Phase node**：agent node 每次经过都从全新的 `messages[]` 开始。分支之间没关系的时候，这样最好。
+但几个 node 其实是同一件事的不同阶段，这样就不对了，因为每个阶段都得把任务重读一次。
+
+Phase node 反过来，把 trajectory 留着。整条路只有一份 `messages[]`。进到一个 phase 的时候，harness 换两样东西：system prompt 和整套 tool。
+Explore 挂读取和搜索，implement 挂编辑和执行，review 挂读取和一个下结论的 tool。
+没有东西要打包给下一个 phase，因为它要的 history 里都有。
+
+Model 想结束一个 phase，就调用一个 gate tool，例如 `finish_exploring`。harness 把这个调用当成 edge，直接开始下一个 phase。
+gate 是唯一的出口，所以一个 phase 什么时候结束，是 harness 说了算，不是 model。
+
+路线是先 explore，再 implement，最后 review。review 可以把执行送回 implement。这个形状就是一条路加一条往回的 edge。
+送回去也不用交接，因为 review 写的东西就在同一份 history 里。
+
+要挂哪一种，看你怎么分配 context（第 8 章）。每个 node 都用全新的 `messages[]`，window 就小，分支之间也互不干扰。
+只留一条 trajectory 则是前面查到的东西都还看得到，但路越长，被吃掉的 window 也越多。
+
+书把这个做法算成 multi-agent，理由是每个 phase 的 prompt 和 tool 都不一样；这个 repo 则算成同一个 agent 换了 prompt 和 tool。
+算哪一种都好，机制是同一个，所以引用的时候先讲清楚你用的是哪个定义。这个做法的证据只有书里自己做的实验。
+
 ---
 
 ## 各系统做法
@@ -154,10 +162,10 @@ edges = {
   缓解：严格的 state 边界；node 只读需要的子集，只返回自己的更新（第 8 章）。
 - **跑到一半挂掉（Mid-run death）**：一张长图在第七个 node 挂掉，重来却从第一个 node 开始。
   缓解：记下每个 node 的输出；续跑时跑完的 node 从记录重放（第 11、12 章）。
-- **Phase 走不完（Phase that never ends）**：phase node 的 gate tool 一直没被调用，它就用同一份 prompt、同一套 tool 一直做下去，直到 budget 用完。
+- **Phase 走不完（Phase that never ends）**：model 一直不调用 gate tool，这个 phase 就用同一份 prompt、同一套 tool 一直做下去，只有 budget 停得了它。
   缓解：gate 是唯一的出口；每个 phase 各自有 step budget；budget 用完就往下一个 phase 走，或者交给人。
-- **Trajectory 背着每个 phase（Trajectory that carries every phase）**：只有一条 trajectory，每过一个 phase 就长一截，里面还留着现在这个 phase 没挂的 tool 的调用记录。
-  缓解：在 phase 的 prompt 里讲清楚现在是哪个 phase、有哪些 tool；调用没挂的 tool 就回一个清楚的错误；跑完的 phase 拿去 compact（第 8 章）。
+- **Trajectory 背着每个 phase（Trajectory that carries every phase）**：只有一条 trajectory，每过一个 phase 就长一截。里面还留着现在没挂的 tool 的调用记录，model 可能会再叫一次。
+  缓解：在 phase 的 prompt 里写清楚现在是哪个 phase、有哪些 tool；叫到没挂的 tool 就回一个清楚的错误；跑完的 phase 拿去 compact（第 8 章）。
 
 ---
 
@@ -187,5 +195,5 @@ uv run python sections/22-graph-engineering/src/demo.py  # live demo, needs a ke
 - [Hermes Agent 源码](https://github.com/NousResearch/hermes-agent)：`tools/delegate_tool.py`、`tools/async_delegation.py`、`batch_runner.py`。
 - [mini-swe-agent source](https://github.com/swe-agent/mini-swe-agent)：`agents/default.py` 的 run loop 与 budget、`run/benchmarks/swebench.py`。
 - [ai-agent-book · 第 10 章](https://github.com/bojieli/ai-agent-book/blob/main/book/chapter10.md)（《深入理解 AI Agent》，李博杰，多 Agent 协作，以中文原版为准）：
-  在同一条 trajectory 上做多阶段角色转换，每个 phase 一份 system prompt 和一套 tool，phase 之间用 tool call 当关卡，review 可以绕回实现。
-  这个做法的依据是书里自己做的实验，只有这一个来源。同一章主要用的词是「collaboration topology」和「orchestration」。
+  在同一条 trajectory 上做多阶段角色转换：每个 phase 一份 system prompt 和一套 tool，phase 之间用 tool call 当关卡，review 可以绕回实现。
+  这个做法的证据只有书里自己做的实验。同一章主要用的词是「collaboration topology」和「orchestration」。

--- a/sections/22-graph-engineering/README.zh-CN.md
+++ b/sections/22-graph-engineering/README.zh-CN.md
@@ -110,8 +110,7 @@ edges = {
 
 ### 延伸阅读
 
-下面这个做法出自 ai-agent-book，那本书写的是真的跑在产品里的 agent。
-这一章的可执行程序没有做这件事，下面表格里那几个系统，也没有证据说它们是这样做的。
+以下设计 `src/` 都没有实现，出自 ai-agent-book，也未经下面表格的系统证实。
 
 **Phase node：**phase node 把一件工作拆成好几个阶段来跑，而每个阶段共用同一份 `messages[]`。
 Explore、implement、review 是同一件工作的三个阶段，不是三件工作。

--- a/sections/22-graph-engineering/README.zh-CN.md
+++ b/sections/22-graph-engineering/README.zh-CN.md
@@ -60,6 +60,22 @@ def run_graph(nodes, edges, state, start, budget=20):  # src/graph.py
 
 怎么选？原则就是省 token：分支条件写得出来的，就交给代码；model 调用只留给真的需要判断的 node。
 
+### Phase node
+
+Agent node 每次经过都从全新的 `messages[]` 开始。分支彼此无关的时候这样最好；但几个 node 其实是同一件事的不同阶段，这样就不对了。
+
+Phase node 就是把 trajectory 留下来的那个变体。整条路只有一份 `messages[]`。进到某个 phase 的时候，harness 换掉外面那层框：换一份 system prompt，换一套 tool。
+Explore 挂读取和搜索，implement 挂编辑和执行，review 挂读取和一个下结论的 tool。这个 phase 要的东西 history 里都有，不用再打包一次。
+
+Model 要离开一个 phase，就调用一个 gate tool，例如 `finish_exploring`。harness 把这个调用当成 edge，直接进下一个 phase。
+gate 是唯一的出口，所以一个 phase 什么时候结束由 harness 决定，不是看 model 自己怎么讲。
+形状是一条路加一条往回的 edge：explore、implement、review，而 review 可以把执行送回 implement，笔记本来就留在 history 里。
+
+要挂哪一种，是 context 的取舍（第 8 章）。每个 node 都用全新的 `messages[]`，window 就小，分支之间也彼此独立。
+只留一条 trajectory 则是前后比较连贯，但路越长，吃掉的 window 也越多。
+记载这个做法的书把它算成 multi-agent，理由是每个 phase 的 prompt 和 tool 都不一样；这个 repo 则把它算成同一个 agent 换了外框。
+机制是同一个，所以引用的时候要先讲清楚你用的是哪个定义。这个做法的证据来自书里自己做的实验，只有这一个来源。
+
 ### 常见的图形
 
 出处里叫得出名字的 workflow pattern，其实都是图形：
@@ -69,6 +85,9 @@ def run_graph(nodes, edges, state, start, budget=20):  # src/graph.py
 - **Parallelization**：几条同时跑的分支在一个 node 会合。可以是拆工作（sectioning），也可以是同一件事跑多次投票（voting）。
 - **Orchestrator-workers**：一个 node 在执行时决定要派出多少工作，再由一个 node 收拢。edge 是动态的，但形状仍然是图。
 - **Evaluator-optimizer**：一个 worker node、一个 checker node，加一条往回的 edge。这就是第 21 章的验证 loop，放进图里变成一个子图。
+
+名字还没有统一。`ai-agent-book` 主要用的词是「collaboration topology」和「orchestration」，「graph engineering」只被它放在一则术语说明里。
+这一章沿用这个名字，因为它讲的东西就是一张写在代码里的图。看不同来源的时候，对得上的是机制，不是那个词。
 
 ### 什么时候不要画图
 
@@ -135,6 +154,10 @@ edges = {
   缓解：严格的 state 边界；node 只读需要的子集，只返回自己的更新（第 8 章）。
 - **跑到一半挂掉（Mid-run death）**：一张长图在第七个 node 挂掉，重来却从第一个 node 开始。
   缓解：记下每个 node 的输出；续跑时跑完的 node 从记录重放（第 11、12 章）。
+- **Phase 走不完（Phase that never ends）**：phase node 的 gate tool 一直没被调用，它就用同一份 prompt、同一套 tool 一直做下去，直到 budget 用完。
+  缓解：gate 是唯一的出口；每个 phase 各自有 step budget；budget 用完就往下一个 phase 走，或者交给人。
+- **Trajectory 背着每个 phase（Trajectory that carries every phase）**：只有一条 trajectory，每过一个 phase 就长一截，里面还留着现在这个 phase 没挂的 tool 的调用记录。
+  缓解：在 phase 的 prompt 里讲清楚现在是哪个 phase、有哪些 tool；调用没挂的 tool 就回一个清楚的错误；跑完的 phase 拿去 compact（第 8 章）。
 
 ---
 
@@ -163,3 +186,6 @@ uv run python sections/22-graph-engineering/src/demo.py  # live demo, needs a ke
 - [Claude Code](https://code.claude.com/docs)：`Workflow` script 的约定（pipeline、并行分发、结构化输出、续跑）。内容依据 tool schema 和文档记载的行为，不是 source backup。
 - [Hermes Agent 源码](https://github.com/NousResearch/hermes-agent)：`tools/delegate_tool.py`、`tools/async_delegation.py`、`batch_runner.py`。
 - [mini-swe-agent source](https://github.com/swe-agent/mini-swe-agent)：`agents/default.py` 的 run loop 与 budget、`run/benchmarks/swebench.py`。
+- [ai-agent-book · 第 10 章](https://github.com/bojieli/ai-agent-book/blob/main/book/chapter10.md)（《深入理解 AI Agent》，李博杰，多 Agent 协作，以中文原版为准）：
+  在同一条 trajectory 上做多阶段角色转换，每个 phase 一份 system prompt 和一套 tool，phase 之间用 tool call 当关卡，review 可以绕回实现。
+  这个做法的依据是书里自己做的实验，只有这一个来源。同一章主要用的词是「collaboration topology」和「orchestration」。

--- a/sections/22-graph-engineering/README.zh-CN.md
+++ b/sections/22-graph-engineering/README.zh-CN.md
@@ -51,9 +51,9 @@ def run_graph(nodes, edges, state, start, budget=20):  # src/graph.py
 
 每个 node 都在纯代码和完整 agent 之间选一个位置：
 
-- **Code node**：解析、验证、固定的 API 调用。确定性的，不花 token。
-- **Model node**：一次 LLM 调用，例如分类器。有限度的判断。
-- **Agent node**：一整个第 1 章的 loop，带着 tool。开放式的判断，但被固定在一个位置上。
+- **Code node：**解析、验证、固定的 API 调用。确定性的，不花 token。
+- **Model node：**一次 LLM 调用，例如分类器。有限度的判断。
+- **Agent node：**一整个第 1 章的 loop，带着 tool。开放式的判断，但被固定在一个位置上。
 
 `agent_node` 把内层 loop 挂成一个 node。每次经过都用 state 组出 prompt，在全新的 `messages[]` 上跑 `run_turn`，
 所以这个 node 只看得到 prompt builder 给它的部分，不是整趟执行。
@@ -64,11 +64,11 @@ def run_graph(nodes, edges, state, start, budget=20):  # src/graph.py
 
 出处里叫得出名字的 workflow pattern，其实都是图形：
 
-- **Prompt chaining**：一串 node 排成一条路，中间用代码把关。
-- **Routing**：一条条件式 edge，分流到各个专门的 node。
-- **Parallelization**：几条同时跑的分支在一个 node 会合。可以是拆工作（sectioning），也可以是同一件事跑多次投票（voting）。
-- **Orchestrator-workers**：一个 node 在执行时决定要派出多少工作，再由一个 node 收拢。edge 是动态的，但形状仍然是图。
-- **Evaluator-optimizer**：一个 worker node、一个 checker node，加一条往回的 edge。这就是第 21 章的验证 loop，放进图里变成一个子图。
+- **Prompt chaining：**一串 node 排成一条路，中间用代码把关。
+- **Routing：**一条条件式 edge，分流到各个专门的 node。
+- **Parallelization：**几条同时跑的分支在一个 node 会合。可以是拆工作（sectioning），也可以是同一件事跑多次投票（voting）。
+- **Orchestrator-workers：**一个 node 在执行时决定要派出多少工作，再由一个 node 收拢。edge 是动态的，但形状仍然是图。
+- **Evaluator-optimizer：**一个 worker node、一个 checker node，加一条往回的 edge。这就是第 21 章的验证 loop，放进图里变成一个子图。
 
 各家的讲法还没统一。同样的东西，`ai-agent-book` 用的词是「collaboration topology」和「orchestration」，「graph engineering」它只在术语说明里提了一句。
 这一章还是用自己的名字，因为它讲的就是一张写在代码里的图。你去看别的来源时，对照的是机制，不是那个词。
@@ -113,24 +113,32 @@ edges = {
 下面这个做法出自 ai-agent-book，那本书写的是真的跑在产品里的 agent。
 这一章的可执行程序没有做这件事，下面表格里那几个系统，也没有证据说它们是这样做的。
 
-**Phase node**：agent node 每次经过都从全新的 `messages[]` 开始。分支之间没关系的时候，这样最好。
-但几个 node 其实是同一件事的不同阶段，这样就不对了，因为每个阶段都得把任务重读一次。
+**Phase node：**phase node 把一件工作拆成好几个阶段来跑，而每个阶段共用同一份 `messages[]`。
+Explore、implement、review 是同一件工作的三个阶段，不是三件工作。
+前一个阶段查到什么，trajectory 就带到下一个阶段，所以没有哪个阶段需要把任务从头再读一遍。
 
-Phase node 反过来，把 trajectory 留着。整条路只有一份 `messages[]`。进到一个 phase 的时候，harness 换两样东西：system prompt 和整套 tool。
-Explore 挂读取和搜索，implement 挂编辑和执行，review 挂读取和一个下结论的 tool。
-没有东西要打包给下一个 phase，因为它要的 history 里都有。
+**每个 phase 的 tool：**每个 phase 有自己的 system prompt，也有自己的一套 tool，换 phase 的时候 harness 两样一起换掉。
+history 原封不动留着，所以没有东西要打包给下一个 phase。书里写的三个 phase 是：
 
-Model 想结束一个 phase，就调用一个 gate tool，例如 `finish_exploring`。harness 把这个调用当成 edge，直接开始下一个 phase。
-gate 是唯一的出口，所以一个 phase 什么时候结束，是 harness 说了算，不是 model。
+- **Explore：**读取和搜索。
+- **Implement：**编辑和执行。
+- **Review：**读取，再加一个返回结论的 tool。
 
-路线是先 explore，再 implement，最后 review。review 可以把执行送回 implement。这个形状就是一条路加一条往回的 edge。
-送回去也不用交接，因为 review 写的东西就在同一份 history 里。
+**Gate tool：**model 想离开一个 phase，就调用一个 gate tool，例如 `finish_exploring`。
+harness 把这个调用当成 edge，接着开始下一个 phase。gate 是唯一的出口，所以一个 phase 什么时候结束，是 harness 说了算，不是 model。
 
-要挂哪一种，看你怎么分配 context（第 8 章）。每个 node 都用全新的 `messages[]`，window 就小，分支之间也互不干扰。
-只留一条 trajectory 则是前面查到的东西都还看得到，但路越长，被吃掉的 window 也越多。
+**路线：**先跑 explore，再跑 implement，最后 review。review 没过就把执行送回 implement，
+implement 接着往下做，review 写的东西本来就在 trajectory 里。用这一章的讲法，这就是一条路加一条往回的 edge，
+跟前面的 evaluator-optimizer 同一个形状。
 
-书把这个做法算成 multi-agent，理由是每个 phase 的 prompt 和 tool 都不一样；这个 repo 则算成同一个 agent 换了 prompt 和 tool。
-算哪一种都好，机制是同一个，所以引用的时候先讲清楚你用的是哪个定义。这个做法的证据只有书里自己做的实验。
+**要挂哪一种：**分支之间没关系，就用全新的 `messages[]`；几个 node 是同一件工作的不同阶段，就留同一条 trajectory。
+全新的 `messages[]` 让每个 node 的 window 都很小，分支之间也互不干扰。
+只留一条 trajectory 则是前面查到的东西都还看得到，但路越长，被吃掉的 window 也越多。这是 context 怎么分配的问题（第 8 章）。
+
+**这样算不算 multi-agent：**书把这个做法算成 multi-agent，理由是每个 phase 的 prompt 和 tool 都换掉了。
+这个 repo 则算成同一个 agent 换了 prompt 和 tool。用哪个名字，机制都是同一个，所以引用这个结果的时候，先讲清楚你用的是哪个定义。
+
+**只有一个来源：**这个做法的依据是书里自己做的实验，没有第三方的报告佐证。
 
 ---
 
@@ -151,20 +159,20 @@ gate 是唯一的出口，所以一个 phase 什么时候结束，是 harness �
 
 ## 哪里会出错
 
-- **Model 当 router（Model as router）**：把选路交给 model，烧 token、增加延迟，而且每次跑不一样。最上游选错一次，后面全部跟着错。
+- **Model 当 router（Model as router）：**把选路交给 model，烧 token、增加延迟，而且每次跑不一样。最上游选错一次，后面全部跟着错。
   缓解：转移用代码判断；model 调用留给需要判断的 node。
-- **过度画图（Over-graphing）**：需要探索的任务被固定的图框住，解法要走的路被挡掉。
+- **过度画图（Over-graphing）：**需要探索的任务被固定的图框住，解法要走的路被挡掉。
   缓解：只把本来就要强制执行的结构写进图里；开放式的工作留给普通的 loop。
-- **没有失败的路（No failure edge）**：负责检查的 node 遇到 FAIL 却无路可送，烂输出就一路流到下游。
+- **没有失败的路（No failure edge）：**负责检查的 node 遇到 FAIL 却无路可送，烂输出就一路流到下游。
   缓解：每个检查 node 都给一条带 budget 的往回 edge（第 21 章）。
-- **没有上限的 cycle（Unbounded cycle）**：没有上限的重试 edge 会永远绕下去。缓解：harness 强制执行的 step budget；budget 用完就交给人。
-- **State 膨胀（State bloat）**：每个 node 都把完整输出倒进共用的 state，后面的 node 被淹没。
+- **没有上限的 cycle（Unbounded cycle）：**没有上限的重试 edge 会永远绕下去。缓解：harness 强制执行的 step budget；budget 用完就交给人。
+- **State 膨胀（State bloat）：**每个 node 都把完整输出倒进共用的 state，后面的 node 被淹没。
   缓解：严格的 state 边界；node 只读需要的子集，只返回自己的更新（第 8 章）。
-- **跑到一半挂掉（Mid-run death）**：一张长图在第七个 node 挂掉，重来却从第一个 node 开始。
+- **跑到一半挂掉（Mid-run death）：**一张长图在第七个 node 挂掉，重来却从第一个 node 开始。
   缓解：记下每个 node 的输出；续跑时跑完的 node 从记录重放（第 11、12 章）。
-- **Phase 走不完（Phase that never ends）**：model 一直不调用 gate tool，这个 phase 就用同一份 prompt、同一套 tool 一直做下去，只有 budget 停得了它。
+- **Phase 走不完（Phase that never ends）：**model 一直不调用 gate tool，这个 phase 就用同一份 prompt、同一套 tool 一直做下去，只有 budget 停得了它。
   缓解：gate 是唯一的出口；每个 phase 各自有 step budget；budget 用完就往下一个 phase 走，或者交给人。
-- **Trajectory 背着每个 phase（Trajectory that carries every phase）**：只有一条 trajectory，每过一个 phase 就长一截。里面还留着现在没挂的 tool 的调用记录，model 可能会再叫一次。
+- **Trajectory 背着每个 phase（Trajectory that carries every phase）：**只有一条 trajectory，每过一个 phase 就长一截。里面还留着现在没挂的 tool 的调用记录，model 可能会再叫一次。
   缓解：在 phase 的 prompt 里写清楚现在是哪个 phase、有哪些 tool；叫到没挂的 tool 就回一个清楚的错误；跑完的 phase 拿去 compact（第 8 章）。
 
 ---

--- a/sections/22-graph-engineering/README.zh-TW.md
+++ b/sections/22-graph-engineering/README.zh-TW.md
@@ -51,9 +51,9 @@ def run_graph(nodes, edges, state, start, budget=20):  # src/graph.py
 
 每個 node 都在純程式碼和完整 agent 之間選一個位置：
 
-- **Code node**：解析、驗證、固定的 API 呼叫。決定性的，不花 token。
-- **Model node**：一次 LLM 呼叫，例如分類器。有限度的判斷。
-- **Agent node**：一整個第 1 章的 loop，帶著 tool。開放式的判斷，但被固定在一個位置上。
+- **Code node：**解析、驗證、固定的 API 呼叫。決定性的，不花 token。
+- **Model node：**一次 LLM 呼叫，例如分類器。有限度的判斷。
+- **Agent node：**一整個第 1 章的 loop，帶著 tool。開放式的判斷，但被固定在一個位置上。
 
 `agent_node` 把內層 loop 掛成一個 node。每次經過都用 state 組出 prompt，在全新的 `messages[]` 上跑 `run_turn`，
 所以這個 node 只看得到 prompt builder 給它的部分，不是整趟執行。
@@ -64,11 +64,11 @@ def run_graph(nodes, edges, state, start, budget=20):  # src/graph.py
 
 出處裡叫得出名字的 workflow pattern，其實都是圖形：
 
-- **Prompt chaining**：一串 node 排成一條路，中間用程式碼把關。
-- **Routing**：一條條件式 edge，分流到各個專門的 node。
-- **Parallelization**：幾條同時跑的分支在一個 node 會合。可以是拆工作（sectioning），也可以是同一件事跑多次投票（voting）。
-- **Orchestrator-workers**：一個 node 在執行時決定要派出多少工作，再由一個 node 收攏。edge 是動態的，但形狀仍然是圖。
-- **Evaluator-optimizer**：一個 worker node、一個 checker node，加一條往回的 edge。這就是第 21 章的驗證 loop，放進圖裡變成一個子圖。
+- **Prompt chaining：**一串 node 排成一條路，中間用程式碼把關。
+- **Routing：**一條條件式 edge，分流到各個專門的 node。
+- **Parallelization：**幾條同時跑的分支在一個 node 會合。可以是拆工作（sectioning），也可以是同一件事跑多次投票（voting）。
+- **Orchestrator-workers：**一個 node 在執行時決定要派出多少工作，再由一個 node 收攏。edge 是動態的，但形狀仍然是圖。
+- **Evaluator-optimizer：**一個 worker node、一個 checker node，加一條往回的 edge。這就是第 21 章的驗證 loop，放進圖裡變成一個子圖。
 
 各家的講法還沒統一。同樣的東西，`ai-agent-book` 用的詞是「collaboration topology」和「orchestration」，「graph engineering」它只在術語註記裡提了一句。
 這一章還是用自己的名字，因為它講的就是一張寫在程式碼裡的圖。你去看別的來源時，對照的是機制，不是那個詞。
@@ -113,24 +113,32 @@ edges = {
 下面這個做法出自 ai-agent-book，那本書寫的是真的跑在產品裡的 agent。
 這一章的可執行程式沒有做這件事，下面表格裡那幾個系統，也沒有證據說它們是這樣做的。
 
-**Phase node**：agent node 每次經過都從全新的 `messages[]` 開始。分支之間沒關係的時候，這樣最好。
-但幾個 node 其實是同一件事的不同階段，這樣就不對了，因為每個階段都得把任務重讀一次。
+**Phase node：**phase node 把一件工作拆成好幾個階段來跑，而每個階段共用同一份 `messages[]`。
+Explore、implement、review 是同一件工作的三個階段，不是三件工作。
+前一個階段查到什麼，trajectory 就帶到下一個階段，所以沒有哪個階段需要把任務從頭再讀一遍。
 
-Phase node 反過來，把 trajectory 留著。整條路只有一份 `messages[]`。進到一個 phase 的時候，harness 換兩樣東西：system prompt 和整套 tool。
-Explore 掛讀取和搜尋，implement 掛編輯和執行，review 掛讀取和一個下結論的 tool。
-沒有東西要打包給下一個 phase，因為它要的 history 裡都有。
+**每個 phase 的 tool：**每個 phase 有自己的 system prompt，也有自己的一套 tool，換 phase 的時候 harness 兩樣一起換掉。
+history 原封不動留著，所以沒有東西要打包給下一個 phase。書裡寫的三個 phase 是：
 
-Model 想結束一個 phase，就呼叫一個 gate tool，例如 `finish_exploring`。harness 把這個呼叫當成 edge，直接開始下一個 phase。
-gate 是唯一的出口，所以一個 phase 什麼時候結束，是 harness 說了算，不是 model。
+- **Explore：**讀取和搜尋。
+- **Implement：**編輯和執行。
+- **Review：**讀取，再加一個回傳結論的 tool。
 
-路線是先 explore，再 implement，最後 review。review 可以把執行送回 implement。這個形狀就是一條路加一條往回的 edge。
-送回去也不用交接，因為 review 寫的東西就在同一份 history 裡。
+**Gate tool：**model 想離開一個 phase，就呼叫一個 gate tool，例如 `finish_exploring`。
+harness 把這個呼叫當成 edge，接著開始下一個 phase。gate 是唯一的出口，所以一個 phase 什麼時候結束，是 harness 說了算，不是 model。
 
-要掛哪一種，看你怎麼分配 context（第 8 章）。每個 node 都用全新的 `messages[]`，window 就小，分支之間也互不干擾。
-只留一條 trajectory 則是前面查到的東西都還看得到，但路愈長，被吃掉的 window 也愈多。
+**路線：**先跑 explore，再跑 implement，最後 review。review 沒過就把執行送回 implement，
+implement 接著往下做，review 寫的東西本來就在 trajectory 裡。用這一章的講法，這就是一條路加一條往回的 edge，
+跟前面的 evaluator-optimizer 同一個形狀。
 
-書把這個做法算成 multi-agent，理由是每個 phase 的 prompt 和 tool 都不一樣；這個 repo 則算成同一個 agent 換了 prompt 和 tool。
-算哪一種都好，機制是同一個，所以引用的時候先講清楚你用的是哪個定義。這個做法的證據只有書裡自己做的實驗。
+**要掛哪一種：**分支之間沒關係，就用全新的 `messages[]`；幾個 node 是同一件工作的不同階段，就留同一條 trajectory。
+全新的 `messages[]` 讓每個 node 的 window 都很小，分支之間也互不干擾。
+只留一條 trajectory 則是前面查到的東西都還看得到，但路愈長，被吃掉的 window 也愈多。這是 context 怎麼分配的問題（第 8 章）。
+
+**這樣算不算 multi-agent：**書把這個做法算成 multi-agent，理由是每個 phase 的 prompt 和 tool 都換掉了。
+這個 repo 則算成同一個 agent 換了 prompt 和 tool。用哪個名字，機制都是同一個，所以引用這個結果的時候，先講清楚你用的是哪個定義。
+
+**只有一個來源：**這個做法的依據是書裡自己做的實驗，沒有第三方的報告佐證。
 
 ---
 
@@ -151,20 +159,20 @@ gate 是唯一的出口，所以一個 phase 什麼時候結束，是 harness �
 
 ## 哪裡會出錯
 
-- **Model 當 router（Model as router）**：把選路交給 model，燒 token、增加延遲，而且每次跑不一樣。最上游選錯一次，後面全部跟著錯。
+- **Model 當 router（Model as router）：**把選路交給 model，燒 token、增加延遲，而且每次跑不一樣。最上游選錯一次，後面全部跟著錯。
   緩解：轉移用程式碼判斷；model 呼叫留給需要判斷的 node。
-- **過度畫圖（Over-graphing）**：需要探索的任務被固定的圖框住，解法要走的路被擋掉。
+- **過度畫圖（Over-graphing）：**需要探索的任務被固定的圖框住，解法要走的路被擋掉。
   緩解：只把本來就要強制執行的結構寫進圖裡；開放式的工作留給普通的 loop。
-- **沒有失敗的路（No failure edge）**：負責檢查的 node 遇到 FAIL 卻無路可送，爛輸出就一路流到下游。
+- **沒有失敗的路（No failure edge）：**負責檢查的 node 遇到 FAIL 卻無路可送，爛輸出就一路流到下游。
   緩解：每個檢查 node 都給一條帶 budget 的往回 edge（第 21 章）。
-- **沒有上限的 cycle（Unbounded cycle）**：沒有上限的重試 edge 會永遠繞下去。緩解：harness 強制執行的 step budget；budget 用完就交給人。
-- **State 膨脹（State bloat）**：每個 node 都把完整輸出倒進共用的 state，後面的 node 被淹沒。
+- **沒有上限的 cycle（Unbounded cycle）：**沒有上限的重試 edge 會永遠繞下去。緩解：harness 強制執行的 step budget；budget 用完就交給人。
+- **State 膨脹（State bloat）：**每個 node 都把完整輸出倒進共用的 state，後面的 node 被淹沒。
   緩解：嚴格的 state 邊界；node 只讀需要的子集，只回傳自己的更新（第 8 章）。
-- **跑到一半掛掉（Mid-run death）**：一張長圖在第七個 node 掛掉，重來卻從第一個 node 開始。
+- **跑到一半掛掉（Mid-run death）：**一張長圖在第七個 node 掛掉，重來卻從第一個 node 開始。
   緩解：記下每個 node 的輸出；續跑時跑完的 node 從紀錄重放（第 11、12 章）。
-- **Phase 走不完（Phase that never ends）**：model 一直不呼叫 gate tool，這個 phase 就用同一份 prompt、同一套 tool 一直做下去，只有 budget 停得了它。
+- **Phase 走不完（Phase that never ends）：**model 一直不呼叫 gate tool，這個 phase 就用同一份 prompt、同一套 tool 一直做下去，只有 budget 停得了它。
   緩解：gate 是唯一的出口；每個 phase 各自有 step budget；budget 用完就往下一個 phase 走，或者交給人。
-- **Trajectory 背著每個 phase（Trajectory that carries every phase）**：只有一條 trajectory，每過一個 phase 就長一截。裡面還留著現在沒掛的 tool 的呼叫紀錄，model 可能會再叫一次。
+- **Trajectory 背著每個 phase（Trajectory that carries every phase）：**只有一條 trajectory，每過一個 phase 就長一截。裡面還留著現在沒掛的 tool 的呼叫紀錄，model 可能會再叫一次。
   緩解：在 phase 的 prompt 裡寫清楚現在是哪個 phase、有哪些 tool；叫到沒掛的 tool 就回一個清楚的錯誤；跑完的 phase 拿去 compact（第 8 章）。
 
 ---

--- a/sections/22-graph-engineering/README.zh-TW.md
+++ b/sections/22-graph-engineering/README.zh-TW.md
@@ -110,8 +110,7 @@ edges = {
 
 ### 延伸閱讀
 
-下面這個做法出自 ai-agent-book，那本書寫的是真的跑在產品裡的 agent。
-這一章的可執行程式沒有做這件事，下面表格裡那幾個系統，也沒有證據說它們是這樣做的。
+以下設計 `src/` 都沒有實作，出自 ai-agent-book，也未經下面表格的系統證實。
 
 **Phase node：**phase node 把一件工作拆成好幾個階段來跑，而每個階段共用同一份 `messages[]`。
 Explore、implement、review 是同一件工作的三個階段，不是三件工作。

--- a/sections/22-graph-engineering/README.zh-TW.md
+++ b/sections/22-graph-engineering/README.zh-TW.md
@@ -60,22 +60,6 @@ def run_graph(nodes, edges, state, start, budget=20):  # src/graph.py
 
 怎麼選？原則就是省 token：分支條件寫得出來的，就交給程式碼；model 呼叫只留給真的需要判斷的 node。
 
-### Phase node
-
-Agent node 每次經過都從全新的 `messages[]` 開始。分支彼此無關的時候這樣最好；但幾個 node 其實是同一件事的不同階段，這樣就不對了。
-
-Phase node 就是把 trajectory 留下來的那個變體。整條路只有一份 `messages[]`。進到某個 phase 的時候，harness 換掉外面那層框：換一份 system prompt，換一套 tool。
-Explore 掛讀取和搜尋，implement 掛編輯和執行，review 掛讀取和一個下結論的 tool。這個 phase 要的東西 history 裡都有，不用再打包一次。
-
-Model 要離開一個 phase，就呼叫一個 gate tool，例如 `finish_exploring`。harness 把這個呼叫當成 edge，直接進下一個 phase。
-gate 是唯一的出口，所以一個 phase 什麼時候結束由 harness 決定，不是看 model 自己怎麼講。
-形狀是一條路加一條往回的 edge：explore、implement、review，而 review 可以把執行送回 implement，筆記本來就留在 history 裡。
-
-要掛哪一種，是 context 的取捨（第 8 章）。每個 node 都用全新的 `messages[]`，window 就小，分支之間也彼此獨立。
-只留一條 trajectory 則是前後比較連貫，但路愈長，吃掉的 window 也愈多。
-記載這個做法的書把它算成 multi-agent，理由是每個 phase 的 prompt 和 tool 都不一樣；這個 repo 則把它算成同一個 agent 換了外框。
-機制是同一個，所以引用的時候要先講清楚你用的是哪個定義。這個做法的證據來自書裡自己做的實驗，只有這一個來源。
-
 ### 常見的圖形
 
 出處裡叫得出名字的 workflow pattern，其實都是圖形：
@@ -86,8 +70,8 @@ gate 是唯一的出口，所以一個 phase 什麼時候結束由 harness 決�
 - **Orchestrator-workers**：一個 node 在執行時決定要派出多少工作，再由一個 node 收攏。edge 是動態的，但形狀仍然是圖。
 - **Evaluator-optimizer**：一個 worker node、一個 checker node，加一條往回的 edge。這就是第 21 章的驗證 loop，放進圖裡變成一個子圖。
 
-名字還沒有統一。`ai-agent-book` 主要用的詞是「collaboration topology」和「orchestration」，「graph engineering」只被它放在一則術語註記裡。
-這一章沿用這個名字，因為它講的東西就是一張寫在程式碼裡的圖。看不同來源的時候，對得上的是機制，不是那個詞。
+各家的講法還沒統一。同樣的東西，`ai-agent-book` 用的詞是「collaboration topology」和「orchestration」，「graph engineering」它只在術語註記裡提了一句。
+這一章還是用自己的名字，因為它講的就是一張寫在程式碼裡的圖。你去看別的來源時，對照的是機制，不是那個詞。
 
 ### 什麼時候不要畫圖
 
@@ -124,6 +108,30 @@ edges = {
 }
 ```
 
+### 延伸閱讀
+
+下面這個做法出自 ai-agent-book，那本書寫的是真的跑在產品裡的 agent。
+這一章的可執行程式沒有做這件事，下面表格裡那幾個系統，也沒有證據說它們是這樣做的。
+
+**Phase node**：agent node 每次經過都從全新的 `messages[]` 開始。分支之間沒關係的時候，這樣最好。
+但幾個 node 其實是同一件事的不同階段，這樣就不對了，因為每個階段都得把任務重讀一次。
+
+Phase node 反過來，把 trajectory 留著。整條路只有一份 `messages[]`。進到一個 phase 的時候，harness 換兩樣東西：system prompt 和整套 tool。
+Explore 掛讀取和搜尋，implement 掛編輯和執行，review 掛讀取和一個下結論的 tool。
+沒有東西要打包給下一個 phase，因為它要的 history 裡都有。
+
+Model 想結束一個 phase，就呼叫一個 gate tool，例如 `finish_exploring`。harness 把這個呼叫當成 edge，直接開始下一個 phase。
+gate 是唯一的出口，所以一個 phase 什麼時候結束，是 harness 說了算，不是 model。
+
+路線是先 explore，再 implement，最後 review。review 可以把執行送回 implement。這個形狀就是一條路加一條往回的 edge。
+送回去也不用交接，因為 review 寫的東西就在同一份 history 裡。
+
+要掛哪一種，看你怎麼分配 context（第 8 章）。每個 node 都用全新的 `messages[]`，window 就小，分支之間也互不干擾。
+只留一條 trajectory 則是前面查到的東西都還看得到，但路愈長，被吃掉的 window 也愈多。
+
+書把這個做法算成 multi-agent，理由是每個 phase 的 prompt 和 tool 都不一樣；這個 repo 則算成同一個 agent 換了 prompt 和 tool。
+算哪一種都好，機制是同一個，所以引用的時候先講清楚你用的是哪個定義。這個做法的證據只有書裡自己做的實驗。
+
 ---
 
 ## 各系統做法
@@ -154,10 +162,10 @@ edges = {
   緩解：嚴格的 state 邊界；node 只讀需要的子集，只回傳自己的更新（第 8 章）。
 - **跑到一半掛掉（Mid-run death）**：一張長圖在第七個 node 掛掉，重來卻從第一個 node 開始。
   緩解：記下每個 node 的輸出；續跑時跑完的 node 從紀錄重放（第 11、12 章）。
-- **Phase 走不完（Phase that never ends）**：phase node 的 gate tool 一直沒被呼叫，它就用同一份 prompt、同一套 tool 一直做下去，直到 budget 用完。
+- **Phase 走不完（Phase that never ends）**：model 一直不呼叫 gate tool，這個 phase 就用同一份 prompt、同一套 tool 一直做下去，只有 budget 停得了它。
   緩解：gate 是唯一的出口；每個 phase 各自有 step budget；budget 用完就往下一個 phase 走，或者交給人。
-- **Trajectory 背著每個 phase（Trajectory that carries every phase）**：只有一條 trajectory，每過一個 phase 就長一截，裡面還留著現在這個 phase 沒掛的 tool 的呼叫紀錄。
-  緩解：在 phase 的 prompt 裡講清楚現在是哪個 phase、有哪些 tool；呼叫沒掛的 tool 就回一個清楚的錯誤；跑完的 phase 拿去 compact（第 8 章）。
+- **Trajectory 背著每個 phase（Trajectory that carries every phase）**：只有一條 trajectory，每過一個 phase 就長一截。裡面還留著現在沒掛的 tool 的呼叫紀錄，model 可能會再叫一次。
+  緩解：在 phase 的 prompt 裡寫清楚現在是哪個 phase、有哪些 tool；叫到沒掛的 tool 就回一個清楚的錯誤；跑完的 phase 拿去 compact（第 8 章）。
 
 ---
 
@@ -187,5 +195,5 @@ uv run python sections/22-graph-engineering/src/demo.py  # live demo, needs a ke
 - [Hermes Agent 原始碼](https://github.com/NousResearch/hermes-agent)：`tools/delegate_tool.py`、`tools/async_delegation.py`、`batch_runner.py`。
 - [mini-swe-agent source](https://github.com/swe-agent/mini-swe-agent)：`agents/default.py` 的 run loop 與 budget、`run/benchmarks/swebench.py`。
 - [ai-agent-book · 第 10 章](https://github.com/bojieli/ai-agent-book/blob/main/book/chapter10.md)（《深入理解 AI Agent》，李博杰，多 Agent 协作，以中文原版為準）：
-  在同一條 trajectory 上做多階段角色轉換，每個 phase 一份 system prompt 和一套 tool，phase 之間用 tool call 當關卡，review 可以繞回實作。
-  這個做法的依據是書裡自己做的實驗，只有這一個來源。同一章主要用的詞是「collaboration topology」和「orchestration」。
+  在同一條 trajectory 上做多階段角色轉換：每個 phase 一份 system prompt 和一套 tool，phase 之間用 tool call 當關卡，review 可以繞回實作。
+  這個做法的證據只有書裡自己做的實驗。同一章主要用的詞是「collaboration topology」和「orchestration」。

--- a/sections/22-graph-engineering/README.zh-TW.md
+++ b/sections/22-graph-engineering/README.zh-TW.md
@@ -60,6 +60,22 @@ def run_graph(nodes, edges, state, start, budget=20):  # src/graph.py
 
 怎麼選？原則就是省 token：分支條件寫得出來的，就交給程式碼；model 呼叫只留給真的需要判斷的 node。
 
+### Phase node
+
+Agent node 每次經過都從全新的 `messages[]` 開始。分支彼此無關的時候這樣最好；但幾個 node 其實是同一件事的不同階段，這樣就不對了。
+
+Phase node 就是把 trajectory 留下來的那個變體。整條路只有一份 `messages[]`。進到某個 phase 的時候，harness 換掉外面那層框：換一份 system prompt，換一套 tool。
+Explore 掛讀取和搜尋，implement 掛編輯和執行，review 掛讀取和一個下結論的 tool。這個 phase 要的東西 history 裡都有，不用再打包一次。
+
+Model 要離開一個 phase，就呼叫一個 gate tool，例如 `finish_exploring`。harness 把這個呼叫當成 edge，直接進下一個 phase。
+gate 是唯一的出口，所以一個 phase 什麼時候結束由 harness 決定，不是看 model 自己怎麼講。
+形狀是一條路加一條往回的 edge：explore、implement、review，而 review 可以把執行送回 implement，筆記本來就留在 history 裡。
+
+要掛哪一種，是 context 的取捨（第 8 章）。每個 node 都用全新的 `messages[]`，window 就小，分支之間也彼此獨立。
+只留一條 trajectory 則是前後比較連貫，但路愈長，吃掉的 window 也愈多。
+記載這個做法的書把它算成 multi-agent，理由是每個 phase 的 prompt 和 tool 都不一樣；這個 repo 則把它算成同一個 agent 換了外框。
+機制是同一個，所以引用的時候要先講清楚你用的是哪個定義。這個做法的證據來自書裡自己做的實驗，只有這一個來源。
+
 ### 常見的圖形
 
 出處裡叫得出名字的 workflow pattern，其實都是圖形：
@@ -69,6 +85,9 @@ def run_graph(nodes, edges, state, start, budget=20):  # src/graph.py
 - **Parallelization**：幾條同時跑的分支在一個 node 會合。可以是拆工作（sectioning），也可以是同一件事跑多次投票（voting）。
 - **Orchestrator-workers**：一個 node 在執行時決定要派出多少工作，再由一個 node 收攏。edge 是動態的，但形狀仍然是圖。
 - **Evaluator-optimizer**：一個 worker node、一個 checker node，加一條往回的 edge。這就是第 21 章的驗證 loop，放進圖裡變成一個子圖。
+
+名字還沒有統一。`ai-agent-book` 主要用的詞是「collaboration topology」和「orchestration」，「graph engineering」只被它放在一則術語註記裡。
+這一章沿用這個名字，因為它講的東西就是一張寫在程式碼裡的圖。看不同來源的時候，對得上的是機制，不是那個詞。
 
 ### 什麼時候不要畫圖
 
@@ -111,14 +130,14 @@ edges = {
 
 各個 agent 怎麼決定下一步跑什麼。
 
-|                        | Claude Code                                                                | Hermes Agent                                       | mini-swe-agent                                                   |
-| ---------------------- | -------------------------------------------------------------------------- | -------------------------------------------------- | ---------------------------------------------------------------- |
-| **Pros**         | Routing 是程式碼：不花 token、不會變來變去。續跑時跑完的 node 從紀錄重放。 | 不用事先畫圖，任務長什麼樣，結構就長什麼樣。       | 整張圖一眼就能看完。                                             |
-| **Cons**         | 圖活在單次執行的 script 裡，不是可以重用的宣告式圖。                       | Routing 花 model 的 token，每次跑可能不一樣。      | 所有任務共用同一個形狀，沒有分支可以特化。                       |
-| **Why**          | 把編排當成程式：script 寫好一次，harness 每次都決定性地執行。              | 假設助理型工作太開放，結構沒辦法預先宣告。         | 一個 baseline：所有選擇都留在 model 裡，harness 只留一個 cycle。 |
-| **How: nodes**   | 一個 node 一個 subagent，回傳通過 schema 驗證的結構化輸出。                | 委派出去的 subagent，深度和並行數都有上限。        | 兩個：一個 model step、一個 environment step。                   |
-| **How: routing** | 階段之間用普通的 script 程式碼：條件、迴圈、pipeline、平行分派。           | model 用 tool call 選路，沒有寫在程式碼裡的 edge。 | 一個固定的 cycle，跑到 model 提交或 budget 用完為止。            |
-| **How: state**   | 階段的回傳值往下傳；journal 記下每個 node 的輸出供續跑。                   | 結果經過 completion queue 回到呼叫端。             | message list 就是全部的 state。                                  |
+| | Claude Code | Hermes Agent | mini-swe-agent |
+| --- | --- | --- | --- |
+| **Pros** | Routing 是程式碼：不花 token、不會變來變去。續跑時跑完的 node 從紀錄重放。 | 不用事先畫圖，任務長什麼樣，結構就長什麼樣。 | 整張圖一眼就能看完。 |
+| **Cons** | 圖活在單次執行的 script 裡，不是可以重用的宣告式圖。 | Routing 花 model 的 token，每次跑可能不一樣。 | 所有任務共用同一個形狀，沒有分支可以特化。 |
+| **Why** | 把編排當成程式：script 寫好一次，harness 每次都決定性地執行。 | 假設助理型工作太開放，結構沒辦法預先宣告。 | 一個 baseline：所有選擇都留在 model 裡，harness 只留一個 cycle。 |
+| **How: nodes** | 一個 node 一個 subagent，回傳通過 schema 驗證的結構化輸出。 | 委派出去的 subagent，深度和並行數都有上限。 | 兩個：一個 model step、一個 environment step。 |
+| **How: routing** | 階段之間用普通的 script 程式碼：條件、迴圈、pipeline、平行分派。 | model 用 tool call 選路，沒有寫在程式碼裡的 edge。 | 一個固定的 cycle，跑到 model 提交或 budget 用完為止。 |
+| **How: state** | 階段的回傳值往下傳；journal 記下每個 node 的輸出供續跑。 | 結果經過 completion queue 回到呼叫端。 | message list 就是全部的 state。 |
 
 ---
 
@@ -135,6 +154,10 @@ edges = {
   緩解：嚴格的 state 邊界；node 只讀需要的子集，只回傳自己的更新（第 8 章）。
 - **跑到一半掛掉（Mid-run death）**：一張長圖在第七個 node 掛掉，重來卻從第一個 node 開始。
   緩解：記下每個 node 的輸出；續跑時跑完的 node 從紀錄重放（第 11、12 章）。
+- **Phase 走不完（Phase that never ends）**：phase node 的 gate tool 一直沒被呼叫，它就用同一份 prompt、同一套 tool 一直做下去，直到 budget 用完。
+  緩解：gate 是唯一的出口；每個 phase 各自有 step budget；budget 用完就往下一個 phase 走，或者交給人。
+- **Trajectory 背著每個 phase（Trajectory that carries every phase）**：只有一條 trajectory，每過一個 phase 就長一截，裡面還留著現在這個 phase 沒掛的 tool 的呼叫紀錄。
+  緩解：在 phase 的 prompt 裡講清楚現在是哪個 phase、有哪些 tool；呼叫沒掛的 tool 就回一個清楚的錯誤；跑完的 phase 拿去 compact（第 8 章）。
 
 ---
 
@@ -163,3 +186,6 @@ uv run python sections/22-graph-engineering/src/demo.py  # live demo, needs a ke
 - [Claude Code](https://code.claude.com/docs)：`Workflow` script 的約定（pipeline、平行分派、結構化輸出、續跑）。內容依據 tool schema 和文件記載的行為，不是 source backup。
 - [Hermes Agent 原始碼](https://github.com/NousResearch/hermes-agent)：`tools/delegate_tool.py`、`tools/async_delegation.py`、`batch_runner.py`。
 - [mini-swe-agent source](https://github.com/swe-agent/mini-swe-agent)：`agents/default.py` 的 run loop 與 budget、`run/benchmarks/swebench.py`。
+- [ai-agent-book · 第 10 章](https://github.com/bojieli/ai-agent-book/blob/main/book/chapter10.md)（《深入理解 AI Agent》，李博杰，多 Agent 协作，以中文原版為準）：
+  在同一條 trajectory 上做多階段角色轉換，每個 phase 一份 system prompt 和一套 tool，phase 之間用 tool call 當關卡，review 可以繞回實作。
+  這個做法的依據是書裡自己做的實驗，只有這一個來源。同一章主要用的詞是「collaboration topology」和「orchestration」。


### PR DESCRIPTION
Implements #41. Part of #24.

## What landed

Multi-stage role switching as a shared-trajectory phase node with per-phase prompt and tool swap, and the book's demotion of the Graph Engineering term recorded as a sourced counterpoint. The section keeps its own naming as fact, and the definitional split over what counts as multi-agent is stated.

Book material lands as mechanism text, failure modes, and Sources only. No per-system table columns were added.
Designs this section's `src/` does not implement sit under a `Further reading` subsection after `How it integrates`, behind a one-line caveat.

## Checks

- No line over 180 characters (counted as characters for the zh files), no em or en dashes.
- zh-TW and zh-CN mirror the English edits; heading counts equal across the three languages; switcher line untouched.
- Per-system table columns unchanged. `src/` untouched. Offline test suites 23/23.
- `research/*` branches untouched, read via `git show` only.

` 3 files changed, 160 insertions(+), 36 deletions(-)`

Closes #41