### PR TITLE
dsh batch 3: sections 10-11 columns, section 10 prompt-registry demo

### DIFF
--- a/sections/10-system-prompt/README.md
+++ b/sections/10-system-prompt/README.md
@@ -170,7 +170,7 @@ How the prompt is composed each turn.
 | **Pros** | No stale instructions. Guidance matches the live tools. | One render from config. Nothing to invalidate. | Every prompt fact has one owner. Bad references fail loud. |
 | **Cons** | Needs a section registry, cache rules, and ordering discipline. | The prompt cannot change mid-run. | A registry, scopes, and order bands are a lot of machinery. |
 | **Why** | Tools, memory, and modes vary by session. | Assumes the tool set never changes mid-run. | Plugins own their facts, so the prompt is assembled, never edited. |
-| **How: assembly point** | A prompt builder returning one string per section. | Jinja2 templates in config. | A registry, plus an assembly event each scope can adjust. |
+| **How: assembly point** | A prompt builder, one string per section. | Jinja2 templates; a missing variable fails loudly. | A registry, plus an event each scope can adjust. |
 | **How: sections** | Static and dynamic sections; project context rides in messages. | Two templates, system and instance. | Named sections in numeric bands, shadowed by scope. |
 | **How: when built** | Per turn from live state, with dynamic parts memoized. | Once, at run start. | Once per step. Changing facts append as snapshots instead. |
 

--- a/sections/10-system-prompt/README.md
+++ b/sections/10-system-prompt/README.md
@@ -105,6 +105,23 @@ for _ in range(max_steps):                             # src/loop.py
 - It reads live state such as enabled tools and session mode.
 - Passing `prompt=None` keeps the section-9 behavior.
 
+### Contrast: a section registry
+
+The list above is fixed in one file. Adding a section means editing that file, and the file order is the prompt order.
+
+deepseek-harness assembles from registrations instead. Each plugin registers a named section and a number that says where it goes.
+The numbers fall in bands by convention: harness identity first, deployment persona next, tool guidance after that.
+Assembly sorts by number, so a plugin picks its place without knowing what else is registered.
+
+Two more rules come with the registry.
+
+- One agent can register its own section under a name that already exists. That agent sees its version, everyone else keeps the shared one.
+- Section text can carry `{{variables}}`, and rendering is strict. An unknown name raises instead of rendering a hole into a shipped prompt.
+
+Dynamic facts stay out of this prompt. They are appended to the conversation as a snapshot, and only when the rendered text actually changed, so the prefix stays cache-stable.
+
+[`src/registry.py`](src/registry.py) is a strip-down of this. It is a contrast demo, not wired into `assemble()`, so later sections carry the same prompt code forward.
+
 ### Further reading
 
 None of this is in `src/`. It comes from ai-agent-book, and is not confirmed of the systems in the table.
@@ -148,14 +165,14 @@ The prompt layer lowers the odds. The execution layer bounds the damage.
 
 How the prompt is composed each turn.
 
-| | Claude Code | mini-swe-agent |
-| --- | --- | --- |
-| **Pros** | No stale or irrelevant instructions. Tool guidance matches the enabled tool set. | One render from config. Nothing to memoize or invalidate. |
-| **Cons** | Needs a section registry, cache invalidation rules, and ordering discipline. | The prompt cannot change mid-run. Later state reaches the model as observations. |
-| **Why** | Tools, memory, and modes vary by session. The prompt should describe what is active. | Assumes the tool set never changes mid-run, so one render at start holds. |
-| **How: assembly point** | A prompt builder that returns one string per section. | Jinja2 templates in config. A missing variable fails loudly. |
-| **How: sections** | Static and dynamic sections. Project context goes in context messages. | Two templates: system and instance, filled from config, environment, and run state. |
-| **How: when built** | Per turn from live state. Dynamic parts stay memoized until the session is cleared or compacted. | Once, at run start, adapted to the platform. |
+| | Claude Code | mini-swe-agent | deepseek-harness |
+| --- | --- | --- | --- |
+| **Pros** | No stale instructions. Guidance matches the live tools. | One render from config. Nothing to invalidate. | Every prompt fact has one owner. Bad references fail loud. |
+| **Cons** | Needs a section registry, cache rules, and ordering discipline. | The prompt cannot change mid-run. | A registry, scopes, and order bands are a lot of machinery. |
+| **Why** | Tools, memory, and modes vary by session. | Assumes the tool set never changes mid-run. | Plugins own their facts, so the prompt is assembled, never edited. |
+| **How: assembly point** | A prompt builder returning one string per section. | Jinja2 templates in config. | A registry, plus an assembly event each scope can adjust. |
+| **How: sections** | Static and dynamic sections; project context rides in messages. | Two templates, system and instance. | Named sections in numeric bands, shadowed by scope. |
+| **How: when built** | Per turn from live state, with dynamic parts memoized. | Once, at run start. | Once per step. Changing facts append as snapshots instead. |
 
 ---
 
@@ -177,9 +194,10 @@ How the prompt is composed each turn.
 [`src/`](src/) carries 09 forward and adds:
 
 - [`prompt.py`](src/prompt.py): `Section`, `static`, and `assemble`.
+- [`registry.py`](src/registry.py): the deepseek-harness contrast: sections registered with an order number, scope shadowing, and strict `{{variable}}` rendering.
 - [`loop.py`](src/loop.py): re-assembles the prompt each turn.
 - [`demo.py`](src/demo.py): adds top-level `cache_control`.
-- [`test.py`](src/test.py): checks state-driven inclusion.
+- [`test.py`](src/test.py): checks state-driven inclusion; registry checks cover ordering, shadowing, and the fail-loud variable.
 
 ```bash
 python sections/10-system-prompt/src/test.py         # offline checks, no key
@@ -193,6 +211,9 @@ uv run python sections/10-system-prompt/src/demo.py  # live demo, needs a key
 - [Claude Code source](https://github.com/yasasbanukaofficial/claude-code): `constants/prompts.ts`, `constants/systemPromptSections.ts`, `utils/api.ts`, `QueryEngine.ts`.
 - [mini-swe-agent source](https://github.com/swe-agent/mini-swe-agent):
   `config/mini.yaml`, `_render_template` and `get_template_vars` in `agents/default.py`, `models/utils/cache_control.py`.
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness) at `dsh-v0.1.0-rc.7`:
+  `packages/core/system-prompt/README.md`, `packages/core/system-prompt/src/index.ts`, `packages/core/agent-loop/src/runtime-context.ts`,
+  `docs/subsystems/system-prompt.md`, `docs/agent-lifecycle.md`.
 - [Anthropic prompt caching](https://platform.claude.com/docs/en/build-with-claude/prompt-caching): cache breakpoints, TTLs, pricing, and token minimums.
 - [Claude Code prompt caching docs](https://code.claude.com/docs/en/prompt-caching): the explicit cache boundary between a static prefix and a dynamic tail.
 - [ai-agent-book · chapter 2](https://github.com/bojieli/ai-agent-book/blob/main/book/chapter2.md) (《深入理解 AI Agent》, 李博杰; the Chinese original is canonical):

--- a/sections/10-system-prompt/README.zh-CN.md
+++ b/sections/10-system-prompt/README.zh-CN.md
@@ -105,6 +105,23 @@ for _ in range(max_steps):                             # src/loop.py
 - 它读取实时状态，例如启用中的工具和 session 模式。
 - 传入 `prompt=None` 会维持第 9 章的行为。
 
+### 对照：段落 registry
+
+上面那份列表写死在一个文件里。要加段落就得改那个文件，而文件里的先后顺序就是 prompt 的顺序。
+
+deepseek-harness 改成从注册表组出来。每个 plugin 注册一个有名字的段落，再给一个数字说明它该排在哪。
+数字按惯例分成几个区段：harness 身份最前面，接着是部署方的 persona，再来才是工具指引。
+组装时照数字排序，所以 plugin 不必知道别人注册了什么，也能找到自己的位置。
+
+registry 还带来两条规则。
+
+- 某个 agent 可以用一个已经存在的名字，注册自己的段落。那个 agent 看到的是自己那份，其他人照样用共用的。
+- 段落文字里可以放 `{{variables}}`，而且 render 很严格。名字对不上就直接报错，不会让 prompt 带着一个洞发出去。
+
+会变的事实不放进这份 prompt。它们以快照的形式接到对话后面，而且只有 render 出来的文字真的变了才接，前缀因此对 cache 友好。
+
+[`src/registry.py`](src/registry.py) 就是这件事的精简版。它是对照用的 demo，没有接进 `assemble()`，所以后面的章节照样沿用同一套 prompt 代码。
+
 ### 延伸阅读
 
 以下设计 `src/` 都没有实现，出自 ai-agent-book，也未经下面表格的系统证实。
@@ -148,14 +165,14 @@ prompt 层降低发生概率，执行层限制损害范围。
 
 每一轮如何组出 prompt。
 
-| | Claude Code | mini-swe-agent |
-| --- | --- | --- |
-| **Pros** | 不会留着过时或不相关的指令。工具指引对得上启用中的工具集。 | 只从 config render 一次。没有东西要 memoize，也没有 cache 失效规则要管。 |
-| **Cons** | 多了段落 registry、cache 失效规则，以及排序上的纪律。 | prompt 在 run 中途改不了。之后的状态只能以 observation 的形式进到模型。 |
-| **Why** | 工具、记忆和模式会因 session 而异，prompt 要描述实际启用中的内容。 | 假设工具集在 run 中途不会变，开头 render 一次就一直有效。 |
-| **How: assembly point** | 一个 prompt 组装器，每个段落各返回一个字符串。 | config 里的 Jinja2 template。变量缺了会直接报错。 |
-| **How: sections** | 静态与动态段落。项目上下文以 context 消息注入。 | 两份 template：system 与 instance，变量来自 config、环境和运行期状态。 |
-| **How: when built** | 每一轮从实时状态组出。动态段落会被记忆（memoize），直到 session 被清空或压缩。 | 只在 run 开始时组一次，并随平台调整。 |
+| | Claude Code | mini-swe-agent | deepseek-harness |
+| --- | --- | --- | --- |
+| **Pros** | 不会留着过时的指令，工具指引对得上启用中的工具集。 | 只从 config render 一次，没有东西要失效。 | 每一项 prompt 事实都有一个负责人，引用错了会直接报错。 |
+| **Cons** | 多了段落 registry、cache 失效规则和排序纪律。 | prompt 在 run 中途改不了。 | registry、scope 和排序区段，全都是要维护的机制。 |
+| **Why** | 工具、记忆和模式会因 session 而异。 | 假设工具集在 run 中途不会变。 | plugin 各自拥有自己的事实，所以 prompt 是组出来的，不是改字符串。 |
+| **How: assembly point** | 一个 prompt 组装器，每个段落各返回一个字符串。 | config 里的 Jinja2 template。 | 一个 registry，加上每个 scope 都能调整的组装事件。 |
+| **How: sections** | 静态与动态段落，项目上下文走 context 消息。 | 两份 template：system 与 instance。 | 有名字的段落排在数字区段里，scope 可以用同名盖掉。 |
+| **How: when built** | 每一轮从实时状态组出，动态段落会被 memoize。 | 只在 run 开始时组一次。 | 每一步组一次。会变的事实改以快照追加。 |
 
 ---
 
@@ -177,9 +194,10 @@ prompt 层降低发生概率，执行层限制损害范围。
 [`src/`](src/) 承接 09 并加入：
 
 - [`prompt.py`](src/prompt.py)：`Section`、`static` 和 `assemble`。
+- [`registry.py`](src/registry.py)：deepseek-harness 的对照：段落注册时带一个排序数字，scope 可以盖掉同名段落，`{{variable}}` 严格 render。
 - [`loop.py`](src/loop.py)：每一轮重新组出 prompt。
 - [`demo.py`](src/demo.py)：加入顶层的 `cache_control`。
-- [`test.py`](src/test.py)：检查段落会依状态正确纳入或略过。
+- [`test.py`](src/test.py)：检查段落会依状态正确纳入或略过；registry 的检查涵盖排序、同名覆盖，以及变量对不上就报错。
 
 ```bash
 python sections/10-system-prompt/src/test.py         # offline checks, no key
@@ -193,6 +211,9 @@ uv run python sections/10-system-prompt/src/demo.py  # live demo, needs a key
 - [Claude Code 源码](https://github.com/yasasbanukaofficial/claude-code)：`constants/prompts.ts`、`constants/systemPromptSections.ts`、`utils/api.ts`、`QueryEngine.ts`。
 - [mini-swe-agent source](https://github.com/swe-agent/mini-swe-agent)：`config/mini.yaml`、
   `agents/default.py` 的 `_render_template` 与 `get_template_vars`、`models/utils/cache_control.py`。
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness)（`dsh-v0.1.0-rc.7`）：
+  `packages/core/system-prompt/README.md`、`packages/core/system-prompt/src/index.ts`、`packages/core/agent-loop/src/runtime-context.ts`、
+  `docs/subsystems/system-prompt.md`、`docs/agent-lifecycle.md`。
 - [Anthropic prompt caching](https://platform.claude.com/docs/en/build-with-claude/prompt-caching)：cache 断点、TTL、定价，以及 token 下限。
 - [Claude Code prompt caching 文档](https://code.claude.com/docs/en/prompt-caching)：静态前缀与动态尾段之间那道明确的 cache 边界。
 - [ai-agent-book · 第 2 章](https://github.com/bojieli/ai-agent-book/blob/main/book/chapter2.md)（《深入理解 AI Agent》，李博杰，以中文原版为准）：

--- a/sections/10-system-prompt/README.zh-CN.md
+++ b/sections/10-system-prompt/README.zh-CN.md
@@ -170,7 +170,7 @@ prompt 层降低发生概率，执行层限制损害范围。
 | **Pros** | 不会留着过时的指令，工具指引对得上启用中的工具集。 | 只从 config render 一次，没有东西要失效。 | 每一项 prompt 事实都有一个负责人，引用错了会直接报错。 |
 | **Cons** | 多了段落 registry、cache 失效规则和排序纪律。 | prompt 在 run 中途改不了。 | registry、scope 和排序区段，全都是要维护的机制。 |
 | **Why** | 工具、记忆和模式会因 session 而异。 | 假设工具集在 run 中途不会变。 | plugin 各自拥有自己的事实，所以 prompt 是组出来的，不是改字符串。 |
-| **How: assembly point** | 一个 prompt 组装器，每个段落各返回一个字符串。 | config 里的 Jinja2 template。 | 一个 registry，加上每个 scope 都能调整的组装事件。 |
+| **How: assembly point** | 一个 prompt 组装器，每个段落各返回一个字符串。 | config 里的 Jinja2 template，变量缺了会直接报错。 | 一个 registry，加上每个 scope 都能调整的组装事件。 |
 | **How: sections** | 静态与动态段落，项目上下文走 context 消息。 | 两份 template：system 与 instance。 | 有名字的段落排在数字区段里，scope 可以用同名盖掉。 |
 | **How: when built** | 每一轮从实时状态组出，动态段落会被 memoize。 | 只在 run 开始时组一次。 | 每一步组一次。会变的事实改以快照追加。 |
 

--- a/sections/10-system-prompt/README.zh-TW.md
+++ b/sections/10-system-prompt/README.zh-TW.md
@@ -105,6 +105,23 @@ for _ in range(max_steps):                             # src/loop.py
 - 它讀取即時狀態，例如啟用中的工具和 session 模式。
 - 傳入 `prompt=None` 會維持第 9 章的行為。
 
+### 對照：段落 registry
+
+上面那份清單寫死在一個檔案裡。要加段落就得改那個檔案，而檔案裡的先後順序就是 prompt 的順序。
+
+deepseek-harness 改成從註冊表組出來。每個 plugin 註冊一個有名字的段落，再給一個數字說明它該排在哪。
+數字照慣例分成幾個區段：harness 身分最前面，接著是部署方的 persona，再來才是工具指引。
+組裝時照數字排序，所以 plugin 不必知道別人註冊了什麼，也能找到自己的位置。
+
+registry 還帶來兩條規則。
+
+- 某個 agent 可以用一個已經存在的名字，註冊自己的段落。那個 agent 看到的是自己那份，其他人照樣用共用的。
+- 段落文字裡可以放 `{{variables}}`，而且 render 很嚴格。名字對不上就直接報錯，不會讓 prompt 帶著一個洞送出去。
+
+會變的事實不放進這份 prompt。它們以快照的形式接到對話後面，而且只有 render 出來的文字真的變了才接，前綴因此對 cache 友善。
+
+[`src/registry.py`](src/registry.py) 就是這件事的精簡版。它是對照用的 demo，沒有接進 `assemble()`，所以後面的章節照樣沿用同一套 prompt 程式碼。
+
 ### 延伸閱讀
 
 以下設計 `src/` 都沒有實作，出自 ai-agent-book，也未經下面表格的系統證實。
@@ -148,14 +165,14 @@ prompt 層降低發生機率，執行層限制損害範圍。
 
 每一輪如何組出 prompt。
 
-| | Claude Code | mini-swe-agent |
-| --- | --- | --- |
-| **Pros** | 不會留著過時或不相關的指令。工具指引對得上啟用中的工具集。 | 只從 config render 一次。沒有東西要 memoize，也沒有 cache 失效規則要管。 |
-| **Cons** | 多了段落 registry、cache 失效規則，以及排序上的紀律。 | prompt 在 run 中途改不了。之後的狀態只能以 observation 的形式進到模型。 |
-| **Why** | 工具、記憶和模式會因 session 而異，prompt 要描述實際啟用中的內容。 | 假設工具集在 run 中途不會變，開頭 render 一次就一直有效。 |
-| **How: assembly point** | 一個 prompt 組裝器，每個段落各回傳一個字串。 | config 裡的 Jinja2 template。變數缺了會直接報錯。 |
-| **How: sections** | 靜態與動態段落。專案脈絡以 context 訊息注入。 | 兩份 template：system 與 instance，變數來自 config、環境和執行期狀態。 |
-| **How: when built** | 每一輪從即時狀態組出。動態段落會被記憶（memoize），直到 session 被清空或壓縮。 | 只在 run 開始時組一次，並隨平台調整。 |
+| | Claude Code | mini-swe-agent | deepseek-harness |
+| --- | --- | --- | --- |
+| **Pros** | 不會留著過時的指令，工具指引對得上啟用中的工具集。 | 只從 config render 一次，沒有東西要失效。 | 每一項 prompt 事實都有一個負責人，引用錯了會直接報錯。 |
+| **Cons** | 多了段落 registry、cache 失效規則和排序紀律。 | prompt 在 run 中途改不了。 | registry、scope 和排序區段，全都是要維護的機制。 |
+| **Why** | 工具、記憶和模式會因 session 而異。 | 假設工具集在 run 中途不會變。 | plugin 各自擁有自己的事實，所以 prompt 是組出來的，不是改字串。 |
+| **How: assembly point** | 一個 prompt 組裝器，每個段落各回傳一個字串。 | config 裡的 Jinja2 template。 | 一個 registry，加上每個 scope 都能調整的組裝事件。 |
+| **How: sections** | 靜態與動態段落，專案脈絡走 context 訊息。 | 兩份 template：system 與 instance。 | 有名字的段落排在數字區段裡，scope 可以用同名蓋掉。 |
+| **How: when built** | 每一輪從即時狀態組出，動態段落會被 memoize。 | 只在 run 開始時組一次。 | 每一步組一次。會變的事實改以快照附加。 |
 
 ---
 
@@ -177,9 +194,10 @@ prompt 層降低發生機率，執行層限制損害範圍。
 [`src/`](src/) 承接 09 並加入：
 
 - [`prompt.py`](src/prompt.py)：`Section`、`static` 和 `assemble`。
+- [`registry.py`](src/registry.py)：deepseek-harness 的對照：段落註冊時帶一個排序數字，scope 可以蓋掉同名段落，`{{variable}}` 嚴格 render。
 - [`loop.py`](src/loop.py)：每一輪重新組出 prompt。
 - [`demo.py`](src/demo.py)：加入頂層的 `cache_control`。
-- [`test.py`](src/test.py)：檢查段落會依狀態正確納入或略過。
+- [`test.py`](src/test.py)：檢查段落會依狀態正確納入或略過；registry 的檢查涵蓋排序、同名覆蓋，以及變數對不上就報錯。
 
 ```bash
 python sections/10-system-prompt/src/test.py         # offline checks, no key
@@ -193,6 +211,9 @@ uv run python sections/10-system-prompt/src/demo.py  # live demo, needs a key
 - [Claude Code 原始碼](https://github.com/yasasbanukaofficial/claude-code)：`constants/prompts.ts`、`constants/systemPromptSections.ts`、`utils/api.ts`、`QueryEngine.ts`。
 - [mini-swe-agent source](https://github.com/swe-agent/mini-swe-agent)：`config/mini.yaml`、
   `agents/default.py` 的 `_render_template` 與 `get_template_vars`、`models/utils/cache_control.py`。
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness)（`dsh-v0.1.0-rc.7`）：
+  `packages/core/system-prompt/README.md`、`packages/core/system-prompt/src/index.ts`、`packages/core/agent-loop/src/runtime-context.ts`、
+  `docs/subsystems/system-prompt.md`、`docs/agent-lifecycle.md`。
 - [Anthropic prompt caching](https://platform.claude.com/docs/en/build-with-claude/prompt-caching)：cache 斷點、TTL、定價，以及 token 下限。
 - [Claude Code prompt caching 文件](https://code.claude.com/docs/en/prompt-caching)：靜態前綴與動態尾段之間那道明確的 cache 邊界。
 - [ai-agent-book · 第 2 章](https://github.com/bojieli/ai-agent-book/blob/main/book/chapter2.md)（《深入理解 AI Agent》，李博杰，以中文原版為準）：

--- a/sections/10-system-prompt/README.zh-TW.md
+++ b/sections/10-system-prompt/README.zh-TW.md
@@ -170,7 +170,7 @@ prompt 層降低發生機率，執行層限制損害範圍。
 | **Pros** | 不會留著過時的指令，工具指引對得上啟用中的工具集。 | 只從 config render 一次，沒有東西要失效。 | 每一項 prompt 事實都有一個負責人，引用錯了會直接報錯。 |
 | **Cons** | 多了段落 registry、cache 失效規則和排序紀律。 | prompt 在 run 中途改不了。 | registry、scope 和排序區段，全都是要維護的機制。 |
 | **Why** | 工具、記憶和模式會因 session 而異。 | 假設工具集在 run 中途不會變。 | plugin 各自擁有自己的事實，所以 prompt 是組出來的，不是改字串。 |
-| **How: assembly point** | 一個 prompt 組裝器，每個段落各回傳一個字串。 | config 裡的 Jinja2 template。 | 一個 registry，加上每個 scope 都能調整的組裝事件。 |
+| **How: assembly point** | 一個 prompt 組裝器，每個段落各回傳一個字串。 | config 裡的 Jinja2 template，變數缺了會直接報錯。 | 一個 registry，加上每個 scope 都能調整的組裝事件。 |
 | **How: sections** | 靜態與動態段落，專案脈絡走 context 訊息。 | 兩份 template：system 與 instance。 | 有名字的段落排在數字區段裡，scope 可以用同名蓋掉。 |
 | **How: when built** | 每一輪從即時狀態組出，動態段落會被 memoize。 | 只在 run 開始時組一次。 | 每一步組一次。會變的事實改以快照附加。 |
 

--- a/sections/10-system-prompt/src/registry.py
+++ b/sections/10-system-prompt/src/registry.py
@@ -1,0 +1,54 @@
+"""Prompt section registry (section 10): the deepseek-harness contrast.
+
+prompt.py assembles one fixed list in file order, so anything that wants a new
+section has to edit that list. dsh keeps a registry instead. A plugin registers a
+named section with a numeric order, an agent-scoped section shadows a global one
+of the same name, and assembly sorts by order. Text renders through strict
+{{variable}} interpolation: an unknown name raises rather than shipping a prompt
+with a hole in it.
+
+This is a contrast demo. It is not wired into assemble(), so later sections carry
+prompt.py forward unchanged.
+"""
+from __future__ import annotations
+
+import re
+
+HARNESS, PERSONA, TOOLS = -100, 0, 100   # the order bands dsh uses by convention
+
+
+class PromptRegistry:
+    """Named sections and variables, per scope, assembled in numeric order."""
+
+    def __init__(self):
+        self._sections: dict[tuple, tuple] = {}    # (scope, name) -> (order, text)
+        self._variables: dict[tuple, str] = {}     # (scope, name) -> value
+
+    def section(self, name, text, order=PERSONA, scope=None) -> None:
+        self._sections[(scope, name)] = (order, text)
+
+    def variable(self, name, value, scope=None) -> None:
+        self._variables[(scope, name)] = value
+
+    def assemble(self, scope=None) -> str:
+        """One prompt for this scope: a scoped section shadows the global one of that name."""
+        chosen: dict[str, tuple] = {}
+        for (sec_scope, name), entry in self._sections.items():
+            if sec_scope is not None and sec_scope != scope:
+                continue                          # belongs to another agent
+            if sec_scope is not None or name not in chosen:
+                chosen[name] = entry              # a scoped section shadows the global one
+        variables = {n: v for (s, n), v in self._variables.items() if s is None}
+        variables.update({n: v for (s, n), v in self._variables.items() if s is not None and s == scope})
+        ordered = sorted(chosen.values(), key=lambda e: e[0])
+        return "\n\n".join(render(text, variables) for _order, text in ordered)
+
+
+def render(text, variables) -> str:
+    """Strict {{name}} interpolation. An unknown name raises; nothing renders empty."""
+    def sub(match):
+        name = match.group(1).strip()
+        if name not in variables:
+            raise KeyError(f"unknown prompt variable {name!r}")
+        return str(variables[name])
+    return re.sub(r"\{\{([^{}]*)\}\}", sub, text)

--- a/sections/10-system-prompt/src/test.py
+++ b/sections/10-system-prompt/src/test.py
@@ -2,6 +2,7 @@
 
     python sections/10-system-prompt/src/test.py
 """
+import registry
 from prompt import DEMO_SECTIONS, assemble
 
 SEC = DEMO_SECTIONS
@@ -29,6 +30,25 @@ def test():
     # only the state-driven tail moves; the static head and the tools section stay put
     assert p1 != p2 != p3
     assert "Ping" in p1 and "Ping" in p3
+
+    # registry: order bands decide the layout, not the order sections were registered
+    reg = registry.PromptRegistry()
+    reg.section("tools", "Tools: {{tools}}", order=registry.TOOLS)
+    reg.section("identity", "You are a tiny agent.", order=registry.HARNESS)
+    reg.variable("tools", "Read, Ping")
+    assert reg.assemble() == "You are a tiny agent.\n\nTools: Read, Ping"
+
+    # registry: an agent-scoped section shadows the global one of the same name
+    reg.section("identity", "You are a reviewer.", order=registry.HARNESS, scope="reviewer")
+    assert "reviewer" in reg.assemble("reviewer") and "reviewer" not in reg.assemble()
+
+    # registry: an unknown variable fails loud instead of rendering a hole
+    reg.section("broken", "Model: {{model}}")
+    try:
+        reg.assemble()
+        raise AssertionError("unknown variable should raise")
+    except KeyError:
+        pass
 
     print("10 prompt: ok")
 

--- a/sections/11-error-recovery/README.md
+++ b/sections/11-error-recovery/README.md
@@ -160,7 +160,7 @@ Recovery wraps the model call. The loop body stays the same.
 | **Pros** | Specific paths save more runs than a blanket retry. | Three bounded paths. A crash leaves a full trajectory. | Retries are logged, so a resumed session knows them. |
 | **Cons** | More branches and bounds to maintain. | Saves fewer runs. Overflow aborts, and so do three format errors. | No fallback model. Its always mode retries forever. |
 | **Why** | One temporary API failure should not end a long task. | Retry, hand format errors back, name the exit. | The log is the truth, so recovery replays a fresh turn. |
-| **How: retry** | Backoff on 429, 408, 409, 5xx; a server `retry-after` wins. | tenacity backoff, 10 attempts. | An error event after the failed turn closes, then a fresh one. |
+| **How: retry** | Backoff on 429, 408, 409, 5xx; `retry-after` wins. | tenacity backoff, 4 to 60 seconds, 10 attempts. | An error event after the failed turn, then a fresh one. |
 | **How: token handling** | Raise the output cap, continue after a `max_tokens` stop, or compact. | None. Overflow aborts the run. | One overflow code: prune, then summarize. |
 | **How: model fallback** | Fallback model after repeated overload (529). | None. | None. The retry turn rebuilds the same request. |
 

--- a/sections/11-error-recovery/README.md
+++ b/sections/11-error-recovery/README.md
@@ -155,14 +155,14 @@ Pick each one from measured failures, not from intuition. The book's three-strik
 
 Recovery wraps the model call. The loop body stays the same.
 
-| | Claude Code | mini-swe-agent |
-| --- | --- | --- |
-| **Pros** | Specific recovery paths save more runs than a blanket retry. | Only three bounded paths to maintain. A crash still leaves a complete trajectory on disk. |
-| **Cons** | More branches and bounds to maintain. | Saves fewer runs. Context overflow aborts, and three format errors in a row end the run. |
-| **Why** | One temporary API failure should not end a long task. | Keeps three paths: retry transient errors, return format errors to the model, named exit for the rest. |
-| **How: retry** | Backoff retries on 429, 408, 409, and 5xx. A server `retry-after` wins. | tenacity backoff, 4 to 60 seconds, 10 attempts. Skips errors a retry cannot fix. |
-| **How: token handling** | Escalate output tokens, continue after a `max_tokens` stop, or compact on `prompt_too_long`. | None. Context overflow aborts the run. |
-| **How: model fallback** | Fallback model after repeated overload (529). Background 529 retries are capped. | None. |
+| | Claude Code | mini-swe-agent | deepseek-harness |
+| --- | --- | --- | --- |
+| **Pros** | Specific paths save more runs than a blanket retry. | Three bounded paths. A crash leaves a full trajectory. | Retries are logged, so a resumed session knows them. |
+| **Cons** | More branches and bounds to maintain. | Saves fewer runs. Overflow aborts the run. | No fallback model. One mode retries forever. |
+| **Why** | One temporary API failure should not end a long task. | Retry, hand format errors back, name the exit. | The log is the truth, so recovery replays a fresh turn. |
+| **How: retry** | Backoff on 429, 408, 409, and 5xx. A server `retry-after` wins. | tenacity backoff, 4 to 60 seconds, 10 attempts. | An error event, then a fresh turn. |
+| **How: token handling** | Raise the output cap, continue, or compact on `prompt_too_long`. | None. Overflow aborts the run. | One overflow code: prune, then summarize. |
+| **How: model fallback** | Fallback model after repeated overload (529). | None. | None. The retry turn rebuilds the same request. |
 
 ---
 
@@ -202,6 +202,9 @@ uv run python sections/11-error-recovery/src/demo.py  # live demo, needs a key
   `services/api/withRetry.ts`, `query.ts`, `services/api/claude.ts`, `services/api/errors.ts`, `query/tokenBudget.ts`, `utils/context.ts`.
 - [mini-swe-agent source](https://github.com/swe-agent/mini-swe-agent):
   `models/utils/retry.py`, `models/litellm_model.py`, `run()` and `max_consecutive_format_errors` in `agents/default.py`.
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness) at `dsh-v0.1.0-rc.7`:
+  `packages/llm/llm-retry/README.md`, `packages/llm/llm-retry/src/types.ts`, `packages/core/agent-loop/src/agent.ts`,
+  `docs/subsystems/llm-streaming.md`, `docs/subsystems/core.md`, `docs/subsystems/persistence.md`.
 - [ai-agent-book · chapter 5](https://github.com/bojieli/ai-agent-book/blob/main/book/chapter5.md) (《深入理解 AI Agent》, 李博杰; the Chinese original is canonical):
   the four-layer failure taxonomy, tool-plus-args loop fingerprints, the idle watchdog, `tool_result` pair repair with its product versus training-data split,
   graded recovery with error quarantine, and the death-spiral defenses. Its footnote ch5-3 sources the taxonomy from a study of production agents,

--- a/sections/11-error-recovery/README.md
+++ b/sections/11-error-recovery/README.md
@@ -158,10 +158,10 @@ Recovery wraps the model call. The loop body stays the same.
 | | Claude Code | mini-swe-agent | deepseek-harness |
 | --- | --- | --- | --- |
 | **Pros** | Specific paths save more runs than a blanket retry. | Three bounded paths. A crash leaves a full trajectory. | Retries are logged, so a resumed session knows them. |
-| **Cons** | More branches and bounds to maintain. | Saves fewer runs. Overflow aborts the run. | No fallback model. One mode retries forever. |
+| **Cons** | More branches and bounds to maintain. | Saves fewer runs. Overflow aborts, and so do three format errors. | No fallback model. Its always mode retries forever. |
 | **Why** | One temporary API failure should not end a long task. | Retry, hand format errors back, name the exit. | The log is the truth, so recovery replays a fresh turn. |
-| **How: retry** | Backoff on 429, 408, 409, and 5xx. A server `retry-after` wins. | tenacity backoff, 4 to 60 seconds, 10 attempts. | An error event, then a fresh turn. |
-| **How: token handling** | Raise the output cap, continue, or compact on `prompt_too_long`. | None. Overflow aborts the run. | One overflow code: prune, then summarize. |
+| **How: retry** | Backoff on 429, 408, 409, 5xx; a server `retry-after` wins. | tenacity backoff, 10 attempts. | An error event after the failed turn closes, then a fresh one. |
+| **How: token handling** | Raise the output cap, continue after a `max_tokens` stop, or compact. | None. Overflow aborts the run. | One overflow code: prune, then summarize. |
 | **How: model fallback** | Fallback model after repeated overload (529). | None. | None. The retry turn rebuilds the same request. |
 
 ---

--- a/sections/11-error-recovery/README.zh-CN.md
+++ b/sections/11-error-recovery/README.zh-CN.md
@@ -158,10 +158,10 @@ Recovery 包住模型调用。loop 主体维持不变。
 | | Claude Code | mini-swe-agent | deepseek-harness |
 | --- | --- | --- | --- |
 | **Pros** | 针对性的恢复路径，救回的 run 比一概重试更多。 | 只有三条路径要维护，crash 也留得下完整轨迹。 | 每次重试都写进 log，session 续跑后也知道自己重试过什么。 |
-| **Cons** | 要维护的分支与界限更多。 | 救回的 run 较少，overflow 直接中止。 | 没有 fallback 模型。有一种模式会无上限地一直重试。 |
+| **Cons** | 要维护的分支与界限更多。 | 救回的 run 较少。overflow 会中止，连续三次格式错误也会。 | 没有 fallback 模型。always 模式会无上限地一直重试。 |
 | **Why** | 一次暂时的 API 失败不该终结长任务。 | 重试、把格式错误还给模型，其余具名退出。 | log 才是事实，所以恢复是重开一个 turn 重放。 |
 | **How: retry** | 带退避重试 429、408、409 和 5xx，`retry-after` 优先。 | tenacity 退避 4 到 60 秒，最多 10 次。 | 失败的 turn 收掉后发一则错误事件，接着开新的 turn。 |
-| **How: token handling** | 提高输出上限、续写，或在 `prompt_too_long` 时压缩。 | 没有，overflow 直接中止 run。 | 一个统一的 overflow 代码，先修剪再摘要。 |
+| **How: token handling** | 提高输出上限、在 `max_tokens` 停止后续写，或压缩。 | 没有，overflow 直接中止 run。 | 一个统一的 overflow 代码，先修剪再摘要。 |
 | **How: model fallback** | 反复过载（529）后改用 fallback 模型。 | 没有。 | 没有。重试的 turn 会重建同一个请求。 |
 
 ---

--- a/sections/11-error-recovery/README.zh-CN.md
+++ b/sections/11-error-recovery/README.zh-CN.md
@@ -155,14 +155,14 @@ response = recovery.with_retry(
 
 Recovery 包住模型调用。loop 主体维持不变。
 
-| | Claude Code | mini-swe-agent |
-| --- | --- | --- |
-| **Pros** | 针对性的恢复路径救回的 run 比一概重试更多。 | 只有三条路径要维护。就算 crash，磁盘上也留有完整轨迹。 |
-| **Cons** | 要维护的分支与界限更多。 | 救回的 run 较少。context overflow 直接中止，连续三次格式错误也会结束 run。 |
-| **Why** | 一次暂时的 API 失败不该终结长任务。 | 只留三条路：暂时性错误就重试、格式错误还给模型、其余带着具名状态退出。 |
-| **How: retry** | 带退避重试 429、408、409 和 5xx，`retry-after` 优先。 | tenacity 退避 4 到 60 秒，最多 10 次。救不回的错误直接跳过。 |
-| **How: token handling** | 提高输出 token、在 `max_tokens` 停止后续写，或在 `prompt_too_long` 时压缩。 | 没有，context overflow 直接中止 run。 |
-| **How: model fallback** | 反复过载（529）后改用 fallback。后台来源的 529 重试次数有限制。 | 没有。 |
+| | Claude Code | mini-swe-agent | deepseek-harness |
+| --- | --- | --- | --- |
+| **Pros** | 针对性的恢复路径，救回的 run 比一概重试更多。 | 只有三条路径要维护，crash 也留得下完整轨迹。 | 每次重试都写进 log，session 续跑后也知道自己重试过什么。 |
+| **Cons** | 要维护的分支与界限更多。 | 救回的 run 较少，overflow 直接中止。 | 没有 fallback 模型。有一种模式会无上限地一直重试。 |
+| **Why** | 一次暂时的 API 失败不该终结长任务。 | 重试、把格式错误还给模型，其余具名退出。 | log 才是事实，所以恢复是重开一个 turn 重放。 |
+| **How: retry** | 带退避重试 429、408、409 和 5xx，`retry-after` 优先。 | tenacity 退避 4 到 60 秒，最多 10 次。 | 失败的 turn 收掉后发一则错误事件，接着开新的 turn。 |
+| **How: token handling** | 提高输出上限、续写，或在 `prompt_too_long` 时压缩。 | 没有，overflow 直接中止 run。 | 一个统一的 overflow 代码，先修剪再摘要。 |
+| **How: model fallback** | 反复过载（529）后改用 fallback 模型。 | 没有。 | 没有。重试的 turn 会重建同一个请求。 |
 
 ---
 
@@ -202,6 +202,9 @@ uv run python sections/11-error-recovery/src/demo.py  # live demo, needs a key
   `services/api/withRetry.ts`、`query.ts`、`services/api/claude.ts`、`services/api/errors.ts`、`query/tokenBudget.ts`、`utils/context.ts`。
 - [mini-swe-agent source](https://github.com/swe-agent/mini-swe-agent)：
   `models/utils/retry.py`、`models/litellm_model.py`、`agents/default.py` 的 `run()` 与 `max_consecutive_format_errors`。
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness)（`dsh-v0.1.0-rc.7`）：
+  `packages/llm/llm-retry/README.md`、`packages/llm/llm-retry/src/types.ts`、`packages/core/agent-loop/src/agent.ts`、
+  `docs/subsystems/llm-streaming.md`、`docs/subsystems/core.md`、`docs/subsystems/persistence.md`。
 - [ai-agent-book · 第 5 章](https://github.com/bojieli/ai-agent-book/blob/main/book/chapter5.md)（《深入理解 AI Agent》，李博杰，以中文原版为准）：
   四层失败分类、用 tool 加参数做 loop fingerprint、idle watchdog、`tool_result` 成对修补以及产品与训练数据两套标准、
   分级恢复加错误隔离，还有防死亡螺旋的那几招。它的脚注 ch5-3 说这套分类来自对生产环境 agent 的研究（其中包含 Claude Code），

--- a/sections/11-error-recovery/README.zh-TW.md
+++ b/sections/11-error-recovery/README.zh-TW.md
@@ -158,10 +158,10 @@ Recovery 包住模型呼叫。loop 主體維持不變。
 | | Claude Code | mini-swe-agent | deepseek-harness |
 | --- | --- | --- | --- |
 | **Pros** | 針對性的復原路徑，救回的 run 比一概重試更多。 | 只有三條路徑要維護，crash 也留得下完整軌跡。 | 每次重試都寫進 log，session 續跑後也知道自己重試過什麼。 |
-| **Cons** | 要維護的分支與界限更多。 | 救回的 run 較少，overflow 直接中止。 | 沒有 fallback 模型。有一種模式會無上限地一直重試。 |
+| **Cons** | 要維護的分支與界限更多。 | 救回的 run 較少。overflow 會中止，連續三次格式錯誤也會。 | 沒有 fallback 模型。always 模式會無上限地一直重試。 |
 | **Why** | 一次暫時的 API 失敗不該終結長任務。 | 重試、把格式錯誤還給模型，其餘具名退出。 | log 才是事實，所以復原是重開一個 turn 重放。 |
 | **How: retry** | 帶退避重試 429、408、409 和 5xx，`retry-after` 優先。 | tenacity 退避 4 到 60 秒，最多 10 次。 | 失敗的 turn 收掉後發一則錯誤事件，接著開新的 turn。 |
-| **How: token handling** | 提高輸出上限、續寫，或在 `prompt_too_long` 時壓縮。 | 沒有，overflow 直接中止 run。 | 一個統一的 overflow 代碼，先修剪再摘要。 |
+| **How: token handling** | 提高輸出上限、在 `max_tokens` 停止後續寫，或壓縮。 | 沒有，overflow 直接中止 run。 | 一個統一的 overflow 代碼，先修剪再摘要。 |
 | **How: model fallback** | 反覆過載（529）後改用 fallback 模型。 | 沒有。 | 沒有。重試的 turn 會重建同一個請求。 |
 
 ---

--- a/sections/11-error-recovery/README.zh-TW.md
+++ b/sections/11-error-recovery/README.zh-TW.md
@@ -155,14 +155,14 @@ response = recovery.with_retry(
 
 Recovery 包住模型呼叫。loop 主體維持不變。
 
-| | Claude Code | mini-swe-agent |
-| --- | --- | --- |
-| **Pros** | 針對性的復原路徑救回的 run 比一概重試更多。 | 只有三條路徑要維護。就算 crash，硬碟上也留有完整軌跡。 |
-| **Cons** | 要維護的分支與界限更多。 | 救回的 run 較少。context overflow 直接中止，連續三次格式錯誤也會結束 run。 |
-| **Why** | 一次暫時的 API 失敗不該終結長任務。 | 只留三條路：暫時性錯誤就重試、格式錯誤還給模型、其餘帶著具名狀態退出。 |
-| **How: retry** | 帶退避重試 429、408、409 和 5xx，`retry-after` 優先。 | tenacity 退避 4 到 60 秒，最多 10 次。救不回的錯誤直接跳過。 |
-| **How: token handling** | 提高輸出 token、在`max_tokens` 停止後續寫，或在 `prompt_too_long` 時壓縮。 | 沒有，context overflow 直接中止 run。 |
-| **How: model fallback** | 反覆過載（529）後改用 fallback。背景來源的 529 重試次數有限制。 | 沒有。 |
+| | Claude Code | mini-swe-agent | deepseek-harness |
+| --- | --- | --- | --- |
+| **Pros** | 針對性的復原路徑，救回的 run 比一概重試更多。 | 只有三條路徑要維護，crash 也留得下完整軌跡。 | 每次重試都寫進 log，session 續跑後也知道自己重試過什麼。 |
+| **Cons** | 要維護的分支與界限更多。 | 救回的 run 較少，overflow 直接中止。 | 沒有 fallback 模型。有一種模式會無上限地一直重試。 |
+| **Why** | 一次暫時的 API 失敗不該終結長任務。 | 重試、把格式錯誤還給模型，其餘具名退出。 | log 才是事實，所以復原是重開一個 turn 重放。 |
+| **How: retry** | 帶退避重試 429、408、409 和 5xx，`retry-after` 優先。 | tenacity 退避 4 到 60 秒，最多 10 次。 | 失敗的 turn 收掉後發一則錯誤事件，接著開新的 turn。 |
+| **How: token handling** | 提高輸出上限、續寫，或在 `prompt_too_long` 時壓縮。 | 沒有，overflow 直接中止 run。 | 一個統一的 overflow 代碼，先修剪再摘要。 |
+| **How: model fallback** | 反覆過載（529）後改用 fallback 模型。 | 沒有。 | 沒有。重試的 turn 會重建同一個請求。 |
 
 ---
 
@@ -202,6 +202,9 @@ uv run python sections/11-error-recovery/src/demo.py  # live demo, needs a key
   `services/api/withRetry.ts`、`query.ts`、`services/api/claude.ts`、`services/api/errors.ts`、`query/tokenBudget.ts`、`utils/context.ts`。
 - [mini-swe-agent source](https://github.com/swe-agent/mini-swe-agent)：
   `models/utils/retry.py`、`models/litellm_model.py`、`agents/default.py` 的 `run()` 與 `max_consecutive_format_errors`。
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness)（`dsh-v0.1.0-rc.7`）：
+  `packages/llm/llm-retry/README.md`、`packages/llm/llm-retry/src/types.ts`、`packages/core/agent-loop/src/agent.ts`、
+  `docs/subsystems/llm-streaming.md`、`docs/subsystems/core.md`、`docs/subsystems/persistence.md`。
 - [ai-agent-book · 第 5 章](https://github.com/bojieli/ai-agent-book/blob/main/book/chapter5.md)（《深入理解 AI Agent》，李博杰，以中文原版為準）：
   四層失敗分類、用 tool 加參數做 loop fingerprint、idle watchdog、`tool_result` 成對修補以及產品與訓練資料兩套標準、
   分級復原加錯誤隔離，還有防死亡螺旋的那幾招。它的註腳 ch5-3 說這套分類來自對生產環境 agent 的研究（其中包含 Claude Code），


### PR DESCRIPTION
Closes #75. Part of PRD #72.

## What changed

- Sections 10 and 11 each gain a deepseek-harness column, mirrored in `README.zh-TW.md` and `README.zh-CN.md`.
- Section 10 adds `src/registry.py`: sections registered with an order number, an agent scope that shadows a global section by name, and strict `{{variable}}` rendering that raises on an unknown name. Contrast demo, not wired into `assemble()`, so later sections carry `prompt.py` forward.
- Section 9 gets nothing, per the PRD.
- Existing cells were tightened where a new column pushed a row past 180 characters.

## Verification

- `python sections/10-system-prompt/src/test.py` and `sections/11-error-recovery/src/test.py` pass offline.
- No line over 180 characters, no em or en dashes, table column counts consistent across all three languages.