### PR TITLE
docs: add Agent QA feedback-loop example

### DIFF
--- a/sections/23-evaluation/README.md
+++ b/sections/23-evaluation/README.md
@@ -181,6 +181,10 @@ Inside a product this becomes standing infrastructure. A master switch disables 
 Feature flags carry the AB test arms and double as a kill switch.
 A snapshot of the fully rendered system prompt per commit lets a prompt edit run the eval suite like any other code change.
 
+Product-facing test agents make the same loop concrete. Agent QA curates product, suite, and test observations after successful runs,
+then injects relevant memory into later test steps. This is a scoped feedback loop over the test harness,
+not proof that the application under test improved itself.
+
 For the AB tests, separate the mechanism metric you moved (plan length, prompt size) from the goal metric you care about (task success, session cost).
 Keep guardrail metrics that stop the experiment even when the goal metric improves.
 
@@ -273,5 +277,7 @@ uv run python sections/23-evaluation/src/demo.py  # live demo, needs a key
 - [GAIA](https://arxiv.org/abs/2311.12983): 466 questions with answers withheld for 300 of them, so the leaderboard cannot be scraped.
 - [BIG-bench](https://github.com/google/BIG-bench): the canary string carried in every task file to keep benchmark tasks out of web-scraped training data.
 - [Rubrics as Rewards](https://arxiv.org/abs/2507.17746) (Scale AI): checklist rubrics that name required facts, required reasoning steps, and the pitfalls that must be penalized.
+- [Agent QA](https://github.com/vostride/agent-qa): memory curation after successful runs and runtime injection into later test steps,
+  used as the product-facing feedback-loop example.
 - [Claude Code](https://code.claude.com/docs): the reviewer and judge stages in the workflow contract, from tool schemas and documented behavior, not the source backup.
   Evaluation suites are not present in the source, so those cells are marked as reconstruction.

--- a/sections/23-evaluation/README.zh-CN.md
+++ b/sections/23-evaluation/README.zh-CN.md
@@ -182,6 +182,10 @@ benchmark 报告只拿来做一个决定：下一步要改什么。
 Feature flag 负责分 AB 测试的组别，出事时也是断路开关。
 每个 commit 都存一份完整展开后的 system prompt，改 prompt 就跟改代码一样，要跑一次评估。
 
+面向产品的测试 agent 能把同一条 loop 落到实处。Agent QA 会在成功 run 后整理 product、suite 和 test observation，
+再把相关 memory 注入后续的测试步骤。这里改善的是测试 harness 中一个边界清楚的 feedback loop，
+不代表被测应用自己变好了。
+
 做 AB 测试时，要把你直接动到的机制指标（计划长度、prompt 大小）和你真正在乎的目标指标（任务成功率、单次会话成本）分开。
 另外留一组护栏指标：就算目标指标变好，护栏一破也要停下实验。
 
@@ -275,5 +279,7 @@ uv run python sections/23-evaluation/src/demo.py  # live demo, needs a key
 - [BIG-bench](https://github.com/google/BIG-bench)：每个任务文件都带 canary 字符串，避免题目被爬进训练数据。
 - [Rubrics as Rewards](https://arxiv.org/abs/2507.17746)（Scale AI）：清单式的 rubric，写明要提到哪些事实、
   要有哪些推理步骤，以及哪些常见错误必须扣分。
+- [Agent QA](https://github.com/vostride/agent-qa)：在成功 run 后整理 memory，并把它注入后续的测试步骤；
+  这里拿它当面向产品的 feedback loop 例子。
 - [Claude Code](https://code.claude.com/docs)：workflow 约定里的 reviewer 与 judge 阶段。
   内容依据 tool schema 和文档记载的行为，不是 source backup。评估套件不在源码里，那几格都标成重建。

--- a/sections/23-evaluation/README.zh-TW.md
+++ b/sections/23-evaluation/README.zh-TW.md
@@ -182,6 +182,10 @@ benchmark 報告只拿來做一個決定：下一步要改什麼。
 Feature flag 負責分 AB 測試的組別，出事時也是斷路開關。
 每個 commit 都存一份完整展開後的 system prompt，改 prompt 就跟改程式碼一樣，要跑一次評估。
 
+面向產品的測試 agent 能把同一條 loop 落到實處。Agent QA 會在成功 run 後整理 product、suite 與 test observation，
+再把相關 memory 注入後續的測試步驟。這裡改善的是測試 harness 中一個邊界清楚的 feedback loop，
+不代表受測應用自己變好了。
+
 做 AB 測試時，要把你直接動到的機制指標（計畫長度、prompt 大小）和你真正在乎的目標指標（任務成功率、單次會話成本）分開。
 另外留一組護欄指標：就算目標指標變好，護欄一破也要停下實驗。
 
@@ -275,5 +279,7 @@ uv run python sections/23-evaluation/src/demo.py  # live demo, needs a key
 - [BIG-bench](https://github.com/google/BIG-bench)：每個任務檔案都帶 canary 字串，避免題目被爬進訓練資料。
 - [Rubrics as Rewards](https://arxiv.org/abs/2507.17746)（Scale AI）：清單式的 rubric，寫明要提到哪些事實、
   要有哪些推理步驟，以及哪些常見錯誤必須扣分。
+- [Agent QA](https://github.com/vostride/agent-qa)：在成功 run 後整理 memory，並把它注入後續的測試步驟；
+  這裡拿它當面向產品的 feedback loop 例子。
 - [Claude Code](https://code.claude.com/docs)：workflow 約定裡的 reviewer 與 judge 階段。
   內容依據 tool schema 和文件記載的行為，不是 source backup。評估套件不在原始碼裡，那幾格都標成重建。


### PR DESCRIPTION
## Summary

- add Agent QA as a product-facing feedback-loop example in section 23
- explain the bounded mechanism: successful runs curate observations, and later test steps receive relevant memory
- update English, Simplified Chinese, and Traditional Chinese together
- add the canonical project repository to the section's Sources

## Source trace

The project README describes execution memory built from product, suite, and test observations and reused in future runs. The implementation makes both halves of the loop inspectable:

- [`curator.ts`](https://github.com/vostride/agent-qa/blob/main/packages/core/src/memory/curator.ts) evaluates observations after a successful test run.
- [`local-provider.ts`](https://github.com/vostride/agent-qa/blob/main/packages/core/src/memory/local-provider.ts) retrieves matching observations and formats the memory context supplied to later steps.

The added paragraph deliberately scopes the claim to improvement of the test harness. It does not claim that the application under test improves itself.

Agent QA is currently source-available under FSL-1.1-ALv2, which converts to Apache-2.0 after two years. I am affiliated with Vostride and Agent QA.

## Validation

- `python3 sections/23-evaluation/src/test.py` passes all five evaluation checks.
- `git diff --check` passes.
- No added line exceeds 180 characters.
- No added line contains an em dash or en dash.
- The English, Simplified Chinese, and Traditional Chinese sections contain the same claim and source.
- No existing pull request mentions Agent QA.
