### PR TITLE
docs: dsh batch 1, sections 1-4 columns and section 4 hooks demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Each system is a worked example for the sections below.
 | **Claude Code**  | Frontier coding agent: edits files, runs commands, ships changes in real repos. | The full harness, start here       | 0 to 23 (all)        | v2.1.88         |
 | **Hermes Agent** | Long-term assistant: remembers you, learns workflows, runs anywhere. | Memory, skills, always-on channels | 7, 9, 14, 16, 19, 21, 22 | v2026.7.1 |
 | **mini-swe-agent** | Research baseline: one bash tool, about 150 lines. | The smallest complete loop, budgets, eval harness | 0 to 3, 8, 10, 11, 20 to 23 | v2.4.5 |
+| **deepseek-harness** | Plugin-first harness: every part, including the loop, is a replaceable plugin. | Plugin seams, durable session log, ACP | 1 to 8, 10 to 14, 16 to 21 | dsh-v0.1.0-rc.7 |
 | *(more soon)*        |                                                                                 |                                    |                      |                 |
 
 > More systems can be added later, including OpenClaw and aider.
@@ -187,6 +188,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full PR checklist.
 - [claude-code](https://github.com/yasasbanukaofficial/claude-code): Claude Code source backup used for mechanism names and implementation paths.
 - [hermes-agent](https://github.com/NousResearch/hermes-agent): Open-source agent harness (MIT) used as the second system under study.
 - [mini-swe-agent](https://github.com/swe-agent/mini-swe-agent): Minimal SWE agent (MIT) used as the third system under study.
+- [deepseek-harness](https://github.com/deepseek-ai/deepseek-harness): Plugin-based agent harness (MIT) used as the fourth system under study.
 - [learn-claude-code](https://github.com/shareAI-lab/learn-claude-code): Code-first harness reconstruction and section framing.
 - [Anthropic Agent Skills best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices): Progressive disclosure levels for skills.
 - [Anthropic prompt caching](https://platform.claude.com/docs/en/build-with-claude/prompt-caching): Cache breakpoints, TTLs, pricing, and token minimums.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -66,6 +66,7 @@
 | **Claude Code**    | 目前最强的 coding agent：改文件、跑命令，直接在真实 repo 里完成改动。 | 完整 harness 架构，从这里读起         | 0 到 23（全部）           | v2.1.88   |
 | **Hermes Agent**   | 长期助理：记得你、学会你的工作流程，还能跨平台跑任务。                | Memory、skills、always-on channels    | 7、9、14、16、19、21、22  | v2026.7.1 |
 | **mini-swe-agent** | 研究基准：一个 bash 工具，约 150 行。                                 | 最小的完整 loop、budget、eval harness | 0 到 3、8、10、11、20 到 23 | v2.4.5    |
+| **deepseek-harness** | Plugin 优先的 harness：每个部件（连 loop 在内）都是可替换的 plugin。 | Plugin 接缝、durable session log、ACP | 1 到 8、10 到 14、16 到 21 | dsh-v0.1.0-rc.7 |
 | *(更多陆续加入)*       |                                                                       |                                       |                           |           |
 
 > 之后可以再加入更多系统，例如 OpenClaw 和 aider。
@@ -187,6 +188,7 @@ uv run python sections/01-agent-loop/src/demo.py  # 实时
 - [claude-code](https://github.com/yasasbanukaofficial/claude-code): Claude Code 源码备份，用来对照机制名称与实现路径。
 - [hermes-agent](https://github.com/NousResearch/hermes-agent): 开源 agent harness（MIT），作为第二个研究系统。
 - [mini-swe-agent](https://github.com/swe-agent/mini-swe-agent): 极简 SWE agent（MIT），作为第三个研究系统。
+- [deepseek-harness](https://github.com/deepseek-ai/deepseek-harness): 基于 plugin 的 agent harness（MIT），作为第四个研究系统。
 - [learn-claude-code](https://github.com/shareAI-lab/learn-claude-code): 以代码为主的 harness 重建与章节架构。
 - [Anthropic Agent Skills 最佳实践](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices): skills 的渐进式披露层级。
 - [Anthropic prompt caching](https://platform.claude.com/docs/en/build-with-claude/prompt-caching): cache 断点、TTL、计价与 token 下限。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -66,6 +66,7 @@
 | **Claude Code**    | 目前最強的 coding agent：改檔案、跑指令，直接在真實 repo 裡完成改動。 | 完整 harness 架構，從這裡讀起         | 0 到 23（全部）           | v2.1.88   |
 | **Hermes Agent**   | 長期助理：記得你、學會你的工作流程，還能跨平台跑任務。                | Memory、skills、always-on channels    | 7、9、14、16、19、21、22  | v2026.7.1 |
 | **mini-swe-agent** | 研究基準：一個 bash 工具，約 150 行。                                 | 最小的完整 loop、budget、eval harness | 0 到 3、8、10、11、20 到 23 | v2.4.5    |
+| **deepseek-harness** | Plugin 優先的 harness：每個部件（連 loop 在內）都是可替換的 plugin。 | Plugin 接縫、durable session log、ACP | 1 到 8、10 到 14、16 到 21 | dsh-v0.1.0-rc.7 |
 | *(更多陸續加入)*       |                                                                       |                                       |                           |           |
 
 > 之後可以再加入更多系統，例如 OpenClaw 和 aider。
@@ -187,6 +188,7 @@ uv run python sections/01-agent-loop/src/demo.py  # 即時
 - [claude-code](https://github.com/yasasbanukaofficial/claude-code): Claude Code 原始碼備份，用來對照機制名稱與實作路徑。
 - [hermes-agent](https://github.com/NousResearch/hermes-agent): 開源 agent harness（MIT），作為第二個研究系統。
 - [mini-swe-agent](https://github.com/swe-agent/mini-swe-agent): 極簡 SWE agent（MIT），作為第三個研究系統。
+- [deepseek-harness](https://github.com/deepseek-ai/deepseek-harness): 以 plugin 為基礎的 agent harness（MIT），作為第四個研究系統。
 - [learn-claude-code](https://github.com/shareAI-lab/learn-claude-code): 以程式碼為主的 harness 重建與章節架構。
 - [Anthropic Agent Skills 最佳實踐](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices): skills 的漸進式揭露層級。
 - [Anthropic prompt caching](https://platform.claude.com/docs/en/build-with-claude/prompt-caching): cache 斷點、TTL、計價與 token 下限。

--- a/sections/01-agent-loop/README.md
+++ b/sections/01-agent-loop/README.md
@@ -86,15 +86,15 @@ This bare loop has no permission gate. Section 3 adds that gate before tool exec
 
 How each agent owns the loop and decides when to stop.
 
-| | Claude Code | mini-swe-agent |
-| --- | --- | --- |
-| **Pros** | Streams progress, gates side effects, and runs tools in parallel. | A tiny loop that is easy to read and audit. |
-| **Cons** | The loop sits inside a larger runtime. | No side-effect gate, no streaming, no parallel tools. |
-| **Why** | Keep the same core branch and add features around it. | A minimal loop is the point. The environment, not the model, detects when the task is done. |
-| **How: loop driver** | An async generator. Each tool plugs into dispatch through one contract. | A while loop. Each step asks the model for a command, then runs it. |
-| **How: stop signal** | `stop_reason: end_turn`. | An appended`role: "exit"` message. The environment detects the submit marker. A reply with no command is a format error. |
-| **How: parallel tools** | Yes. Tool calls in one model turn can run in parallel. | No. Actions run in order. |
-| **How: streaming** | Yes. Yields model tokens, tool calls, and tool results as they happen. | No. |
+| | Claude Code | mini-swe-agent | deepseek-harness |
+| --- | --- | --- | --- |
+| **Pros** | Streams progress, gates side effects, runs tools in parallel. | A tiny loop, easy to read and audit. | Swappable loop, interceptable phases, a log that replays. |
+| **Cons** | The loop sits inside a larger runtime. | No side-effect gate, no streaming, no parallel tools. | The most moving parts. Needs turn, step, and inbox vocabulary. |
+| **Why** | Keep one core branch, add features around it. | A minimal loop is the point. The environment, not the model, detects completion. | The loop is one plugin among peers. |
+| **How: loop driver** | An async generator. Tools plug in via one contract. | A while loop. Ask the model for a command, run it. | A swappable plugin over a durable event log. |
+| **How: stop signal** | `stop_reason: end_turn`. | The environment sees a submit marker and appends `role: "exit"`. | Nothing owed, no checkpoint objection, or `concludesTurn`. |
+| **How: parallel tools** | Yes. Calls in one model turn can run in parallel. | No. Actions run in order. | Yes. Exclusive calls form barriers; safe calls share a bounded pool. |
+| **How: streaming** | Yes. Yields model tokens, tool calls, and tool results as they happen. | No. | Yes. Stream chunks land in the session log as durable events. |
 
 ---
 
@@ -128,4 +128,6 @@ uv run python sections/01-agent-loop/src/demo.py  # live demo, needs a key
 
 - [Claude Code source](https://github.com/yasasbanukaofficial/claude-code): `QueryEngine.ts`, `query/`, `Tool.ts`.
 - [mini-swe-agent source](https://github.com/swe-agent/mini-swe-agent): `agents/default.py`, `exceptions.py`, `environments/local.py`.
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness) at `dsh-v0.1.0-rc.7`:
+  `docs/architecture.md`, `docs/agent-lifecycle.md`, `docs/subsystems/core.md`, `packages/core/agent-loop/src/agent.ts`, `packages/core/agent/src/types.ts`.
 - [learn-claude-code · s01 Agent Loop](https://github.com/shareAI-lab/learn-claude-code): section framing.

--- a/sections/01-agent-loop/README.zh-CN.md
+++ b/sections/01-agent-loop/README.zh-CN.md
@@ -83,15 +83,15 @@ for user_text in turns:                              # the outer loop: one itera
 
 各个 agent 如何拥有这个 loop，以及如何决定何时停止。
 
-| | Claude Code | mini-swe-agent |
-| --- | --- | --- |
-| **Pros** | 能流式传输进度、把关副作用，还能并行执行工具。 | loop 很小，容易阅读与审计。 |
-| **Cons** | loop 包在一个更大的 runtime 里，不能单独拿出来用。 | 无法把关副作用、流式传输进度，或并行执行工具。 |
-| **Why** | 核心分支保持不变，功能都加在外围。 | 小 loop 本身就是目的。检测任务是否完成的是环境，不是模型。 |
-| **How: loop driver** | 一个 async generator。每个工具通过同一份契约接进 dispatch。 | 一个 while loop。每一步跟模型要一条命令，再执行。 |
-| **How: stop signal** | `stop_reason: end_turn`。 | 附加一条 `role: "exit"` 消息。由环境检测提交标记。没带命令的响应只算格式错误。 |
-| **How: parallel tools** | 有。同一次模型轮次中的工具调用可以并行执行。 | 没有，action 依序执行。 |
-| **How: streaming** | 有。模型 token、工具调用与工具结果发生的当下就逐一送出。 | 没有。 |
+| | Claude Code | mini-swe-agent | deepseek-harness |
+| --- | --- | --- | --- |
+| **Pros** | 能流式传输进度、把关副作用，还能并行执行工具。 | loop 很小，容易阅读与审计。 | loop 可以整个换掉，每个阶段都能拦截，log 可以重放。 |
+| **Cons** | loop 包在一个更大的 runtime 里，不能单独拿出来用。 | 无法把关副作用、流式传输进度，或并行执行工具。 | 活动零件最多。得先懂 turn、step、inbox 这套词汇。 |
+| **Why** | 核心分支保持不变，功能都加在外围。 | 小 loop 本身就是目的。检测任务是否完成的是环境，不是模型。 | loop 就是众多 plugin 里的一个。 |
+| **How: loop driver** | 一个 async generator。每个工具通过同一份契约接进 dispatch。 | 一个 while loop。每一步跟模型要一条命令，再执行。 | 一个可换掉的 plugin，跑在一份 durable 事件 log 上。 |
+| **How: stop signal** | `stop_reason: end_turn`。 | 由环境检测提交标记，附加一条 `role: "exit"` 消息。 | 模型没欠任何事、检查点没反对，或 tool result 带 `concludesTurn`。 |
+| **How: parallel tools** | 有。同一次模型轮次中的工具调用可以并行执行。 | 没有，action 依序执行。 | 有。exclusive 调用形成 barrier，安全调用共用一个有上限的池。 |
+| **How: streaming** | 有。模型 token、工具调用与工具结果发生的当下就逐一送出。 | 没有。 | 有。流式 chunk 以 durable 事件写进 session log。 |
 
 ---
 
@@ -125,4 +125,6 @@ uv run python sections/01-agent-loop/src/demo.py  # live demo, needs a key
 
 - [Claude Code source](https://github.com/yasasbanukaofficial/claude-code)：`QueryEngine.ts`、`query/`、`Tool.ts`。
 - [mini-swe-agent source](https://github.com/swe-agent/mini-swe-agent)：`agents/default.py`、`exceptions.py`、`environments/local.py`。
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness)（`dsh-v0.1.0-rc.7`）：
+  `docs/architecture.md`、`docs/agent-lifecycle.md`、`docs/subsystems/core.md`、`packages/core/agent-loop/src/agent.ts`、`packages/core/agent/src/types.ts`。
 - [learn-claude-code · s01 Agent Loop](https://github.com/shareAI-lab/learn-claude-code)：章节框架。

--- a/sections/01-agent-loop/README.zh-TW.md
+++ b/sections/01-agent-loop/README.zh-TW.md
@@ -83,15 +83,15 @@ for user_text in turns:                              # the outer loop: one itera
 
 各個 agent 如何擁有這個 loop，以及如何決定何時停止。
 
-| | Claude Code | mini-swe-agent |
-| --- | --- | --- |
-| **Pros** | 能串流進度、把關副作用，還能平行執行工具。 | loop 很小，容易閱讀與稽核。 |
-| **Cons** | loop 包在一個更大的 runtime 裡，不能單獨拿出來用。 | 無法把關副作用、串流進度，或平行執行工具。 |
-| **Why** | 核心分支保持不變，功能都加在外圍。 | 小 loop 本身就是目的。偵測任務是否完成的是環境，不是模型。 |
-| **How: loop driver** | 一個 async generator。每個工具透過同一份契約接進 dispatch。 | 一個 while loop。每一步跟模型要一道指令，再執行。 |
-| **How: stop signal** | `stop_reason: end_turn`。 | 附加一則 `role: "exit"` 訊息。由環境偵測提交標記。沒帶指令的回應只算格式錯誤。 |
-| **How: parallel tools** | 有。同一次模型輪次中的工具呼叫可以平行執行。 | 沒有，action 依序執行。 |
-| **How: streaming** | 有。模型 token、工具呼叫與工具結果發生的當下就逐一送出。 | 沒有。 |
+| | Claude Code | mini-swe-agent | deepseek-harness |
+| --- | --- | --- | --- |
+| **Pros** | 能串流進度、把關副作用，還能平行執行工具。 | loop 很小，容易閱讀與稽核。 | loop 可以整個換掉，每個階段都能攔截，log 可以重放。 |
+| **Cons** | loop 包在一個更大的 runtime 裡，不能單獨拿出來用。 | 無法把關副作用、串流進度，或平行執行工具。 | 活動零件最多。得先懂 turn、step、inbox 這套詞彙。 |
+| **Why** | 核心分支保持不變，功能都加在外圍。 | 小 loop 本身就是目的。偵測任務是否完成的是環境，不是模型。 | loop 就是眾多 plugin 裡的一個。 |
+| **How: loop driver** | 一個 async generator。每個工具透過同一份契約接進 dispatch。 | 一個 while loop。每一步跟模型要一道指令，再執行。 | 一個可換掉的 plugin，跑在一份 durable 事件 log 上。 |
+| **How: stop signal** | `stop_reason: end_turn`。 | 由環境偵測提交標記，附加一則 `role: "exit"` 訊息。 | 模型沒欠任何事、檢查點沒反對，或 tool result 帶 `concludesTurn`。 |
+| **How: parallel tools** | 有。同一次模型輪次中的工具呼叫可以平行執行。 | 沒有，action 依序執行。 | 有。exclusive 呼叫形成 barrier，安全呼叫共用一個有上限的池。 |
+| **How: streaming** | 有。模型 token、工具呼叫與工具結果發生的當下就逐一送出。 | 沒有。 | 有。串流 chunk 以 durable 事件寫進 session log。 |
 
 ---
 
@@ -125,4 +125,6 @@ uv run python sections/01-agent-loop/src/demo.py  # live demo, needs a key
 
 - [Claude Code source](https://github.com/yasasbanukaofficial/claude-code)：`QueryEngine.ts`、`query/`、`Tool.ts`。
 - [mini-swe-agent source](https://github.com/swe-agent/mini-swe-agent)：`agents/default.py`、`exceptions.py`、`environments/local.py`。
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness)（`dsh-v0.1.0-rc.7`）：
+  `docs/architecture.md`、`docs/agent-lifecycle.md`、`docs/subsystems/core.md`、`packages/core/agent-loop/src/agent.ts`、`packages/core/agent/src/types.ts`。
 - [learn-claude-code · s01 Agent Loop](https://github.com/shareAI-lab/learn-claude-code)：章節框架。

--- a/sections/02-tool-runtime/README.md
+++ b/sections/02-tool-runtime/README.md
@@ -191,15 +191,15 @@ Appending leaves the prefix alone, and the schema turns into ordinary history on
 
 How each agent defines tools, routes calls, handles parallelism, and exposes a large catalog.
 
-| | Claude Code | mini-swe-agent |
-| --- | --- | --- |
-| **Pros** | Per-tool validation, permissions, safe parallelism, and lazy discovery. | One `bash` tool keeps the runtime small. No catalog to manage. |
-| **Cons** | Every tool has to carry a contract. | No per-tool validation or permissions. The confirm gate (section 3) sees only a command string. |
-| **Why** | Adding a capability should mean registering a tool, with the loop unchanged. | Assumes every action can be a shell command, so one tool is enough. |
-| **How: tool definition** | Schema, handler, and predicates. | One hardcoded `bash` schema is the whole catalog: one command field. Any other name is an error. |
-| **How: dispatch** | Name lookup with aliases, over a permission-filtered pool with MCP tools. | No registry. Every call is a shell command. |
-| **How: parallel calls** | Safe calls batch. Unsafe calls run alone. Safety flags default to off. | No. The legacy text mode requires exactly one action per response. |
-| **How: discovery** | Names ship first. Full schemas load on request, by exact name or keyword. | Not needed with one tool. |
+| | Claude Code | mini-swe-agent | deepseek-harness |
+| --- | --- | --- | --- |
+| **Pros** | Per-tool validation, permissions, parallelism, lazy discovery. | One `bash` tool, a small runtime, no catalog. | Per-agent tool sets; one audited pipeline per call. |
+| **Cons** | Every tool has to carry a contract. | No per-tool validation or permissions. The gate sees one command string. | Even simple tools must declare an output contract. |
+| **Why** | One new tool per capability; the loop stays put. | Every action is a shell command, so one tool is enough. | One per-scope resolver feeds lookup, dispatch, display. |
+| **How: tool definition** | Schema, handler, and predicates. | One `bash` schema, one command field; other names error. | Schema, typed output contract, body, pure presenters. |
+| **How: dispatch** | Alias lookup over a permission-filtered pool with MCP. | No registry. Every call is a shell command. | Scoped lookup, then a five-stage guarded pipeline. |
+| **How: parallel calls** | Safe calls batch; unsafe run alone; flags default off. | No. Text mode takes one action per response. | Classified per call, fail closed to exclusive. |
+| **How: discovery** | Names first; full schemas load on request by name or keyword. | Not needed with one tool. | No lazy loading. Restrictions and presets shape each scope. |
 
 ---
 
@@ -238,6 +238,8 @@ uv run python sections/02-tool-runtime/src/demo.py  # live demo, needs a key
 - [Claude Code source](https://github.com/yasasbanukaofficial/claude-code):
   `Tool.ts`, `tools.ts`, `services/tools/toolOrchestration.ts`, `services/tools/toolExecution.ts`, `tools/ToolSearchTool/ToolSearchTool.ts`.
 - [mini-swe-agent source](https://github.com/swe-agent/mini-swe-agent): `models/utils/actions_toolcall.py`, `models/utils/actions_text.py`, `environments/__init__.py`.
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness) at `dsh-v0.1.0-rc.7`:
+  `docs/subsystems/tools.md`, `docs/tool-execution-pipeline.md`, `packages/core/tools/src/index.ts`, `packages/core/tools/src/schema.ts`.
 - [learn-claude-code · s02_tool_use](https://github.com/shareAI-lab/learn-claude-code): section framing.
 - [ai-agent-book](https://github.com/bojieli/ai-agent-book): `book/chapter4.md`, `book/chapter5.md` (《深入理解 AI Agent》, 李博杰; the Chinese original is canonical):
   the five-tool grouping, granularity, description craft, parameter fidelity, perception interface rules, proactive discovery, cache-safe loading, streaming tool start

--- a/sections/02-tool-runtime/README.zh-CN.md
+++ b/sections/02-tool-runtime/README.zh-CN.md
@@ -187,15 +187,15 @@ MCP-Zero 让 agent 说出自己缺哪一种能力，系统先找到对应的 ser
 
 各个 agent 如何定义工具、路由调用、处理并行，以及公开一份庞大目录。
 
-| | Claude Code | mini-swe-agent |
-| --- | --- | --- |
-| **Pros** | 每个工具各自带验证、权限、安全并行和延迟探索。 | 单一 `bash` 工具小得多，也没有目录要维护。 |
-| **Cons** | 每个工具都得背一份契约。 | 验证和权限做不到 per-tool。跑命令前的确认（第 3 章）看到的只有一条命令字符串。 |
-| **Why** | 新增一项能力，应该就只是注册一个工具，loop 维持不变。 | 假设每个行动都能写成一条 shell 命令，所以一个工具就够了。 |
-| **How: tool definition** | schema、handler 与判定式。 | 一份写死的 `bash` schema 就是整份目录，只有一个命令字段，别的名称一律报错。 |
-| **How: dispatch** | 依名称查表，含别名。工具池依权限筛选，并合并 MCP 工具。 | 没有 registry，每次调用都是一条 shell 命令。 |
-| **How: parallel calls** | 安全调用批量执行，不安全的单独执行。安全标记默认关闭。 | 没有。旧版文本模式每次响应只允许一个 action。 |
-| **How: discovery** | 先给名称。完整 schema 依精确名称或关键字按需加载。 | 只有一个工具，不需要。 |
+| | Claude Code | mini-swe-agent | deepseek-harness |
+| --- | --- | --- | --- |
+| **Pros** | 每个工具各自带验证、权限、安全并行和延迟探索。 | 单一 `bash` 工具小得多，也没有目录要维护。 | 每个 agent 有自己的工具集，每次调用都走同一条可审计的 pipeline。 |
+| **Cons** | 每个工具都得背一份契约。 | 验证和权限做不到 per-tool。gate 看到的只有一条命令字符串。 | 再简单的工具也得声明 output 契约。 |
+| **Why** | 新增一项能力，应该就只是注册一个工具，loop 维持不变。 | 假设每个行动都能写成一条 shell 命令，所以一个工具就够了。 | 同一个 scope 的可见性解析，同时喂给查表、dispatch 和呈现。 |
+| **How: tool definition** | schema、handler 与判定式。 | 一份 `bash` schema，只有一个命令字段，别的名称一律报错。 | schema、类型化的 output 契约、执行本体，加上纯函数的呈现器。 |
+| **How: dispatch** | 依名称查表，含别名。工具池依权限筛选，并合并 MCP 工具。 | 没有 registry，每次调用都是一条 shell 命令。 | 先做 scope 感知的查表，再走五阶段的守卫 pipeline。 |
+| **How: parallel calls** | 安全调用批量执行，不安全的单独执行。安全标记默认关闭。 | 没有。文本模式每次响应只允许一个 action。 | 每次调用都先分类，不确定就 fail closed 当 exclusive。 |
+| **How: discovery** | 先给名称。完整 schema 依精确名称或关键字按需加载。 | 只有一个工具，不需要。 | 没有延迟加载。限制和 preset 决定每个 scope 看到什么。 |
 
 ---
 
@@ -234,6 +234,8 @@ uv run python sections/02-tool-runtime/src/demo.py  # live demo, needs a key
 - [Claude Code source](https://github.com/yasasbanukaofficial/claude-code)：
   `Tool.ts`、`tools.ts`、`services/tools/toolOrchestration.ts`、`services/tools/toolExecution.ts`、`tools/ToolSearchTool/ToolSearchTool.ts`。
 - [mini-swe-agent source](https://github.com/swe-agent/mini-swe-agent)：`models/utils/actions_toolcall.py`、`models/utils/actions_text.py`、`environments/__init__.py`。
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness)（`dsh-v0.1.0-rc.7`）：
+  `docs/subsystems/tools.md`、`docs/tool-execution-pipeline.md`、`packages/core/tools/src/index.ts`、`packages/core/tools/src/schema.ts`。
 - [learn-claude-code · s02_tool_use](https://github.com/shareAI-lab/learn-claude-code)：章节框架。
 - [ai-agent-book](https://github.com/bojieli/ai-agent-book)：`book/chapter4.md`、`book/chapter5.md`（《深入理解 AI Agent》，李博杰；以中文原版为准）：
   五类工具的分法、粒度、description 的写法、参数保真、感知工具的接口规则、主动发现、对 cache 友好的加载、

--- a/sections/02-tool-runtime/README.zh-TW.md
+++ b/sections/02-tool-runtime/README.zh-TW.md
@@ -187,15 +187,15 @@ MCP-Zero 讓 agent 說出自己缺哪一種能力，系統先找到對應的 ser
 
 各個 agent 如何定義工具、路由呼叫、處理平行，以及公開一份龐大目錄。
 
-| | Claude Code | mini-swe-agent |
-| --- | --- | --- |
-| **Pros** | 每個工具各自帶驗證、權限、安全平行和延遲探索。 | 單一 `bash` 工具小得多，也沒有目錄要維護。 |
-| **Cons** | 每個工具都得背一份契約。 | 驗證和權限做不到 per-tool。跑指令前的確認（第 3 章）看到的只有一條指令字串。 |
-| **Why** | 新增一項能力，應該就只是註冊一個工具，loop 維持不變。 | 假設每個行動都能寫成一條 shell 指令，所以一個工具就夠了。 |
-| **How: tool definition** | schema、handler 與判定式。 | 一份寫死的 `bash` schema 就是整份型錄，只有一個指令欄位，別的名稱一律報錯。 |
-| **How: dispatch** | 依名稱查表，含別名。工具池依權限篩選，並合併 MCP 工具。 | 沒有 registry，每次呼叫都是一條 shell 指令。 |
-| **How: parallel calls** | 安全呼叫批次執行，不安全的單獨執行。安全標記預設關閉。 | 沒有。舊版文字模式每次回應只允許一個 action。 |
-| **How: discovery** | 先給名稱。完整 schema 依精確名稱或關鍵字隨需載入。 | 只有一個工具，不需要。 |
+| | Claude Code | mini-swe-agent | deepseek-harness |
+| --- | --- | --- | --- |
+| **Pros** | 每個工具各自帶驗證、權限、安全平行和延遲探索。 | 單一 `bash` 工具小得多，也沒有目錄要維護。 | 每個 agent 有自己的工具集，每次呼叫都走同一條可稽核的 pipeline。 |
+| **Cons** | 每個工具都得背一份契約。 | 驗證和權限做不到 per-tool。gate 看到的只有一條指令字串。 | 再簡單的工具也得宣告 output 契約。 |
+| **Why** | 新增一項能力，應該就只是註冊一個工具，loop 維持不變。 | 假設每個行動都能寫成一條 shell 指令，所以一個工具就夠了。 | 同一個 scope 的可見性解析，同時餵給查表、dispatch 和呈現。 |
+| **How: tool definition** | schema、handler 與判定式。 | 一份 `bash` schema，只有一個指令欄位，別的名稱一律報錯。 | schema、型別化的 output 契約、執行本體，加上純函式的呈現器。 |
+| **How: dispatch** | 依名稱查表，含別名。工具池依權限篩選，並合併 MCP 工具。 | 沒有 registry，每次呼叫都是一條 shell 指令。 | 先做 scope 感知的查表，再走五階段的守衛 pipeline。 |
+| **How: parallel calls** | 安全呼叫批次執行，不安全的單獨執行。安全標記預設關閉。 | 沒有。文字模式每次回應只允許一個 action。 | 每次呼叫都先分類，不確定就 fail closed 當 exclusive。 |
+| **How: discovery** | 先給名稱。完整 schema 依精確名稱或關鍵字隨需載入。 | 只有一個工具，不需要。 | 沒有延遲載入。限制和 preset 決定每個 scope 看到什麼。 |
 
 ---
 
@@ -234,6 +234,8 @@ uv run python sections/02-tool-runtime/src/demo.py  # live demo, needs a key
 - [Claude Code source](https://github.com/yasasbanukaofficial/claude-code)：
   `Tool.ts`、`tools.ts`、`services/tools/toolOrchestration.ts`、`services/tools/toolExecution.ts`、`tools/ToolSearchTool/ToolSearchTool.ts`。
 - [mini-swe-agent source](https://github.com/swe-agent/mini-swe-agent)：`models/utils/actions_toolcall.py`、`models/utils/actions_text.py`、`environments/__init__.py`。
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness)（`dsh-v0.1.0-rc.7`）：
+  `docs/subsystems/tools.md`、`docs/tool-execution-pipeline.md`、`packages/core/tools/src/index.ts`、`packages/core/tools/src/schema.ts`。
 - [learn-claude-code · s02_tool_use](https://github.com/shareAI-lab/learn-claude-code)：章節框架。
 - [ai-agent-book](https://github.com/bojieli/ai-agent-book)：`book/chapter4.md`、`book/chapter5.md`（《深入理解 AI Agent》，李博杰；以中文原版為準）：
   五類工具的分法、粒度、description 的寫法、參數保真、感知工具的介面規則、主動探索、對 cache 友善的載入、

--- a/sections/03-permission-sandbox/README.md
+++ b/sections/03-permission-sandbox/README.md
@@ -139,15 +139,15 @@ Why this is still safe: the only thing running early is the check. The tool itse
 
 How each agent gates side effects, changes modes, and remembers decisions.
 
-| | Claude Code | mini-swe-agent |
-| --- | --- | --- |
-| **Pros** | Modes, ordered rules, and sandboxing give precise control. | Auditable in minutes. A rejection feeds back to the model, so the loop keeps running. |
-| **Cons** | Many states to reason about. Each bypass or preapproval path must stay visible and narrow. | Treats every command the same and remembers nothing. |
-| **Why** | Asking on every call breeds approval fatigue, so approvals can be remembered. | One prompt plus a regex list is enough when the environment limits the damage. |
-| **How: gate point** | Before each tool runs. Web, MCP, and remote runs have their own gates. | Before a step's commands execute. Enter approves, a typed comment rejects. |
-| **How: permission modes** | Default, edit-approved, plan, deny, and bypass, plus internal modes. | `human`, `confirm`, and `yolo`. Slash commands switch them at runtime. |
-| **How: sandbox** | Bash can run inside a sandbox. | The environment class is the sandbox, picked per run: host, throwaway container, or wrappers on shared hosts. |
-| **How: rule persistence** | Rules merge by priority from many sources, saved to the session or settings. | Whitelist regexes in config only. Matches skip the confirm prompt. |
+| | Claude Code | mini-swe-agent | deepseek-harness |
+| --- | --- | --- | --- |
+| **Pros** | Modes, ordered rules, and sandboxing give fine control. | Auditable in minutes. Rejections feed back to the model. | Denials never loosen; sandboxing fails closed. |
+| **Cons** | Many states. Bypass and preapproval paths must stay narrow. | Treats every command the same, remembers nothing. | Policy spans guards, approval, sandbox, presets. |
+| **Why** | Asking every time breeds fatigue, so approvals persist. | A prompt plus regexes; the environment limits the damage. | Each concern is its own fail-closed service. |
+| **How: gate point** | Before each tool; web, MCP, remote gate separately. | Before a step runs. Enter approves, a comment rejects. | A pre-execute event, then deny-only guards. |
+| **How: permission modes** | Default, edit-approved, plan, deny, bypass. | `human`, `confirm`, `yolo`, switched at runtime. | Sandbox mode plus ask or never, bundled as presets. |
+| **How: sandbox** | Bash can run inside a sandbox. | The environment class is the sandbox: host, container, wrappers. | Providers wrap each argv; denials come back classified. |
+| **How: rule persistence** | Rules merge by priority into session or settings. | Config regexes; matches skip the prompt. | Knob changes are log events; replay folds policy. |
 
 ---
 
@@ -185,6 +185,9 @@ uv run python sections/03-permission-sandbox/src/demo.py  # live demo, needs a k
   `QueryEngine.ts`, `hooks/useCanUseTool.tsx`, `types/permissions.ts`, `utils/permissions/PermissionUpdate.ts`.
 - [Claude Code sandbox and web gates](https://github.com/yasasbanukaofficial/claude-code): `tools/BashTool/shouldUseSandbox.ts`, `tools/WebFetchTool/preapproved.ts`.
 - [mini-swe-agent source](https://github.com/swe-agent/mini-swe-agent): `agents/interactive.py`, `environments/docker.py`, `environments/extra/bubblewrap.py`.
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness) at `dsh-v0.1.0-rc.7`:
+  `docs/subsystems/tools.md`, `docs/subsystems/approval.md`, `docs/subsystems/sandbox.md`, `docs/subsystems/permission-presets.md`,
+  `packages/sandbox/sandbox-local/README.md`, `packages/shell/bash-sandbox/README.md`.
 - [ai-agent-book · chapter 5](https://github.com/bojieli/ai-agent-book/blob/main/book/chapter5.md) (《深入理解 AI Agent》, 李博杰; the Chinese original is canonical):
   the memory amplification axis, sandbox egress, mount and quota policy, semantic command parsing, speculative permission checks,
   and constraining the path instead of only the result. Single source for those designs.

--- a/sections/03-permission-sandbox/README.zh-CN.md
+++ b/sections/03-permission-sandbox/README.zh-CN.md
@@ -136,15 +136,15 @@ def _dispatch(block, registry, mode, allow_rules, approver):   # src/loop.py
 
 各个 agent 如何管制副作用、切换 mode，以及记住决策。
 
-| | Claude Code | mini-swe-agent |
-| --- | --- | --- |
-| **Pros** | mode、有序规则与沙箱化提供精确的控制。 | 几分钟就能审计完。拒绝会落回对话，模型读得到原因，loop 继续跑。 |
-| **Cons** | 要推敲的状态很多。每条 bypass 或预先核准的路径都必须保持可见且范围狭窄。 | 对每条命令一视同仁，而且什么都不记。 |
-| **Why** | 每次调用都问会造成核准疲劳，所以系统会把核准记下来。 | 损害交给环境去限制，一个确认提示加一份 regex 清单就够了。 |
-| **How: gate point** | 每个工具执行前。Web、MCP 与远程执行各有核准路径。 | 每一步的命令执行前。按 Enter 就核准，留言就是拒绝。 |
-| **How: permission modes** | Default、edit-approved、plan、deny 与 bypass，另有内部 mode。 | `human`、`confirm` 与 `yolo`，运行期可用斜杠命令切换。 |
-| **How: sandbox** | Bash 可以在沙箱内执行。 | 环境 class 就是沙箱，每次运行挑：主机本身、用完即丢的容器，或在共用主机上包住执行。 |
-| **How: rule persistence** | 规则依优先级从多个来源合并，可存到 session 或 settings。 | 白名单 regex 只写在 config，匹配的命令跳过确认。 |
+| | Claude Code | mini-swe-agent | deepseek-harness |
+| --- | --- | --- | --- |
+| **Pros** | mode、有序规则与沙箱化提供精确的控制。 | 几分钟就能审计完。拒绝会落回对话，模型读得到原因。 | 拒绝只会收紧，沙箱判定 fail closed。 |
+| **Cons** | 要推敲的状态很多。bypass 和预先核准的路径都必须保持狭窄。 | 对每条命令一视同仁，而且什么都不记。 | 策略分散在 guard、approval、沙箱和 preset 之间。 |
+| **Why** | 每次调用都问会造成核准疲劳，所以系统会把核准记下来。 | 损害交给环境去限制，一个确认提示加一份 regex 清单就够了。 | 每个关注点都是自己独立的 fail-closed 服务。 |
+| **How: gate point** | 每个工具执行前。Web、MCP 与远程执行各有核准路径。 | 每一步的命令执行前。按 Enter 就核准，留言就是拒绝。 | 先跑 pre-execute 事件，再跑只会拒绝的 guard。 |
+| **How: permission modes** | Default、edit-approved、plan、deny 与 bypass。 | `human`、`confirm` 与 `yolo`，运行期可以切换。 | 沙箱 mode 加上 ask 或 never，打包成 preset。 |
+| **How: sandbox** | Bash 可以在沙箱内执行。 | 环境 class 就是沙箱：主机本身、容器，或包住执行。 | provider 逐次把 argv 包起来，拒绝会分类好读回来。 |
+| **How: rule persistence** | 规则依优先级合并，可存到 session 或 settings。 | 白名单 regex 只写在 config，匹配的命令跳过确认。 | 旋钮变动是 log 事件，重放折叠出策略。 |
 
 ---
 
@@ -181,6 +181,9 @@ uv run python sections/03-permission-sandbox/src/demo.py  # live demo, needs a k
 - [Claude Code 源码](https://github.com/yasasbanukaofficial/claude-code)：`QueryEngine.ts`、`hooks/useCanUseTool.tsx`、`types/permissions.ts`、`utils/permissions/PermissionUpdate.ts`。
 - [Claude Code 沙箱与 web gate](https://github.com/yasasbanukaofficial/claude-code)：`tools/BashTool/shouldUseSandbox.ts`、`tools/WebFetchTool/preapproved.ts`。
 - [mini-swe-agent source](https://github.com/swe-agent/mini-swe-agent)：`agents/interactive.py`、`environments/docker.py`、`environments/extra/bubblewrap.py`。
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness)（`dsh-v0.1.0-rc.7`）：
+  `docs/subsystems/tools.md`、`docs/subsystems/approval.md`、`docs/subsystems/sandbox.md`、`docs/subsystems/permission-presets.md`、
+  `packages/sandbox/sandbox-local/README.md`、`packages/shell/bash-sandbox/README.md`。
 - [ai-agent-book · 第 5 章](https://github.com/bojieli/ai-agent-book/blob/main/book/chapter5.md)（《深入理解 AI Agent》，李博杰，以中文原版为准）：
   memory 把攻击放大的那个维度、沙箱的 egress 与 mount、quota 策略、语义式的命令解析、推测式 permission 检查，
   以及管路径而不是只管结果。这几项设计只有这一个来源。

--- a/sections/03-permission-sandbox/README.zh-TW.md
+++ b/sections/03-permission-sandbox/README.zh-TW.md
@@ -136,15 +136,15 @@ def _dispatch(block, registry, mode, allow_rules, approver):   # src/loop.py
 
 各個 agent 如何管制副作用、切換 mode，以及記住決策。
 
-| | Claude Code | mini-swe-agent |
-| --- | --- | --- |
-| **Pros** | mode、有序規則與沙箱化提供精確的控制。 | 幾分鐘就能稽核完。拒絕會落回對話，模型讀得到原因，loop 繼續跑。 |
-| **Cons** | 要推敲的狀態很多。每條 bypass 或預先核准的路徑都必須保持可見且範圍狹窄。 | 對每條指令一視同仁，而且什麼都不記。 |
-| **Why** | 每次呼叫都問會造成核准疲勞，所以系統會把核准記下來。 | 損害交給環境去限制，一個確認提示加一份 regex 清單就夠了。 |
-| **How: gate point** | 每個工具執行前。Web、MCP 與遠端執行各有核准路徑。 | 每一步的指令執行前。按 Enter 就核准，留言就是拒絕。 |
-| **How: permission modes** | Default、edit-approved、plan、deny 與 bypass，另有內部 mode。 | `human`、`confirm` 與 `yolo`，執行期可用斜線指令切換。 |
-| **How: sandbox** | Bash 可以在沙箱內執行。 | 環境 class 就是沙箱，每次執行挑：主機本身、用完即丟的容器，或在共用主機上包住執行。 |
-| **How: rule persistence** | 規則依優先序從多個來源合併，可存到 session 或 settings。 | 白名單 regex 只寫在 config，符合的指令跳過確認。 |
+| | Claude Code | mini-swe-agent | deepseek-harness |
+| --- | --- | --- | --- |
+| **Pros** | mode、有序規則與沙箱化提供精確的控制。 | 幾分鐘就能稽核完。拒絕會落回對話，模型讀得到原因。 | 拒絕只會收緊，沙箱判定 fail closed。 |
+| **Cons** | 要推敲的狀態很多。bypass 和預先核准的路徑都必須保持狹窄。 | 對每條指令一視同仁，而且什麼都不記。 | 政策分散在 guard、approval、沙箱和 preset 之間。 |
+| **Why** | 每次呼叫都問會造成核准疲勞，所以系統會把核准記下來。 | 損害交給環境去限制，一個確認提示加一份 regex 清單就夠了。 | 每個關注點都是自己獨立的 fail-closed 服務。 |
+| **How: gate point** | 每個工具執行前。Web、MCP 與遠端執行各有核准路徑。 | 每一步的指令執行前。按 Enter 就核准，留言就是拒絕。 | 先跑 pre-execute 事件，再跑只會拒絕的 guard。 |
+| **How: permission modes** | Default、edit-approved、plan、deny 與 bypass。 | `human`、`confirm` 與 `yolo`，執行期可以切換。 | 沙箱 mode 加上 ask 或 never，打包成 preset。 |
+| **How: sandbox** | Bash 可以在沙箱內執行。 | 環境 class 就是沙箱：主機本身、容器，或包住執行。 | provider 逐次把 argv 包起來，拒絕會分類好讀回來。 |
+| **How: rule persistence** | 規則依優先序合併，可存到 session 或 settings。 | 白名單 regex 只寫在 config，符合的指令跳過確認。 | 旋鈕變動是 log 事件，重放折疊出政策。 |
 
 ---
 
@@ -181,6 +181,9 @@ uv run python sections/03-permission-sandbox/src/demo.py  # live demo, needs a k
 - [Claude Code 原始碼](https://github.com/yasasbanukaofficial/claude-code)：`QueryEngine.ts`、`hooks/useCanUseTool.tsx`、`types/permissions.ts`、`utils/permissions/PermissionUpdate.ts`。
 - [Claude Code 沙箱與 web gate](https://github.com/yasasbanukaofficial/claude-code)：`tools/BashTool/shouldUseSandbox.ts`、`tools/WebFetchTool/preapproved.ts`。
 - [mini-swe-agent source](https://github.com/swe-agent/mini-swe-agent)：`agents/interactive.py`、`environments/docker.py`、`environments/extra/bubblewrap.py`。
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness)（`dsh-v0.1.0-rc.7`）：
+  `docs/subsystems/tools.md`、`docs/subsystems/approval.md`、`docs/subsystems/sandbox.md`、`docs/subsystems/permission-presets.md`、
+  `packages/sandbox/sandbox-local/README.md`、`packages/shell/bash-sandbox/README.md`。
 - [ai-agent-book · 第 5 章](https://github.com/bojieli/ai-agent-book/blob/main/book/chapter5.md)（《深入理解 AI Agent》，李博杰，以中文原版為準）：
   memory 把攻擊放大的那個維度、沙箱的 egress 與 mount、quota 政策、語意式的指令解析、推測式 permission 檢查，
   以及管路徑而不是只管結果。這幾項設計只有這一個來源。

--- a/sections/04-hooks/README.md
+++ b/sections/04-hooks/README.md
@@ -66,6 +66,17 @@ The demo uses a `PreToolUse` hook to block `rm -rf` even under `bypassPermission
 
 This section covers lifecycle hooks. React render hooks in a `hooks/` folder are unrelated UI code that share the same word.
 
+### Contrast: waterfall hooks
+
+deepseek-harness uses a different hook surface. A hook is an in-process listener on a typed event, not a shell subprocess.
+
+- Listeners form a chain. Each receives the payload and a `next()` callback.
+- A listener that returns without calling `next()` owns the decision.
+- A listener that calls `next()` delegates downstream, and may wrap what comes back.
+- External shell hooks are bridged on. Their outputs fold most-restrictively: deny over ask over allow.
+
+[`src/waterfall.py`](src/waterfall.py) is a strip-down of that surface. It is a contrast demo, not wired into `_dispatch`, so later sections carry the same loop forward.
+
 ### Further reading
 
 None of this is in `src/`. It comes from ai-agent-book, and is not confirmed of the systems in the table.
@@ -87,14 +98,14 @@ The pattern has one limit. A blocked write never runs, so the hook produces no d
 
 How each agent exposes interception points around the loop.
 
-| | Claude Code |
-| --- | --- |
-| **Pros** | Users extend behavior without editing the loop. Good for logging, validation, notifications, and policy checks. |
-| **Cons** | The fixed event list is also the limit. A hook can only intercept where the system exposes an event. |
-| **Why** | Keeps the loop small. New behavior attaches to fixed events instead of editing or forking the loop. |
-| **How: hook events** | A fixed list of 27 lifecycle events, covering tool, prompt, session, stop, subagent, compact, and setup. |
-| **How: fire point** | Loaded from settings and frozen at startup. `PreToolUse` fires before the permission gate. |
-| **How: can block or modify?** | Yes. Deny, ask, update input, add context, or stop. Hook output is reconciled with rule-based permissions. |
+| | Claude Code | deepseek-harness |
+| --- | --- | --- |
+| **Pros** | Users extend behavior without editing the loop: logging, validation, notifications, policy checks. | Hooks are typed plugins; existing shell hooks still run. |
+| **Cons** | The fixed event list is the limit. A hook only intercepts where an event exists. | Two surfaces to learn; the bridge covers a subset and cannot rewrite input. |
+| **Why** | Keeps the loop small. New behavior attaches to fixed events, not forks. | The extension surface is the event system the harness itself runs on. |
+| **How: hook events** | 27 lifecycle events across tool, prompt, session, stop, subagent, compact, setup. | Waterfall and serial events per phase; bridges map shell dialects on. |
+| **How: fire point** | Loaded from settings and frozen at startup. `PreToolUse` fires before the permission gate. | In the pre-execute waterfall, before deny-only guards. |
+| **How: can block or modify?** | Yes. Deny, ask, update input, add context, or stop; reconciled with rules. | Yes, via typed decisions; shell hooks fold deny > ask > allow. |
 
 ---
 
@@ -115,7 +126,8 @@ How each agent exposes interception points around the loop.
 
 - [`hooks.py`](src/hooks.py): the `Hooks` object with `fire_pre` and `fire_post`.
 - [`loop.py`](src/loop.py): `_dispatch` fires `PreToolUse` before the gate and `PostToolUse` after a run.
-- [`test.py`](src/test.py): a pre-hook blocks `rm -rf` even under `bypassPermissions`.
+- [`waterfall.py`](src/waterfall.py): the deepseek-harness contrast: typed waterfall events with `next()` delegation, plus the deny over ask over allow fold.
+- [`test.py`](src/test.py): a pre-hook blocks `rm -rf` even under `bypassPermissions`; waterfall checks cover owning, delegating, and the fold.
 
 ```bash
 python sections/04-hooks/src/test.py         # offline checks, no key
@@ -128,6 +140,9 @@ uv run python sections/04-hooks/src/demo.py  # live demo, needs a key
 
 - [Claude Code source](https://github.com/yasasbanukaofficial/claude-code):
   `types/hooks.ts`, `entrypoints/sdk/coreTypes.ts`, `services/tools/toolHooks.ts`, `query/stopHooks.ts`, `services/tools/toolExecution.ts`, `setup.ts`.
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness) at `dsh-v0.1.0-rc.7`:
+  `packages/hooks/README.md`, `packages/hooks/hooks-claude-code/README.md`, `packages/hooks/hook-protocol/README.md`,
+  `docs/cordis-primer.md`, `docs/subsystems/core.md`.
 - [learn-claude-code · s04_hooks](https://github.com/shareAI-lab/learn-claude-code): section framing.
 - [ai-agent-book · chapter 5](https://github.com/bojieli/ai-agent-book/blob/main/book/chapter5.md) (《深入理解 AI Agent》, 李博杰; the Chinese original is canonical):
   lint on write: the tool layer runs a linter after a write and adds the diagnostics to the tool result.

--- a/sections/04-hooks/README.md
+++ b/sections/04-hooks/README.md
@@ -68,14 +68,22 @@ This section covers lifecycle hooks. React render hooks in a `hooks/` folder are
 
 ### Contrast: waterfall hooks
 
-deepseek-harness uses a different hook surface. A hook is an in-process listener on a typed event, not a shell subprocess.
+In Claude Code, a hook is an external command. The harness runs it as a subprocess and reads its exit code and output.
+In deepseek-harness, a hook is a plain function that runs inside the harness process.
+It registers on a named event, such as the one that fires before a tool call.
+And instead of an exit code, it returns a typed decision: a plain value like deny, ask, or allow.
 
-- Listeners form a chain. Each receives the payload and a `next()` callback.
-- A listener that returns without calling `next()` owns the decision.
-- A listener that calls `next()` delegates downstream, and may wrap what comes back.
-- External shell hooks are bridged on. Their outputs fold most-restrictively: deny over ask over allow.
+Several hooks can register on one event. They form a chain, and the event fires only the first one.
+Each hook receives the event data plus a `next()` callback, then picks one of two moves:
 
-[`src/waterfall.py`](src/waterfall.py) is a strip-down of that surface. It is a contrast demo, not wired into `_dispatch`, so later sections carry the same loop forward.
+- Return a decision without calling `next()`. The chain stops here. Hooks further down never run.
+- Call `next()`. The rest of the chain decides, and this hook returns that result, as is or adjusted.
+
+dsh calls this dispatch style a waterfall. Existing Claude Code shell hooks still work: a bridge runs them
+and turns their output into the same typed decisions. When several shell hooks answer at once,
+the bridge keeps the strictest answer: deny beats ask, ask beats allow.
+
+[`src/waterfall.py`](src/waterfall.py) is a strip-down of this. It is a contrast demo, not wired into `_dispatch`, so later sections carry the same loop forward.
 
 ### Further reading
 
@@ -100,10 +108,10 @@ How each agent exposes interception points around the loop.
 
 | | Claude Code | deepseek-harness |
 | --- | --- | --- |
-| **Pros** | Users extend behavior without editing the loop: logging, validation, notifications, policy checks. | Hooks are typed plugins; existing shell hooks still run. |
-| **Cons** | The fixed event list is the limit. A hook only intercepts where an event exists. | Two surfaces to learn; the bridge covers a subset and cannot rewrite input. |
+| **Pros** | Users extend behavior without editing the loop: logging, validation, notifications, policy checks. | Hooks are in-process plugins; existing shell hooks still run. |
+| **Cons** | The fixed event list is the limit. A hook only intercepts where an event exists. | Two hook styles to learn; the bridge covers a subset and cannot rewrite input. |
 | **Why** | Keeps the loop small. New behavior attaches to fixed events, not forks. | The extension surface is the event system the harness itself runs on. |
-| **How: hook events** | 27 lifecycle events across tool, prompt, session, stop, subagent, compact, setup. | Waterfall and serial events per phase; bridges map shell dialects on. |
+| **How: hook events** | 27 lifecycle events across tool, prompt, session, stop, subagent, compact, setup. | Waterfall and serial events per phase; bridges adapt shell hooks on. |
 | **How: fire point** | Loaded from settings and frozen at startup. `PreToolUse` fires before the permission gate. | In the pre-execute waterfall, before deny-only guards. |
 | **How: can block or modify?** | Yes. Deny, ask, update input, add context, or stop; reconciled with rules. | Yes, via typed decisions; shell hooks fold deny > ask > allow. |
 
@@ -126,8 +134,8 @@ How each agent exposes interception points around the loop.
 
 - [`hooks.py`](src/hooks.py): the `Hooks` object with `fire_pre` and `fire_post`.
 - [`loop.py`](src/loop.py): `_dispatch` fires `PreToolUse` before the gate and `PostToolUse` after a run.
-- [`waterfall.py`](src/waterfall.py): the deepseek-harness contrast: typed waterfall events with `next()` delegation, plus the deny over ask over allow fold.
-- [`test.py`](src/test.py): a pre-hook blocks `rm -rf` even under `bypassPermissions`; waterfall checks cover owning, delegating, and the fold.
+- [`waterfall.py`](src/waterfall.py): the deepseek-harness contrast: a hook chain with `next()` delegation, plus the strictest-wins merge (deny > ask > allow).
+- [`test.py`](src/test.py): a pre-hook blocks `rm -rf` even under `bypassPermissions`; waterfall checks cover deciding, delegating, and the merge.
 
 ```bash
 python sections/04-hooks/src/test.py         # offline checks, no key

--- a/sections/04-hooks/README.zh-CN.md
+++ b/sections/04-hooks/README.zh-CN.md
@@ -66,6 +66,17 @@ demo 用一个 `PreToolUse` hook，即使在 `bypassPermissions` 之下也拦截
 
 本章谈的是生命周期 hook。放在 `hooks/` 文件夹中的 React render hook，是不相干的 UI 代码，只是共用同一个词。
 
+### 对照：waterfall hooks
+
+deepseek-harness 用的是另一种 hook 表面。hook 是挂在类型化事件上的 in-process listener，不是 shell 子进程。
+
+- listener 排成一条链，每个都拿到 payload 和一个 `next()` callback。
+- listener 不调用 `next()` 就直接返回，等于自己接手这个决策。
+- listener 调用 `next()` 就是把决策交给下游，还可以把下游的结果包一层再返回。
+- 外部的 shell hook 靠 bridge 接上来，输出以最严格者为准折叠：deny > ask > allow。
+
+[`src/waterfall.py`](src/waterfall.py) 是这个表面的 strip-down。它是对照用的 demo，没有接进 `_dispatch`，后面的章节照样沿用原本的 loop。
+
 ### 延伸阅读
 
 以下设计 `src/` 都没有实现，出自 ai-agent-book，也未经下面表格的系统证实。
@@ -87,14 +98,14 @@ demo 用一个 `PreToolUse` hook，即使在 `bypassPermissions` 之下也拦截
 
 各个 agent 如何在 loop 周围提供拦截点。
 
-| | Claude Code |
-| --- | --- |
-| **Pros** | 用户不必改动 loop 就能扩展行为。适合做记录、验证、通知和策略检查。 |
-| **Cons** | 固定的事件列表同时也是它的边界。hook 只能在系统对外提供事件的地方进行拦截。 |
-| **Why** | 让 loop 保持精简。新行为挂接到固定事件上，不用改动或分叉 loop。 |
-| **How: hook events** | 固定的 27 个生命周期事件，涵盖 tool、prompt、session、stop、subagent、compact 与 setup。 |
-| **How: fire point** | 从 settings 加载，启动时冻结。`PreToolUse` 在 permission gate 之前触发。 |
-| **How: can block or modify?** | 可以。拒绝、询问、更新输入、加入 context，或停止。hook 输出会和基于规则的 permission 加以协调。 |
+| | Claude Code | deepseek-harness |
+| --- | --- | --- |
+| **Pros** | 用户不必改动 loop 就能扩展行为。适合做记录、验证、通知和策略检查。 | hook 是类型化的 plugin，既有的 shell hook 照样能跑。 |
+| **Cons** | 固定的事件列表同时也是它的边界。hook 只能在系统对外提供事件的地方进行拦截。 | 要学两套表面。bridge 只涵盖一部分事件，也不能改写工具输入。 |
+| **Why** | 让 loop 保持精简。新行为挂接到固定事件上，不用改动或分叉 loop。 | 扩展表面就是 harness 自己在跑的那套事件系统。 |
+| **How: hook events** | 固定的 27 个生命周期事件，涵盖 tool、prompt、session、stop、subagent、compact 与 setup。 | 每个阶段都有 waterfall 和 serial 事件，bridge 把 shell 方言映射上来。 |
+| **How: fire point** | 从 settings 加载，启动时冻结。`PreToolUse` 在 permission gate 之前触发。 | 在 pre-execute waterfall 里，位于只会拒绝的 guard 之前。 |
+| **How: can block or modify?** | 可以。拒绝、询问、更新输入、加入 context，或停止。hook 输出会和基于规则的 permission 加以协调。 | 可以，靠类型化的决策。多个 shell hook 折叠成 deny > ask > allow。 |
 
 ---
 
@@ -115,7 +126,8 @@ demo 用一个 `PreToolUse` hook，即使在 `bypassPermissions` 之下也拦截
 
 - [`hooks.py`](src/hooks.py)：带有 `fire_pre` 与 `fire_post` 的 `Hooks` 对象。
 - [`loop.py`](src/loop.py)：`_dispatch` 在 gate 之前触发 `PreToolUse`，在执行之后触发 `PostToolUse`。
-- [`test.py`](src/test.py)：一个 pre-hook 即使在 `bypassPermissions` 之下也拦截 `rm -rf`。
+- [`waterfall.py`](src/waterfall.py)：deepseek-harness 的对照：带 `next()` 委派的类型化 waterfall 事件，加上 deny > ask > allow 的折叠。
+- [`test.py`](src/test.py)：一个 pre-hook 即使在 `bypassPermissions` 之下也拦截 `rm -rf`；waterfall 检查涵盖接手、委派和折叠。
 
 ```bash
 python sections/04-hooks/src/test.py         # offline checks, no key
@@ -128,6 +140,9 @@ uv run python sections/04-hooks/src/demo.py  # live demo, needs a key
 
 - [Claude Code 源码](https://github.com/yasasbanukaofficial/claude-code)：
   `types/hooks.ts`、`entrypoints/sdk/coreTypes.ts`、`services/tools/toolHooks.ts`、`query/stopHooks.ts`、`services/tools/toolExecution.ts`、`setup.ts`。
+- [deepseek-harness 源码](https://github.com/deepseek-ai/deepseek-harness)（`dsh-v0.1.0-rc.7`）：
+  `packages/hooks/README.md`、`packages/hooks/hooks-claude-code/README.md`、`packages/hooks/hook-protocol/README.md`、
+  `docs/cordis-primer.md`、`docs/subsystems/core.md`。
 - [learn-claude-code · s04_hooks](https://github.com/shareAI-lab/learn-claude-code)：section framing。
 - [ai-agent-book · 第 5 章](https://github.com/bojieli/ai-agent-book/blob/main/book/chapter5.md)（《深入理解 AI Agent》，李博杰，以中文原版为准）：
   写入后跑 lint：工具层在写入之后跑 linter，把诊断信息加进 tool result。

--- a/sections/04-hooks/README.zh-CN.md
+++ b/sections/04-hooks/README.zh-CN.md
@@ -68,14 +68,21 @@ demo 用一个 `PreToolUse` hook，即使在 `bypassPermissions` 之下也拦截
 
 ### 对照：waterfall hooks
 
-deepseek-harness 用的是另一种 hook 表面。hook 是挂在类型化事件上的 in-process listener，不是 shell 子进程。
+Claude Code 的 hook 是一条外部命令：harness 开一个子进程去跑它，再读它的 exit code 和输出。
+deepseek-harness 的 hook 则是一个普通函数，直接在 harness 进程里跑。
+它挂在一个命名事件上，例如工具调用前会触发的那个事件。
+它返回的也不是 exit code，而是类型化决策：deny、ask、allow 这种普通的值。
 
-- listener 排成一条链，每个都拿到 payload 和一个 `next()` callback。
-- listener 不调用 `next()` 就直接返回，等于自己接手这个决策。
-- listener 调用 `next()` 就是把决策交给下游，还可以把下游的结果包一层再返回。
-- 外部的 shell hook 靠 bridge 接上来，输出以最严格者为准折叠：deny > ask > allow。
+同一个事件可以挂好几个 hook。它们排成一条链，事件触发时只会跑第一个。
+每个 hook 拿到事件数据和一个 `next()` callback，然后二选一：
 
-[`src/waterfall.py`](src/waterfall.py) 是这个表面的 strip-down。它是对照用的 demo，没有接进 `_dispatch`，后面的章节照样沿用原本的 loop。
+- 不调用 `next()`，直接返回决策。链就停在这里，排在后面的 hook 都不会跑。
+- 调用 `next()`，让链的其余部分先决定，这个 hook 再把那个结果返回，可以原样返回，也可以先改一下。
+
+dsh 把这种派发方式叫做 waterfall。原本 Claude Code 的 shell hook 也还能用：一个 bridge 帮忙执行它们，
+把输出转成同样的类型化决策。好几个 shell hook 同时回答时，bridge 取最严格的那个：deny 盖过 ask，ask 盖过 allow。
+
+[`src/waterfall.py`](src/waterfall.py) 就是这套机制的 strip-down。它是对照用的 demo，没有接进 `_dispatch`，后面的章节照样沿用原本的 loop。
 
 ### 延伸阅读
 
@@ -100,12 +107,12 @@ deepseek-harness 用的是另一种 hook 表面。hook 是挂在类型化事件�
 
 | | Claude Code | deepseek-harness |
 | --- | --- | --- |
-| **Pros** | 用户不必改动 loop 就能扩展行为。适合做记录、验证、通知和策略检查。 | hook 是类型化的 plugin，既有的 shell hook 照样能跑。 |
-| **Cons** | 固定的事件列表同时也是它的边界。hook 只能在系统对外提供事件的地方进行拦截。 | 要学两套表面。bridge 只涵盖一部分事件，也不能改写工具输入。 |
-| **Why** | 让 loop 保持精简。新行为挂接到固定事件上，不用改动或分叉 loop。 | 扩展表面就是 harness 自己在跑的那套事件系统。 |
-| **How: hook events** | 固定的 27 个生命周期事件，涵盖 tool、prompt、session、stop、subagent、compact 与 setup。 | 每个阶段都有 waterfall 和 serial 事件，bridge 把 shell 方言映射上来。 |
+| **Pros** | 用户不必改动 loop 就能扩展行为。适合做记录、验证、通知和策略检查。 | hook 是进程内的 plugin，既有的 shell hook 照样能跑。 |
+| **Cons** | 固定的事件列表同时也是它的边界。hook 只能在系统对外提供事件的地方进行拦截。 | 两套 hook 做法都要学。bridge 只涵盖一部分事件，也不能改写工具输入。 |
+| **Why** | 让 loop 保持精简。新行为挂接到固定事件上，不用改动或分叉 loop。 | 扩展用的接口，就是 harness 自己在跑的那套事件系统。 |
+| **How: hook events** | 固定的 27 个生命周期事件，涵盖 tool、prompt、session、stop、subagent、compact 与 setup。 | 每个阶段都有 waterfall 和 serial 事件，shell hook 靠 bridge 接上来。 |
 | **How: fire point** | 从 settings 加载，启动时冻结。`PreToolUse` 在 permission gate 之前触发。 | 在 pre-execute waterfall 里，位于只会拒绝的 guard 之前。 |
-| **How: can block or modify?** | 可以。拒绝、询问、更新输入、加入 context，或停止。hook 输出会和基于规则的 permission 加以协调。 | 可以，靠类型化的决策。多个 shell hook 折叠成 deny > ask > allow。 |
+| **How: can block or modify?** | 可以。拒绝、询问、更新输入、加入 context，或停止。hook 输出会和基于规则的 permission 加以协调。 | 可以，靠类型化决策。多个 shell hook 取最严格的：deny > ask > allow。 |
 
 ---
 
@@ -126,8 +133,8 @@ deepseek-harness 用的是另一种 hook 表面。hook 是挂在类型化事件�
 
 - [`hooks.py`](src/hooks.py)：带有 `fire_pre` 与 `fire_post` 的 `Hooks` 对象。
 - [`loop.py`](src/loop.py)：`_dispatch` 在 gate 之前触发 `PreToolUse`，在执行之后触发 `PostToolUse`。
-- [`waterfall.py`](src/waterfall.py)：deepseek-harness 的对照：带 `next()` 委派的类型化 waterfall 事件，加上 deny > ask > allow 的折叠。
-- [`test.py`](src/test.py)：一个 pre-hook 即使在 `bypassPermissions` 之下也拦截 `rm -rf`；waterfall 检查涵盖接手、委派和折叠。
+- [`waterfall.py`](src/waterfall.py)：deepseek-harness 的对照：一条 hook 链，用 `next()` 往下传，多个结果取最严格的（deny > ask > allow）。
+- [`test.py`](src/test.py)：一个 pre-hook 即使在 `bypassPermissions` 之下也拦截 `rm -rf`；waterfall 检查涵盖直接决定、交给下游，和取最严格。
 
 ```bash
 python sections/04-hooks/src/test.py         # offline checks, no key

--- a/sections/04-hooks/README.zh-TW.md
+++ b/sections/04-hooks/README.zh-TW.md
@@ -66,6 +66,17 @@ demo 用一個 `PreToolUse` hook，即使在 `bypassPermissions` 之下也擋下
 
 本章談的是生命週期 hook。放在 `hooks/` 資料夾中的 React render hook，是不相干的 UI 程式碼，只是共用同一個字。
 
+### 對照：waterfall hooks
+
+deepseek-harness 用的是另一種 hook 表面。hook 是掛在型別化事件上的 in-process listener，不是 shell 子行程。
+
+- listener 排成一條鏈，每個都拿到 payload 和一個 `next()` callback。
+- listener 不呼叫 `next()` 就直接回傳，等於自己接手這個決策。
+- listener 呼叫 `next()` 就是把決策交給下游，還可以把下游的結果包一層再回傳。
+- 外部的 shell hook 靠 bridge 接上來，輸出以最嚴格者為準折疊：deny > ask > allow。
+
+[`src/waterfall.py`](src/waterfall.py) 是這個表面的 strip-down。它是對照用的 demo，沒有接進 `_dispatch`，後面的章節照樣沿用原本的 loop。
+
 ### 延伸閱讀
 
 以下設計 `src/` 都沒有實作，出自 ai-agent-book，也未經下面表格的系統證實。
@@ -87,14 +98,14 @@ demo 用一個 `PreToolUse` hook，即使在 `bypassPermissions` 之下也擋下
 
 各個 agent 如何在 loop 周圍提供攔截點。
 
-| | Claude Code |
-| --- | --- |
-| **Pros** | 使用者不必改動 loop 就能擴充行為。適合做記錄、驗證、通知和政策檢查。 |
-| **Cons** | 固定的事件清單同時也是它的界限。hook 只能在系統對外提供事件的地方進行攔截。 |
-| **Why** | 讓 loop 保持精簡。新行為掛接到固定事件上，不用改動或分岔 loop。 |
-| **How: hook events** | 固定的 27 個生命週期事件，涵蓋 tool、prompt、session、stop、subagent、compact 與 setup。 |
-| **How: fire point** | 從 settings 載入，啟動時凍結。`PreToolUse` 在 permission gate 之前觸發。 |
-| **How: can block or modify?** | 可以。拒絕、詢問、更新輸入、加入 context，或停止。hook 輸出會和以規則為基礎的 permission 加以協調。 |
+| | Claude Code | deepseek-harness |
+| --- | --- | --- |
+| **Pros** | 使用者不必改動 loop 就能擴充行為。適合做記錄、驗證、通知和政策檢查。 | hook 是型別化的 plugin，既有的 shell hook 照樣能跑。 |
+| **Cons** | 固定的事件清單同時也是它的界限。hook 只能在系統對外提供事件的地方進行攔截。 | 要學兩套表面。bridge 只涵蓋一部分事件，也不能改寫工具輸入。 |
+| **Why** | 讓 loop 保持精簡。新行為掛接到固定事件上，不用改動或分岔 loop。 | 擴充表面就是 harness 自己在跑的那套事件系統。 |
+| **How: hook events** | 固定的 27 個生命週期事件，涵蓋 tool、prompt、session、stop、subagent、compact 與 setup。 | 每個階段都有 waterfall 和 serial 事件，bridge 把 shell 方言對映上來。 |
+| **How: fire point** | 從 settings 載入，啟動時凍結。`PreToolUse` 在 permission gate 之前觸發。 | 在 pre-execute waterfall 裡，位在只會拒絕的 guard 之前。 |
+| **How: can block or modify?** | 可以。拒絕、詢問、更新輸入、加入 context，或停止。hook 輸出會和以規則為基礎的 permission 加以協調。 | 可以，靠型別化的決策。多個 shell hook 折疊成 deny > ask > allow。 |
 
 ---
 
@@ -115,7 +126,8 @@ demo 用一個 `PreToolUse` hook，即使在 `bypassPermissions` 之下也擋下
 
 - [`hooks.py`](src/hooks.py)：帶有 `fire_pre` 與 `fire_post` 的 `Hooks` 物件。
 - [`loop.py`](src/loop.py)：`_dispatch` 在 gate 之前觸發 `PreToolUse`，在執行之後觸發 `PostToolUse`。
-- [`test.py`](src/test.py)：一個 pre-hook 即使在 `bypassPermissions` 之下也擋下 `rm -rf`。
+- [`waterfall.py`](src/waterfall.py)：deepseek-harness 的對照：帶 `next()` 委派的型別化 waterfall 事件，加上 deny > ask > allow 的折疊。
+- [`test.py`](src/test.py)：一個 pre-hook 即使在 `bypassPermissions` 之下也擋下 `rm -rf`；waterfall 檢查涵蓋接手、委派和折疊。
 
 ```bash
 python sections/04-hooks/src/test.py         # offline checks, no key
@@ -128,6 +140,9 @@ uv run python sections/04-hooks/src/demo.py  # live demo, needs a key
 
 - [Claude Code 原始碼](https://github.com/yasasbanukaofficial/claude-code)：
   `types/hooks.ts`、`entrypoints/sdk/coreTypes.ts`、`services/tools/toolHooks.ts`、`query/stopHooks.ts`、`services/tools/toolExecution.ts`、`setup.ts`。
+- [deepseek-harness 原始碼](https://github.com/deepseek-ai/deepseek-harness)（`dsh-v0.1.0-rc.7`）：
+  `packages/hooks/README.md`、`packages/hooks/hooks-claude-code/README.md`、`packages/hooks/hook-protocol/README.md`、
+  `docs/cordis-primer.md`、`docs/subsystems/core.md`。
 - [learn-claude-code · s04_hooks](https://github.com/shareAI-lab/learn-claude-code)：section framing。
 - [ai-agent-book · 第 5 章](https://github.com/bojieli/ai-agent-book/blob/main/book/chapter5.md)（《深入理解 AI Agent》，李博杰，以中文原版為準）：
   寫入後跑 lint：工具層在寫入之後跑 linter，把診斷訊息加進 tool result。

--- a/sections/04-hooks/README.zh-TW.md
+++ b/sections/04-hooks/README.zh-TW.md
@@ -68,14 +68,21 @@ demo 用一個 `PreToolUse` hook，即使在 `bypassPermissions` 之下也擋下
 
 ### 對照：waterfall hooks
 
-deepseek-harness 用的是另一種 hook 表面。hook 是掛在型別化事件上的 in-process listener，不是 shell 子行程。
+Claude Code 的 hook 是一條外部指令：harness 開一個子行程去跑它，再讀它的 exit code 和輸出。
+deepseek-harness 的 hook 則是一個普通函式，直接在 harness 行程裡跑。
+它掛在一個具名事件上，例如工具呼叫前會觸發的那個事件。
+它回傳的也不是 exit code，而是型別化決策：deny、ask、allow 這種普通的值。
 
-- listener 排成一條鏈，每個都拿到 payload 和一個 `next()` callback。
-- listener 不呼叫 `next()` 就直接回傳，等於自己接手這個決策。
-- listener 呼叫 `next()` 就是把決策交給下游，還可以把下游的結果包一層再回傳。
-- 外部的 shell hook 靠 bridge 接上來，輸出以最嚴格者為準折疊：deny > ask > allow。
+同一個事件可以掛好幾個 hook。它們排成一條鏈，事件觸發時只會跑第一個。
+每個 hook 拿到事件資料和一個 `next()` callback，然後二選一：
 
-[`src/waterfall.py`](src/waterfall.py) 是這個表面的 strip-down。它是對照用的 demo，沒有接進 `_dispatch`，後面的章節照樣沿用原本的 loop。
+- 不呼叫 `next()`，直接回傳決策。鏈就停在這裡，排在後面的 hook 都不會跑。
+- 呼叫 `next()`，讓鏈的其餘部分先決定，這個 hook 再把那個結果回傳，可以原樣回傳，也可以先改一下。
+
+dsh 把這種派發方式叫做 waterfall。原本 Claude Code 的 shell hook 也還能用：一個 bridge 幫忙執行它們，
+把輸出轉成同樣的型別化決策。好幾個 shell hook 同時回答時，bridge 取最嚴格的那個：deny 蓋過 ask，ask 蓋過 allow。
+
+[`src/waterfall.py`](src/waterfall.py) 就是這套機制的 strip-down。它是對照用的 demo，沒有接進 `_dispatch`，後面的章節照樣沿用原本的 loop。
 
 ### 延伸閱讀
 
@@ -100,12 +107,12 @@ deepseek-harness 用的是另一種 hook 表面。hook 是掛在型別化事件�
 
 | | Claude Code | deepseek-harness |
 | --- | --- | --- |
-| **Pros** | 使用者不必改動 loop 就能擴充行為。適合做記錄、驗證、通知和政策檢查。 | hook 是型別化的 plugin，既有的 shell hook 照樣能跑。 |
-| **Cons** | 固定的事件清單同時也是它的界限。hook 只能在系統對外提供事件的地方進行攔截。 | 要學兩套表面。bridge 只涵蓋一部分事件，也不能改寫工具輸入。 |
-| **Why** | 讓 loop 保持精簡。新行為掛接到固定事件上，不用改動或分岔 loop。 | 擴充表面就是 harness 自己在跑的那套事件系統。 |
-| **How: hook events** | 固定的 27 個生命週期事件，涵蓋 tool、prompt、session、stop、subagent、compact 與 setup。 | 每個階段都有 waterfall 和 serial 事件，bridge 把 shell 方言對映上來。 |
+| **Pros** | 使用者不必改動 loop 就能擴充行為。適合做記錄、驗證、通知和政策檢查。 | hook 是行程內的 plugin，既有的 shell hook 照樣能跑。 |
+| **Cons** | 固定的事件清單同時也是它的界限。hook 只能在系統對外提供事件的地方進行攔截。 | 兩套 hook 做法都要學。bridge 只涵蓋一部分事件，也不能改寫工具輸入。 |
+| **Why** | 讓 loop 保持精簡。新行為掛接到固定事件上，不用改動或分岔 loop。 | 擴充用的介面，就是 harness 自己在跑的那套事件系統。 |
+| **How: hook events** | 固定的 27 個生命週期事件，涵蓋 tool、prompt、session、stop、subagent、compact 與 setup。 | 每個階段都有 waterfall 和 serial 事件，shell hook 靠 bridge 接上來。 |
 | **How: fire point** | 從 settings 載入，啟動時凍結。`PreToolUse` 在 permission gate 之前觸發。 | 在 pre-execute waterfall 裡，位在只會拒絕的 guard 之前。 |
-| **How: can block or modify?** | 可以。拒絕、詢問、更新輸入、加入 context，或停止。hook 輸出會和以規則為基礎的 permission 加以協調。 | 可以，靠型別化的決策。多個 shell hook 折疊成 deny > ask > allow。 |
+| **How: can block or modify?** | 可以。拒絕、詢問、更新輸入、加入 context，或停止。hook 輸出會和以規則為基礎的 permission 加以協調。 | 可以，靠型別化決策。多個 shell hook 取最嚴格的：deny > ask > allow。 |
 
 ---
 
@@ -126,8 +133,8 @@ deepseek-harness 用的是另一種 hook 表面。hook 是掛在型別化事件�
 
 - [`hooks.py`](src/hooks.py)：帶有 `fire_pre` 與 `fire_post` 的 `Hooks` 物件。
 - [`loop.py`](src/loop.py)：`_dispatch` 在 gate 之前觸發 `PreToolUse`，在執行之後觸發 `PostToolUse`。
-- [`waterfall.py`](src/waterfall.py)：deepseek-harness 的對照：帶 `next()` 委派的型別化 waterfall 事件，加上 deny > ask > allow 的折疊。
-- [`test.py`](src/test.py)：一個 pre-hook 即使在 `bypassPermissions` 之下也擋下 `rm -rf`；waterfall 檢查涵蓋接手、委派和折疊。
+- [`waterfall.py`](src/waterfall.py)：deepseek-harness 的對照：一條 hook 鏈，用 `next()` 往下傳，多個結果取最嚴格的（deny > ask > allow）。
+- [`test.py`](src/test.py)：一個 pre-hook 即使在 `bypassPermissions` 之下也擋下 `rm -rf`；waterfall 檢查涵蓋直接決定、交給下游，和取最嚴格。
 
 ```bash
 python sections/04-hooks/src/test.py         # offline checks, no key

--- a/sections/04-hooks/src/test.py
+++ b/sections/04-hooks/src/test.py
@@ -8,6 +8,7 @@ from hooks import POST_TOOL_USE, PRE_TOOL_USE, Hooks
 from loop import _dispatch
 from permissions import BYPASS
 from tools import Registry, Tool
+from waterfall import ALLOW, ASK, DENY, Waterfall, merge
 
 
 def build():
@@ -41,5 +42,35 @@ def test():
     print("04 hooks: ok")
 
 
+def test_waterfall():
+    pre = Waterfall()
+    seen = []
+
+    def audit(call, next):
+        out = next()                       # delegate, then wrap: record the outcome
+        seen.append((call["name"], out))
+        return out
+
+    def guard(call, next):
+        if "rm -rf" in call["args"].get("command", ""):
+            return DENY                    # owns the decision: no next()
+        return next()
+
+    pre.on(audit)
+    pre.on(guard)
+
+    assert pre.dispatch({"name": "Bash", "args": {"command": "rm -rf /"}}) == DENY
+    assert pre.dispatch({"name": "Bash", "args": {"command": "ls"}}) == ALLOW  # chain end: default
+    assert seen == [("Bash", DENY), ("Bash", ALLOW)]   # the wrapper saw both outcomes
+
+    assert merge([ALLOW, ASK, DENY]) == DENY           # most restrictive wins
+    assert merge([DENY, ASK, ALLOW]) == DENY           # ordering cannot loosen it
+    assert merge([ASK, ALLOW]) == ASK
+    assert merge([]) == ALLOW
+
+    print("04 waterfall: ok")
+
+
 if __name__ == "__main__":
     test()
+    test_waterfall()

--- a/sections/04-hooks/src/waterfall.py
+++ b/sections/04-hooks/src/waterfall.py
@@ -1,10 +1,11 @@
-"""Waterfall hooks (section 4, contrast demo): deepseek-harness's hook surface.
+"""Waterfall hooks (section 4, contrast demo): deepseek-harness's hook style.
 
-In dsh a hook is an in-process listener on a typed event, not a shell
-subprocess. Listeners form a chain and each receives (payload, next).
-Returning without calling next() owns the decision; calling next() delegates
-downstream and may wrap the result. Bridged shell hooks fold
-most-restrictively: deny > ask > allow, so ordering cannot loosen a decision.
+In dsh a hook is a plain function on a named event inside the harness
+process, not a shell subprocess. Hooks form a chain and each receives
+(payload, next). Returning without calling next() owns the decision; calling
+next() lets the rest of the chain decide, then may adjust that result.
+Bridged shell hooks merge strictest-wins: deny > ask > allow, so ordering
+cannot loosen a decision.
 
 Standalone on purpose: not wired into _dispatch, so later sections carry the
 same loop forward. Mirrors dsh docs/cordis-primer.md and the hook-protocol

--- a/sections/04-hooks/src/waterfall.py
+++ b/sections/04-hooks/src/waterfall.py
@@ -1,0 +1,39 @@
+"""Waterfall hooks (section 4, contrast demo): deepseek-harness's hook surface.
+
+In dsh a hook is an in-process listener on a typed event, not a shell
+subprocess. Listeners form a chain and each receives (payload, next).
+Returning without calling next() owns the decision; calling next() delegates
+downstream and may wrap the result. Bridged shell hooks fold
+most-restrictively: deny > ask > allow, so ordering cannot loosen a decision.
+
+Standalone on purpose: not wired into _dispatch, so later sections carry the
+same loop forward. Mirrors dsh docs/cordis-primer.md and the hook-protocol
+merge at dsh-v0.1.0-rc.7.
+"""
+from __future__ import annotations
+
+DENY, ASK, ALLOW = "deny", "ask", "allow"
+_RANK = {DENY: 0, ASK: 1, ALLOW: 2}
+
+
+class Waterfall:
+    """One typed event. dispatch() runs the listener chain front to back."""
+
+    def __init__(self):
+        self._listeners = []
+
+    def on(self, fn):
+        self._listeners.append(fn)
+
+    def dispatch(self, payload, default=ALLOW):
+        def call(i):
+            if i == len(self._listeners):
+                return default
+            return self._listeners[i](payload, lambda: call(i + 1))
+
+        return call(0)
+
+
+def merge(decisions):
+    """Fold bridged hook outputs most-restrictively: deny > ask > allow."""
+    return min(decisions, key=_RANK.__getitem__, default=ALLOW)


### PR DESCRIPTION
Closes #73. Batch 1 of PRD #72 (dsh-v0.1.0-rc.7).

- deepseek-harness column in sections 1 to 4 per-system tables; existing cells trimmed to hold the 180-char line rule
- dsh Sources bullets per section
- top-level Systems-table row and references entry, PRD text verbatim; *(more soon)* row kept
- section 4 waterfall.py contrast demo (hook chain, next(), strictest-wins merge) with offline checks; no forward ripple
- zh-TW and zh-CN mirrored for every touched README

Note: the PRD-locked Systems row is 193 chars; exact PRD match kept over the 180 rule (that table already had >180 lines on main).