### PR TITLE
docs(21): add two verification failure modes with sources

### DIFF
--- a/sections/21-loop-engineering/README.md
+++ b/sections/21-loop-engineering/README.md
@@ -196,6 +196,12 @@ How each agent composes its outer loops.
 - **Self-grading.** The worker passes its own output, so the verification loop verifies nothing. Mitigation: a separate checker agent and a rubric fixed outside the loop.
 - **Rubber-stamp rubric.** A grader that always passes is worse than none, because it labels bad output as verified.
   Mitigation: adversarial verify (prompt the checker to refute) and periodic human spot checks.
+- **The checker shares the worker's vendor.** A second agent is not a second opinion when both sit behind the same provider.
+  Mitigation: resolve the checker's vendor from the executor backend, drop same vendor voters when an alternative is configured,
+  and record the residual status (`independent`, `unverified`, `same_vendor`) on the run instead of assuming independence.
+- **The hidden rubric leaks through the failure output.** Hiding the grading command from the worker holds only while the string stays hidden.
+  The harness prints its own assertion into the failure tail that feeds the retry, and verbatim redaction misses any transformed copy:
+  a line wrap, a diff prefix, an ANSI color code inside the string. Mitigation: normalize before matching, and fail closed on the tail.
 - **Unattended too early.** A loop gets L3 write access before its L1 reports were ever checked.
   Mitigation: climb the maturity ladder one level at a time, gated by section 3 permissions.
 - **Silent drift.** An unattended loop degrades and nobody reads its output. Mitigation: heartbeats, always-delivered reports, and section 20 metrics on pass rate and cost.
@@ -249,6 +255,10 @@ uv run python sections/21-loop-engineering/src/demo.py  # live demo, needs a key
 - [Lin et al.](https://arxiv.org/abs/2605.30621): harness updating and harness benefit measured separately, with model swaps used to tell them apart.
 - [AHE](https://arxiv.org/abs/2604.25850) and [Self-Harness](https://arxiv.org/abs/2606.09498): change contracts and bounded candidate spaces for a harness that edits itself.
 - [Claude Code](https://code.claude.com/docs): `/loop`, `ScheduleWakeup`, `Workflow` schema. From tool schemas and documented behavior, not the source backup.
+- [Ouroboros source](https://github.com/Q00/ouroboros): the two failure modes above, read off `orchestrator/contract_redaction.py`
+  (the five encodings a hidden assertion is redacted in), `orchestrator/retry_hints.py` (the deterministic retry hint),
+  `orchestrator/parallel_executor.py` (the `verify_command` gate and its 2000 character output tail),
+  and `evaluation/reviewer_independence.py` (vendor level checker independence and its four statuses).
 - [Hermes Agent source](https://github.com/NousResearch/hermes-agent):
   `agent/iteration_budget.py`, `cron/scheduler.py`, `tools/skill_manager_tool.py`, `hermes_cli/curator.py`, `agent/trajectory.py`.
 - [mini-swe-agent source](https://github.com/swe-agent/mini-swe-agent): `AgentConfig` and `query()` in `agents/default.py`, `agents/interactive.py`, `run/benchmarks/swebench.py`.

--- a/sections/21-loop-engineering/README.zh-CN.md
+++ b/sections/21-loop-engineering/README.zh-CN.md
@@ -195,6 +195,12 @@ loop 能搜的范围是一道阶梯。最底下那阶是 prompt 里的一条规�
 - **自己评自己（Self-grading）：**worker 给自己的输出打分，验证 loop 等于什么都没验。缓解：独立的 checker agent，加上定在 loop 之外的 rubric。
 - **评什么都过（Rubber-stamp rubric）：**永远给过的评分者比没有还糟，因为它给烂输出盖上“已验证”的章。
   缓解：对抗式验证（要求 checker 想办法推翻），加上定期的人工抽查。
+- **checker 和 worker 同厂商（Same-vendor checker）：**换一个 agent 不等于换一个意见，两边在同一个 provider 后面就还是同一套判断。
+  缓解：从执行方的 backend 推出厂商，有替代品的时候把同厂商的投票模型踢出去，
+  并把剩下的状态（`independent`、`unverified`、`same_vendor`）记在这趟 run 上，而不是默认它独立。
+- **藏起来的 rubric 从失败输出漏回去（Rubric leak）：**把评分命令对 worker 藏起来，只在那个字符串真的没露出来的时候才成立。
+  harness 自己会把断言打进喂给重试的失败尾巴里，而逐字脱敏抓不到任何变形过的副本：
+  折行、diff 的行前缀、字符串中间插进来的 ANSI 色码。缓解：先归一化再匹配，尾巴这一段 fail closed。
 - **太早放手（Unattended too early）：**L1 的报告从来没人核对过，loop 就拿到了 L3 的写入权限。
   缓解：成熟度阶梯一次只升一级，由第 3 章的权限把关。
 - **无声劣化（Silent drift）：**无人看管的 loop 越跑越差，却没有人读它的输出。缓解：heartbeat、一律投递的报告，以及第 20 章对通过率和成本的度量。
@@ -248,6 +254,10 @@ uv run python sections/21-loop-engineering/src/demo.py  # live demo, needs a key
 - [Lin et al.](https://arxiv.org/abs/2605.30621)：harness 更新和 harness 收益分开量，用换 model 的方式把两者分辨开来。
 - [AHE](https://arxiv.org/abs/2604.25850) 与 [Self-Harness](https://arxiv.org/abs/2606.09498)：harness 自我修改时的变更契约与受限候选空间。
 - [Claude Code](https://code.claude.com/docs)：`/loop` skill、`ScheduleWakeup`、`Workflow` schema。依据 tool schema 与文档记载的行为描述，非 source backup。
+- [Ouroboros 源码](https://github.com/Q00/ouroboros)：上面两条失败模式的出处，`orchestrator/contract_redaction.py`
+  （隐藏断言被脱敏的五种编码）、`orchestrator/retry_hints.py`（确定性的重试 hint）、
+  `orchestrator/parallel_executor.py`（`verify_command` 门和它 2000 字符的输出尾巴）、
+  `evaluation/reviewer_independence.py`（厂商级的 checker 独立性和它的四种状态）。
 - [Hermes Agent 源码](https://github.com/NousResearch/hermes-agent)：
   `agent/iteration_budget.py`、`cron/scheduler.py`、`tools/skill_manager_tool.py`、`hermes_cli/curator.py`、`agent/trajectory.py`。
 - [mini-swe-agent source](https://github.com/swe-agent/mini-swe-agent)：`agents/default.py` 的 `AgentConfig` 与 `query()`、`agents/interactive.py`、`run/benchmarks/swebench.py`。

--- a/sections/21-loop-engineering/README.zh-TW.md
+++ b/sections/21-loop-engineering/README.zh-TW.md
@@ -195,6 +195,12 @@ loop 能搜的範圍是一道階梯。最底下那階是 prompt 裡的一條規�
 - **自己評自己（Self-grading）：**worker 給自己的輸出打分數，驗證 loop 等於什麼都沒驗。緩解：獨立的 checker agent，加上定在 loop 之外的 rubric。
 - **評什麼都過（Rubber-stamp rubric）：**永遠給過的評分者比沒有還糟，因為它替爛輸出蓋上「已驗證」的章。
   緩解：對抗式驗證（要求 checker 想辦法推翻），加上定期的人工抽查。
+- **checker 和 worker 同廠商（Same-vendor checker）：**換一個 agent 不等於換一個意見，兩邊在同一個 provider 後面就還是同一套判斷。
+  緩解：從執行方的 backend 推出廠商，有替代品的時候把同廠商的投票模型踢出去，
+  並把剩下的狀態（`independent`、`unverified`、`same_vendor`）記在這趟 run 上，而不是預設它獨立。
+- **藏起來的 rubric 從失敗輸出漏回去（Rubric leak）：**把評分指令對 worker 藏起來，只在那個字串真的沒露出來的時候才成立。
+  harness 自己會把斷言印進餵給重試的失敗尾巴裡，而逐字脫敏抓不到任何變形過的副本：
+  折行、diff 的行前綴、字串中間插進來的 ANSI 色碼。緩解：先正規化再比對，尾巴這一段 fail closed。
 - **太早放手（Unattended too early）：**L1 的回報從來沒人核對過，loop 就拿到了 L3 的寫入權限。
   緩解：成熟度階梯一次只升一級，由第 3 章的權限把關。
 - **無聲劣化（Silent drift）：**無人看管的 loop 越跑越差，卻沒有人讀它的輸出。緩解：heartbeat、一律投遞的回報，以及第 20 章對通過率和成本的量測。
@@ -248,6 +254,10 @@ uv run python sections/21-loop-engineering/src/demo.py  # live demo, needs a key
 - [Lin et al.](https://arxiv.org/abs/2605.30621)：harness 更新和 harness 收益分開量，用換 model 的方式把兩者分辨開來。
 - [AHE](https://arxiv.org/abs/2604.25850) 與 [Self-Harness](https://arxiv.org/abs/2606.09498)：harness 自我修改時的變更契約與受限候選空間。
 - [Claude Code](https://code.claude.com/docs)：`/loop` skill、`ScheduleWakeup`、`Workflow` schema。依據 tool schema 與文件記載的行為描述，非 source backup。
+- [Ouroboros 原始碼](https://github.com/Q00/ouroboros)：上面兩條失敗模式的出處，`orchestrator/contract_redaction.py`
+  （隱藏斷言被脫敏的五種編碼）、`orchestrator/retry_hints.py`（確定性的重試 hint）、
+  `orchestrator/parallel_executor.py`（`verify_command` 閘門和它 2000 字元的輸出尾巴）、
+  `evaluation/reviewer_independence.py`（廠商級的 checker 獨立性和它的四種狀態）。
 - [Hermes Agent 原始碼](https://github.com/NousResearch/hermes-agent)：
   `agent/iteration_budget.py`、`cron/scheduler.py`、`tools/skill_manager_tool.py`、`hermes_cli/curator.py`、`agent/trajectory.py`。
 - [mini-swe-agent source](https://github.com/swe-agent/mini-swe-agent)：`agents/default.py` 的 `AgentConfig` 與 `query()`、`agents/interactive.py`、`run/benchmarks/swebench.py`。


### PR DESCRIPTION
Two failure modes for section 21, both sitting under the existing `Self-grading` and `Rubber-stamp rubric` bullets, which they extend rather than repeat.

**Affiliation:** I work on [Ouroboros](https://github.com/Q00/ouroboros), which is where both observations come from. This started as a code review @hardness1020 left on [Q00/ouroboros#1979](https://github.com/Q00/ouroboros/discussions/1979) about hidden assertions and checker independence. Both points held up against the source, so they belong here as failure modes rather than as a plug.

## What the two bullets add

**Same-vendor checker.** The section already says the mitigation for self-grading is "a separate checker agent and a rubric fixed outside the loop." A separate agent is not a separate opinion when both sit behind the same provider, and that case is common: most people have one backend installed. The bullet gives the mitigation we landed on, which is to resolve the checker's vendor from the executor backend, drop same-vendor voters when an alternative exists, and then record the residual status on the run instead of assuming independence. Recording it matters more than the filter, because on a single-vendor setup the filter is a no-op and the honest output is the label.

**Hidden rubric leaks through the failure output.** Hiding the grading command from the worker only holds while the string stays hidden. The harness prints its own assertion into the failure tail that feeds the retry, and redaction that enumerates encodings misses any transformed copy: a line wrap, a diff prefix, an ANSI color code inside the string. This is the more useful half, because the first fix looks complete and is not.

## Sources

The `Sources` block gains one entry with the four files the claims are read off, in the same shape as the Hermes Agent and mini-swe-agent entries.

## Checklist

- All three READMEs updated in the same commit.
- No em or en dashes in the added lines.
- `awk 'length($0)>180'` returns nothing for the added lines. The pre-existing over-length lines in the two Chinese files are untouched.
- 30 insertions, 0 deletions. No existing prose changed.

## One thing I did not do

I offered @hardness1020 a fourth column in the per-system table and then found it does not fit: the existing rows are already 175 to 178 characters, so a fourth column needs the current three cells condensed. That is a bigger edit to your prose than I want to make uninvited. Happy to do it in a separate PR if you want it.
