### PR TITLE
dsh batch 4: sections 12-14 columns

### DIFF
--- a/sections/12-task-system/README.md
+++ b/sections/12-task-system/README.md
@@ -78,15 +78,15 @@ The loop does not change. The model calls `TaskCreate`, `TaskUpdate`, `TaskGet`,
 
 How the durable task graph is shaped and advanced.
 
-| | Claude Code |
-| --- | --- |
-| **Pros** | File-backed tasks survive crashes and support multiple workers. |
-| **Cons** | Costs filesystem reads, writes, and locks. Records need validation to catch missing or circular dependencies. |
-| **Why** | An in-memory todo list dies with the process. The plan must survive sessions and crashes, with ordering stored as data. |
-| **How: task record** | A JSON file per task. Fields cover id, subject, status, owner, and the dependency edges. |
-| **How: dependencies** | `blockedBy` and `blocks` edges. A task can be created already blocked. A claim is refused until every blocker completes. |
-| **How: persistence** | One file per task, plus a high-water mark for the largest issued id. A switch decides whether durable tasks replace in-memory todos. |
-| **How: lifecycle** | `pending -> in_progress -> completed`. A file lock serializes claims. Ownership is cleared when a teammate exits. |
+| | Claude Code | deepseek-harness |
+| --- | --- | --- |
+| **Pros** | File-backed tasks survive crashes and support many workers. | Task state rides the session log, so replay, fork, and resume come free. |
+| **Cons** | Costs reads, writes, and locks. Records need validation. | No dependency edges and no claim gate. One goal per session. |
+| **Why** | An in-memory list dies with the process, so the plan must outlive it. | The session log is the only source of truth, so task state is events. |
+| **How: task record** | A JSON file per task: id, subject, status, owner, edges. | A whole-list snapshot, plus one goal with a phase and a round cap. |
+| **How: dependencies** | `blockedBy` and `blocks` edges. A claim waits for every blocker. | None. List order is the only ordering. |
+| **How: persistence** | One file per task, plus a mark for the largest issued id. | Session events, replayed on load. Self-continuation is never stored. |
+| **How: lifecycle** | `pending -> in_progress -> completed`, with a lock on claims. | Goal phases: active, paused, blocked, complete. Edits need a human. |
 
 ---
 
@@ -118,4 +118,7 @@ uv run python sections/12-task-system/src/demo.py  # live demo, needs a key
 ## Sources
 
 - [Claude Code source](https://github.com/yasasbanukaofficial/claude-code): `utils/tasks.ts`, `Task.ts`, and the `Task*Tool/` directories.
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness) at `dsh-v0.1.0-rc.7`:
+  `packages/goal/goal/src/index.ts`, `packages/goal/goal-round-driver/README.md`, `packages/todo/tool-todo/README.md`,
+  `docs/subsystems/goal.md`, `docs/persistence-catalog.md`.
 - [learn-claude-code · s12_task_system](https://github.com/shareAI-lab/learn-claude-code): section framing.

--- a/sections/12-task-system/README.md
+++ b/sections/12-task-system/README.md
@@ -84,8 +84,8 @@ How the durable task graph is shaped and advanced.
 | **Cons** | Costs reads, writes, and locks. Records need validation. | No dependency edges and no claim gate. One goal per session. |
 | **Why** | An in-memory list dies with the process, so the plan must outlive it. | The session log is the only source of truth, so task state is events. |
 | **How: task record** | A JSON file per task: id, subject, status, owner, edges. | A whole-list snapshot, plus one goal with a phase and a round cap. |
-| **How: dependencies** | `blockedBy` and `blocks` edges. A claim waits for every blocker. | None. List order is the only ordering. |
-| **How: persistence** | One file per task, plus a mark for the largest issued id. | Session events, replayed on load. Self-continuation is never stored. |
+| **How: dependencies** | `blockedBy` and `blocks` edges. A claim is refused until blockers finish. | None. List order is the only ordering. |
+| **How: persistence** | One file per task. A switch decides whether these replace todos. | Session events, replayed on load. Self-continuation is never stored. |
 | **How: lifecycle** | `pending -> in_progress -> completed`, with a lock on claims. | Goal phases: active, paused, blocked, complete. Edits need a human. |
 
 ---

--- a/sections/12-task-system/README.md
+++ b/sections/12-task-system/README.md
@@ -85,7 +85,7 @@ How the durable task graph is shaped and advanced.
 | **Why** | An in-memory list dies with the process, so the plan must outlive it. | The session log is the only source of truth, so task state is events. |
 | **How: task record** | A JSON file per task: id, subject, status, owner, edges. | A whole-list snapshot, plus one goal with a phase and a round cap. |
 | **How: dependencies** | `blockedBy` and `blocks` edges. A claim is refused until blockers finish. | None. List order is the only ordering. |
-| **How: persistence** | One file per task. A switch decides whether these replace todos. | Session events, replayed on load. Self-continuation is never stored. |
+| **How: persistence** | One file per task, plus the largest issued id. A switch can replace todos. | Session events, replayed on load. Self-continuation is never stored. |
 | **How: lifecycle** | `pending -> in_progress -> completed`, with a lock on claims. | Goal phases: active, paused, blocked, complete. Edits need a human. |
 
 ---

--- a/sections/12-task-system/README.zh-CN.md
+++ b/sections/12-task-system/README.zh-CN.md
@@ -78,15 +78,15 @@ loop 没有改变。model 就像调用其他任何工具一样，调用 `TaskCre
 
 持久的 task 图如何塑形，又如何推进。
 
-| | Claude Code |
-| --- | --- |
-| **Pros** | 以文件为后盾的 task 能在宕机后存活，也支持多个 worker。 |
-| **Cons** | 代价是文件系统的读、写和锁。记录也要验证，避免依赖关系指到不存在的 task，或互相等待。 |
-| **Why** | 放在内存里的 todo list 会跟着 process 一起消失。计划必须撑过 session 和宕机，顺序也要用数据来表示。 |
-| **How: task record** | 每个 task 一个 JSON 文件。字段涵盖 id、subject、status、owner，以及依赖关系的边。 |
-| **How: dependencies** | `blockedBy` 和 `blocks` 两种边。可以直接建立被阻挡的 task。阻挡条件全部完成前，认领会被拒绝。 |
-| **How: persistence** | 每个 task 一个文件，外加一个 high-water mark 记录已发出的最大 id。一个开关决定要不要用持久 task 取代 in-memory todo。 |
-| **How: lifecycle** | `pending -> in_progress -> completed`。一把 file lock 让认领动作序列化。teammate 离开时会清掉 ownership。 |
+| | Claude Code | deepseek-harness |
+| --- | --- | --- |
+| **Pros** | 以文件为后盾的 task 能在宕机后存活，也支持多个 worker。 | task 状态就写在 session log 里，重放、fork、续跑全都免费附送。 |
+| **Cons** | 代价是文件系统的读、写和锁，记录还要验证。 | 没有依赖关系的边，也没有认领机制。一个 session 只有一个 goal。 |
+| **Why** | 放在内存里的清单会跟着 process 消失，计划得活得比它久。 | session log 是唯一的事实来源，所以 task 状态就是一连串事件。 |
+| **How: task record** | 每个 task 一个 JSON 文件：id、subject、status、owner 和边。 | 一份整份清单的快照，加上一个 goal，带 phase 和轮数上限。 |
+| **How: dependencies** | `blockedBy` 和 `blocks` 两种边。阻挡条件全部完成前不能认领。 | 没有。顺序就只看清单本身的排列。 |
+| **How: persistence** | 每个 task 一个文件，外加一个记号记住已发出的最大 id。 | session 事件，加载时重放。自动续跑的开关从不写进磁盘。 |
+| **How: lifecycle** | `pending -> in_progress -> completed`，认领动作靠一把锁序列化。 | goal 的 phase：active、paused、blocked、complete。要改得由人出手。 |
 
 ---
 
@@ -118,4 +118,7 @@ uv run python sections/12-task-system/src/demo.py  # live demo, needs a key
 ## 来源
 
 - [Claude Code source](https://github.com/yasasbanukaofficial/claude-code)：`utils/tasks.ts`、`Task.ts`，以及 `Task*Tool/` 目录。
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness)（`dsh-v0.1.0-rc.7`）：
+  `packages/goal/goal/src/index.ts`、`packages/goal/goal-round-driver/README.md`、`packages/todo/tool-todo/README.md`、
+  `docs/subsystems/goal.md`、`docs/persistence-catalog.md`。
 - [learn-claude-code · s12_task_system](https://github.com/shareAI-lab/learn-claude-code)：章节框架。

--- a/sections/12-task-system/README.zh-CN.md
+++ b/sections/12-task-system/README.zh-CN.md
@@ -84,8 +84,8 @@ loop 没有改变。model 就像调用其他任何工具一样，调用 `TaskCre
 | **Cons** | 代价是文件系统的读、写和锁，记录还要验证。 | 没有依赖关系的边，也没有认领机制。一个 session 只有一个 goal。 |
 | **Why** | 放在内存里的清单会跟着 process 消失，计划得活得比它久。 | session log 是唯一的事实来源，所以 task 状态就是一连串事件。 |
 | **How: task record** | 每个 task 一个 JSON 文件：id、subject、status、owner 和边。 | 一份整份清单的快照，加上一个 goal，带 phase 和轮数上限。 |
-| **How: dependencies** | `blockedBy` 和 `blocks` 两种边。阻挡条件全部完成前不能认领。 | 没有。顺序就只看清单本身的排列。 |
-| **How: persistence** | 每个 task 一个文件，外加一个记号记住已发出的最大 id。 | session 事件，加载时重放。自动续跑的开关从不写进磁盘。 |
+| **How: dependencies** | `blockedBy` 和 `blocks` 两种边。阻挡条件没清完，认领会被拒绝。 | 没有。顺序就只看清单本身的排列。 |
+| **How: persistence** | 每个 task 一个文件。一个开关决定要不要用它取代 todo list。 | session 事件，加载时重放。自动续跑的开关从不写进磁盘。 |
 | **How: lifecycle** | `pending -> in_progress -> completed`，认领动作靠一把锁序列化。 | goal 的 phase：active、paused、blocked、complete。要改得由人出手。 |
 
 ---

--- a/sections/12-task-system/README.zh-CN.md
+++ b/sections/12-task-system/README.zh-CN.md
@@ -85,7 +85,7 @@ loop 没有改变。model 就像调用其他任何工具一样，调用 `TaskCre
 | **Why** | 放在内存里的清单会跟着 process 消失，计划得活得比它久。 | session log 是唯一的事实来源，所以 task 状态就是一连串事件。 |
 | **How: task record** | 每个 task 一个 JSON 文件：id、subject、status、owner 和边。 | 一份整份清单的快照，加上一个 goal，带 phase 和轮数上限。 |
 | **How: dependencies** | `blockedBy` 和 `blocks` 两种边。阻挡条件没清完，认领会被拒绝。 | 没有。顺序就只看清单本身的排列。 |
-| **How: persistence** | 每个 task 一个文件。一个开关决定要不要用它取代 todo list。 | session 事件，加载时重放。自动续跑的开关从不写进磁盘。 |
+| **How: persistence** | 每个 task 一个文件，外加已发出的最大 id。一个开关决定要不要取代 todo list。 | session 事件，加载时重放。自动续跑的开关从不写进磁盘。 |
 | **How: lifecycle** | `pending -> in_progress -> completed`，认领动作靠一把锁序列化。 | goal 的 phase：active、paused、blocked、complete。要改得由人出手。 |
 
 ---

--- a/sections/12-task-system/README.zh-TW.md
+++ b/sections/12-task-system/README.zh-TW.md
@@ -78,15 +78,15 @@ loop 沒有改變。model 就像呼叫其他任何工具一樣，呼叫 `TaskCre
 
 持久的 task 圖如何塑形，又如何推進。
 
-| | Claude Code |
-| --- | --- |
-| **Pros** | 以檔案為後盾的 task 能在當機後存活，也支援多個 worker。 |
-| **Cons** | 代價是檔案系統的讀、寫和鎖。記錄也要驗證，避免相依關係指到不存在的 task，或互相等待。 |
-| **Why** | 放在記憶體裡的 todo list 會跟著 process 一起消失。計畫必須撐過 session 和當機，順序也要用資料來表示。 |
-| **How: task record** | 每個 task 一個 JSON 檔。欄位涵蓋 id、subject、status、owner，以及相依關係的邊。 |
-| **How: dependencies** | `blockedBy` 和 `blocks` 兩種邊。可以直接建立被阻擋的 task。阻擋條件全部完成前，認領會被拒絕。 |
-| **How: persistence** | 每個 task 一個檔，外加一個 high-water mark 記錄已發出的最大 id。一個開關決定要不要用持久 task 取代 in-memory todo。 |
-| **How: lifecycle** | `pending -> in_progress -> completed`。一把 file lock 讓認領動作序列化。teammate 離開時會清掉 ownership。 |
+| | Claude Code | deepseek-harness |
+| --- | --- | --- |
+| **Pros** | 以檔案為後盾的 task 能在當機後存活，也支援多個 worker。 | task 狀態就寫在 session log 裡，重放、fork、續跑全都免費附送。 |
+| **Cons** | 代價是檔案系統的讀、寫和鎖，記錄還要驗證。 | 沒有相依關係的邊，也沒有認領機制。一個 session 只有一個 goal。 |
+| **Why** | 放在記憶體裡的清單會跟著 process 消失，計畫得活得比它久。 | session log 是唯一的事實來源，所以 task 狀態就是一連串事件。 |
+| **How: task record** | 每個 task 一個 JSON 檔：id、subject、status、owner 和邊。 | 一份整份清單的快照，加上一個 goal，帶 phase 和輪數上限。 |
+| **How: dependencies** | `blockedBy` 和 `blocks` 兩種邊。阻擋條件全部完成前不能認領。 | 沒有。順序就只看清單本身的排列。 |
+| **How: persistence** | 每個 task 一個檔，外加一個記號記住已發出的最大 id。 | session 事件，載入時重放。自動續跑的開關從不寫進硬碟。 |
+| **How: lifecycle** | `pending -> in_progress -> completed`，認領動作靠一把鎖序列化。 | goal 的 phase：active、paused、blocked、complete。要改得由人出手。 |
 
 ---
 
@@ -118,4 +118,7 @@ uv run python sections/12-task-system/src/demo.py  # live demo, needs a key
 ## 出處
 
 - [Claude Code source](https://github.com/yasasbanukaofficial/claude-code)：`utils/tasks.ts`、`Task.ts`，以及 `Task*Tool/` 目錄。
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness)（`dsh-v0.1.0-rc.7`）：
+  `packages/goal/goal/src/index.ts`、`packages/goal/goal-round-driver/README.md`、`packages/todo/tool-todo/README.md`、
+  `docs/subsystems/goal.md`、`docs/persistence-catalog.md`。
 - [learn-claude-code · s12_task_system](https://github.com/shareAI-lab/learn-claude-code)：章節框架。

--- a/sections/12-task-system/README.zh-TW.md
+++ b/sections/12-task-system/README.zh-TW.md
@@ -84,8 +84,8 @@ loop 沒有改變。model 就像呼叫其他任何工具一樣，呼叫 `TaskCre
 | **Cons** | 代價是檔案系統的讀、寫和鎖，記錄還要驗證。 | 沒有相依關係的邊，也沒有認領機制。一個 session 只有一個 goal。 |
 | **Why** | 放在記憶體裡的清單會跟著 process 消失，計畫得活得比它久。 | session log 是唯一的事實來源，所以 task 狀態就是一連串事件。 |
 | **How: task record** | 每個 task 一個 JSON 檔：id、subject、status、owner 和邊。 | 一份整份清單的快照，加上一個 goal，帶 phase 和輪數上限。 |
-| **How: dependencies** | `blockedBy` 和 `blocks` 兩種邊。阻擋條件全部完成前不能認領。 | 沒有。順序就只看清單本身的排列。 |
-| **How: persistence** | 每個 task 一個檔，外加一個記號記住已發出的最大 id。 | session 事件，載入時重放。自動續跑的開關從不寫進硬碟。 |
+| **How: dependencies** | `blockedBy` 和 `blocks` 兩種邊。阻擋條件沒清完，認領會被拒絕。 | 沒有。順序就只看清單本身的排列。 |
+| **How: persistence** | 每個 task 一個檔。一個開關決定要不要用它取代 todo list。 | session 事件，載入時重放。自動續跑的開關從不寫進硬碟。 |
 | **How: lifecycle** | `pending -> in_progress -> completed`，認領動作靠一把鎖序列化。 | goal 的 phase：active、paused、blocked、complete。要改得由人出手。 |
 
 ---

--- a/sections/12-task-system/README.zh-TW.md
+++ b/sections/12-task-system/README.zh-TW.md
@@ -85,7 +85,7 @@ loop 沒有改變。model 就像呼叫其他任何工具一樣，呼叫 `TaskCre
 | **Why** | 放在記憶體裡的清單會跟著 process 消失，計畫得活得比它久。 | session log 是唯一的事實來源，所以 task 狀態就是一連串事件。 |
 | **How: task record** | 每個 task 一個 JSON 檔：id、subject、status、owner 和邊。 | 一份整份清單的快照，加上一個 goal，帶 phase 和輪數上限。 |
 | **How: dependencies** | `blockedBy` 和 `blocks` 兩種邊。阻擋條件沒清完，認領會被拒絕。 | 沒有。順序就只看清單本身的排列。 |
-| **How: persistence** | 每個 task 一個檔。一個開關決定要不要用它取代 todo list。 | session 事件，載入時重放。自動續跑的開關從不寫進硬碟。 |
+| **How: persistence** | 每個 task 一個檔，外加已發出的最大 id。一個開關決定要不要取代 todo list。 | session 事件，載入時重放。自動續跑的開關從不寫進硬碟。 |
 | **How: lifecycle** | `pending -> in_progress -> completed`，認領動作靠一把鎖序列化。 | goal 的 phase：active、paused、blocked、complete。要改得由人出手。 |
 
 ---

--- a/sections/13-background-execution/README.md
+++ b/sections/13-background-execution/README.md
@@ -124,7 +124,7 @@ How each agent moves work off the loop and reports completion.
 | | Claude Code | deepseek-harness |
 | --- | --- | --- |
 | **Pros** | Throughput improves and idle waits go away. A plain wait blocks nothing. | One registry serves shell, terminal, and child agents alike. |
-| **Cons** | Results arrive late and out of order. The runtime tracks state and cleanup. | Waking an idle agent spends model turns, so it needs a budget. |
+| **Cons** | Results can arrive late and out of order. The runtime tracks state. | Waking an idle agent spends model turns, so it needs a budget. |
 | **Why** | One slow command must not freeze the whole agent. | A finished job must reach the model without the model polling. |
 | **How: off-loop primitive** | Background shell and agent tasks. The subprocess runs on, output redirected. | Any tool takes a run-in-background flag and returns a job id. |
 | **How: notification** | A `<task_notification>` message through one shared queue. | One notice per job. First finish wins, and duplicates are suppressed. |

--- a/sections/13-background-execution/README.md
+++ b/sections/13-background-execution/README.md
@@ -121,14 +121,14 @@ The placeholder is the book author's own design. No other source describes it.
 
 How each agent moves work off the loop and reports completion.
 
-| | Claude Code |
-| --- | --- |
-| **Pros** | Throughput improves and idle waits go away. Even a plain wait is non-blocking and holds no shell process. |
-| **Cons** | Results can arrive later and out of order. The runtime needs task state, notifications, and cleanup. |
-| **Why** | One slow command must not freeze the whole agent. Slow work can run while the agent does something else. |
-| **How: off-loop primitive** | Background shell tasks and background agent tasks, memory consolidation included. The subprocess keeps running with output redirected. |
-| **How: notification** | A `<task_notification>` message. Completions go through one shared queue, and the runtime tracks each task's state. |
-| **How: re-entry** | The queue drains notifications between turns, with `now`, `next`, and `later` priorities. |
+| | Claude Code | deepseek-harness |
+| --- | --- | --- |
+| **Pros** | Throughput improves and idle waits go away. A plain wait blocks nothing. | One registry serves shell, terminal, and child agents alike. |
+| **Cons** | Results arrive late and out of order. The runtime tracks state and cleanup. | Waking an idle agent spends model turns, so it needs a budget. |
+| **Why** | One slow command must not freeze the whole agent. | A finished job must reach the model without the model polling. |
+| **How: off-loop primitive** | Background shell and agent tasks. The subprocess runs on, output redirected. | Any tool takes a run-in-background flag and returns a job id. |
+| **How: notification** | A `<task_notification>` message through one shared queue. | One notice per job. First finish wins, and duplicates are suppressed. |
+| **How: re-entry** | The queue drains between turns, at `now`, `next`, and `later` priorities. | A busy agent gets it next step. An idle one is woken, within a cap. |
 
 ---
 
@@ -165,6 +165,9 @@ uv run python sections/13-background-execution/src/demo.py  # live demo, needs a
 - [Claude Code task sources](https://github.com/yasasbanukaofficial/claude-code): `tasks/LocalShellTask/`, `tasks/DreamTask/`.
 - [Claude Code tool and queue sources](https://github.com/yasasbanukaofficial/claude-code):
   `tools/BashTool/BashTool.tsx`, `tools/SleepTool/prompt.ts`, `utils/task/framework.ts`, `utils/messageQueueManager.ts`.
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness) at `dsh-v0.1.0-rc.7`:
+  `packages/jobs/jobs/src/index.ts`, `packages/jobs/jobs-local/src/index.ts`, `packages/jobs/tool-jobs/README.md`,
+  `docs/subsystems/jobs.md`, `docs/tool-catalog.md`.
 - [learn-claude-code · s13_background_tasks](https://github.com/shareAI-lab/learn-claude-code): section framing.
 - [ai-agent-book](https://github.com/bojieli/ai-agent-book): `book/chapter4.md`, Chinese original canonical.
   Idempotency and cancel semantics, initiate-and-complete naming, event triage at safe points, interrupt placeholders, batched-event attention.

--- a/sections/13-background-execution/README.md
+++ b/sections/13-background-execution/README.md
@@ -124,7 +124,7 @@ How each agent moves work off the loop and reports completion.
 | | Claude Code | deepseek-harness |
 | --- | --- | --- |
 | **Pros** | Throughput improves and idle waits go away. A plain wait blocks nothing. | One registry serves shell, terminal, and child agents alike. |
-| **Cons** | Results can arrive late and out of order. The runtime tracks state. | Waking an idle agent spends model turns, so it needs a budget. |
+| **Cons** | Results can arrive late and out of order. The runtime tracks state and cleanup. | Waking an idle agent spends turns, so it needs a budget. |
 | **Why** | One slow command must not freeze the whole agent. | A finished job must reach the model without the model polling. |
 | **How: off-loop primitive** | Background shell and agent tasks. The subprocess runs on, output redirected. | Any tool takes a run-in-background flag and returns a job id. |
 | **How: notification** | A `<task_notification>` message through one shared queue. | One notice per job. First finish wins, and duplicates are suppressed. |

--- a/sections/13-background-execution/README.zh-CN.md
+++ b/sections/13-background-execution/README.zh-CN.md
@@ -121,14 +121,14 @@ ai-agent-book 的做法是当场补：对同一个 id 补一则占位用的 `too
 
 各个 agent 如何把工作移出 loop，又如何汇报完成。
 
-| | Claude Code |
-| --- | --- |
-| **Pros** | 吞吐量提升，也不再有空闲的等待。连单纯的等待都是非阻塞的，不会占住一个 shell process。 |
-| **Cons** | 结果可能较晚抵达，顺序也可能颠倒。runtime 需要 task 状态、notification 和清理机制。 |
-| **Why** | 一个跑很久的指令不该冻结整个 agent。这种工作可以趁 agent 做别的事时继续跑。 |
-| **How: off-loop primitive** | 后台 shell task 和后台 agent task，连记忆整合都用这种方式跑。subprocess 会继续执行，输出被重定向。 |
-| **How: notification** | 一则 `<task_notification>` 消息。完成消息走同一个共享 queue，runtime 会追踪每个 task 的状态。 |
-| **How: re-entry** | notification 在 turn 之间从 queue 收进对话，分 `now`、`next`、`later` 三种优先级。 |
+| | Claude Code | deepseek-harness |
+| --- | --- | --- |
+| **Pros** | 吞吐量提升，也不再有空闲的等待。单纯的等待不会卡住任何东西。 | 同一个登记处管 shell、终端和 child agent，收结果和喊停都走同一条路。 |
+| **Cons** | 结果可能较晚抵达，顺序也可能颠倒。runtime 要顾状态和清理。 | 叫醒闲着的 agent 会花掉模型轮次，所以得给它一个额度。 |
+| **Why** | 一个跑很久的指令不该冻结整个 agent。 | 工作跑完要让模型知道，而不是叫模型自己一直去问。 |
+| **How: off-loop primitive** | 后台 shell task 和后台 agent task，subprocess 继续跑，输出被重定向。 | 任何工具都能带一个「丢到后台跑」的标志，返回一个 job id。 |
+| **How: notification** | 一则 `<task_notification>` 消息，完成消息走同一个共享 queue。 | 每个 job 一则通知。谁先结束谁算数，重复的会被压下来。 |
+| **How: re-entry** | notification 在 turn 之间收进对话，分 `now`、`next`、`later` 三种优先级。 | agent 忙的话下一步就收到；闲着就叫醒它，次数有上限。 |
 
 ---
 
@@ -165,6 +165,9 @@ uv run python sections/13-background-execution/src/demo.py  # live demo, needs a
 - [Claude Code task sources](https://github.com/yasasbanukaofficial/claude-code)：`tasks/LocalShellTask/`、`tasks/DreamTask/`。
 - [Claude Code tool and queue sources](https://github.com/yasasbanukaofficial/claude-code)：
   `tools/BashTool/BashTool.tsx`、`tools/SleepTool/prompt.ts`、`utils/task/framework.ts`、`utils/messageQueueManager.ts`。
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness)（`dsh-v0.1.0-rc.7`）：
+  `packages/jobs/jobs/src/index.ts`、`packages/jobs/jobs-local/src/index.ts`、`packages/jobs/tool-jobs/README.md`、
+  `docs/subsystems/jobs.md`、`docs/tool-catalog.md`。
 - [learn-claude-code · s13_background_tasks](https://github.com/shareAI-lab/learn-claude-code)：章节框架。
 - [ai-agent-book](https://github.com/bojieli/ai-agent-book)：`book/chapter4.md`，以中文原版为准。
   幂等性与取消语义、启动与完成分开命名、在安全点做 event 分类、打断占位、批次 event 的注意力稀释。

--- a/sections/13-background-execution/README.zh-TW.md
+++ b/sections/13-background-execution/README.zh-TW.md
@@ -121,14 +121,14 @@ ai-agent-book 的做法是當場補：對同一個 id 補一則佔位用的 `too
 
 各個 agent 如何把工作移出 loop，又如何回報完成。
 
-|                                   | Claude Code                                                                                      |
-| --------------------------------- | ------------------------------------------------------------------------------------------------ |
-| **Pros**                    | 吞吐量提升，也不再有閒置的等待。連單純的等待都是非阻塞的，不會佔住一個 shell process。           |
-| **Cons**                    | 結果可能較晚抵達，順序也可能顛倒。runtime 需要 task 狀態、notification 和清理機制。              |
-| **Why**                     | 一個跑很久的指令不該凍結整個 agent。這種工作可以趁 agent 做別的事時繼續跑。                      |
-| **How: off-loop primitive** | 背景 shell task 和背景 agent task，連記憶整併都用這種方式跑。subprocess 會繼續執行，輸出被轉導。 |
-| **How: notification**       | 一則`<task_notification>` 訊息。完成訊息走同一個共享 queue，runtime 會追蹤每個 task 的狀態。   |
-| **How: re-entry**           | notification 在 turn 之間從 queue 收進對話，分`now`、`next`、`later` 三種優先級。                 |
+| | Claude Code | deepseek-harness |
+| --- | --- | --- |
+| **Pros** | 吞吐量提升，也不再有閒置的等待。單純的等待不會卡住任何東西。 | 同一個登記處管 shell、終端機和 child agent，收結果和喊停都走同一條路。 |
+| **Cons** | 結果可能較晚抵達，順序也可能顛倒。runtime 要顧狀態和清理。 | 叫醒閒著的 agent 會花掉模型輪次，所以得給它一個額度。 |
+| **Why** | 一個跑很久的指令不該凍結整個 agent。 | 工作跑完要讓模型知道，而不是叫模型自己一直去問。 |
+| **How: off-loop primitive** | 背景 shell task 和背景 agent task，subprocess 繼續跑，輸出被轉導。 | 任何工具都能帶一個「丟到背景跑」的旗標，回傳一個 job id。 |
+| **How: notification** | 一則 `<task_notification>` 訊息，完成訊息走同一個共享 queue。 | 每個 job 一則通知。誰先結束誰算數，重複的會被壓下來。 |
+| **How: re-entry** | notification 在 turn 之間收進對話，分 `now`、`next`、`later` 三種優先級。 | agent 忙的話下一步就收到；閒著就叫醒它，次數有上限。 |
 
 ---
 
@@ -165,6 +165,9 @@ uv run python sections/13-background-execution/src/demo.py  # live demo, needs a
 - [Claude Code task sources](https://github.com/yasasbanukaofficial/claude-code)：`tasks/LocalShellTask/`、`tasks/DreamTask/`。
 - [Claude Code tool and queue sources](https://github.com/yasasbanukaofficial/claude-code)：
   `tools/BashTool/BashTool.tsx`、`tools/SleepTool/prompt.ts`、`utils/task/framework.ts`、`utils/messageQueueManager.ts`。
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness)（`dsh-v0.1.0-rc.7`）：
+  `packages/jobs/jobs/src/index.ts`、`packages/jobs/jobs-local/src/index.ts`、`packages/jobs/tool-jobs/README.md`、
+  `docs/subsystems/jobs.md`、`docs/tool-catalog.md`。
 - [learn-claude-code · s13_background_tasks](https://github.com/shareAI-lab/learn-claude-code)：章節框架。
 - [ai-agent-book](https://github.com/bojieli/ai-agent-book)：`book/chapter4.md`，以中文原版為準。
   冪等性與取消語義、啟動與完成分開命名、在安全點做 event 分類、打斷佔位、批次 event 的注意力稀釋。

--- a/sections/14-scheduling/README.md
+++ b/sections/14-scheduling/README.md
@@ -134,14 +134,14 @@ Section 19 covers the inbound push side.
 
 How each agent decides when to run scheduled work.
 
-| | Claude Code | Hermes Agent |
-| --- | --- | --- |
-| **Pros** | Simple and private. Durable schedules survive restart. | Fires unattended, no hosted service. Heartbeat files tell a dead ticker from a failing one. |
-| **Cons** | Only ticks while a session runs. Remote triggers need a hosted service and auth. | Needs a running gateway. The shared job store needs locks against double fire. |
-| **Why** | Assumes a local session is running. A hosted trigger covers firing with no local process. | The gateway is a server process, so schedules fire unattended. |
-| **How: trigger** | Cron, sleep, and remote triggers. A ticker checks entries on an interval. | Cron expressions on a gateway tick, in the user's configured timezone. |
-| **How: durability** | Session, or durable in a JSON file with a lock across open sessions. | A JSON job store shared by CLI and gateway, with locks and an atomic claim. |
-| **How: wakeup** | Fired prompts queue at low priority and run between turns. | Due jobs spawn parallel runs with a restricted toolset. Output delivers to chat unless silent. |
+| | Claude Code | Hermes Agent | deepseek-harness |
+| --- | --- | --- | --- |
+| **Pros** | Simple and private. Durable schedules survive restart. | Fires unattended, no hosted service. | Reminders replay with the session. Missed fires collapse to one turn. |
+| **Cons** | Only ticks while a session runs. | Needs a gateway, and locks against double fire. | Fixed rates only, no cron. Nothing fires while the session is closed. |
+| **Why** | Assumes a local session is running. | The gateway is a server, so schedules fire unattended. | A reminder is conversation state, so the session log owns it. |
+| **How: trigger** | Cron, sleep, and remote triggers on a ticker. | Cron expressions on a gateway tick. | After a delay, at a time, or a fixed rate with a five-minute floor. |
+| **How: durability** | Session state, or a JSON file with a lock. | A shared JSON job store with an atomic claim. | Session-log events. A fork keeps history, drops reminders. |
+| **How: wakeup** | Fired prompts queue and run between turns. | Due jobs run in parallel and deliver to chat. | Due work waits for idle, then queues one turn. At-least-once. |
 
 ---
 
@@ -180,6 +180,9 @@ uv run python sections/14-scheduling/src/demo.py  # live demo, needs a key
   `tools/ScheduleCronTool/`, `tools/RemoteTriggerTool/`, `tools/SleepTool/`, `utils/cronScheduler.ts`, `hooks/useScheduledTasks.ts`, `utils/queueProcessor.ts`.
 - [Hermes Agent source](https://github.com/NousResearch/hermes-agent):
   `cron/scheduler.py` (`tick`, `_resolve_cron_disabled_toolsets`), `cron/jobs.py` (`_jobs_lock`, `claim_dispatch`), `hermes_time.py`.
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness) at `dsh-v0.1.0-rc.7`:
+  `packages/schedule/schedule/src/runtime.ts`, `packages/schedule/schedule/src/persistence.ts`, `packages/schedule/schedule/src/tools.ts`,
+  `docs/subsystems/schedule.md`, `docs/tool-catalog.md`.
 - [learn-claude-code · s14_cron_scheduler](https://github.com/shareAI-lab/learn-claude-code): section framing.
 - [ai-agent-book](https://github.com/bojieli/ai-agent-book): `book/chapter4.md`, Chinese original canonical.
   Heartbeat wakeups with judgment, alert fatigue, and the limits of time-driven triggers.

--- a/sections/14-scheduling/README.md
+++ b/sections/14-scheduling/README.md
@@ -137,9 +137,9 @@ How each agent decides when to run scheduled work.
 | | Claude Code | Hermes Agent | deepseek-harness |
 | --- | --- | --- | --- |
 | **Pros** | Simple and private. Durable schedules survive restart. | Fires unattended, no hosted service. | Reminders replay with the session. Missed fires collapse to one turn. |
-| **Cons** | Only ticks while a session runs. | Needs a gateway, and locks against double fire. | Fixed rates only, no cron. Nothing fires while the session is closed. |
+| **Cons** | Ticks while a session runs; remote triggers need a service. | Needs a gateway and locks against double fire. | Fixed rates only. Nothing fires cold. |
 | **Why** | Assumes a local session is running. | The gateway is a server, so schedules fire unattended. | A reminder is conversation state, so the session log owns it. |
-| **How: trigger** | Cron, sleep, and remote triggers on a ticker. | Cron expressions on a gateway tick. | After a delay, at a time, or a fixed rate with a five-minute floor. |
+| **How: trigger** | Cron, sleep, and remote triggers on a ticker. | Cron on a gateway tick, in the user's timezone. | After a delay, at a time, or every five minutes at most. |
 | **How: durability** | Session state, or a JSON file with a lock. | A shared JSON job store with an atomic claim. | Session-log events. A fork keeps history, drops reminders. |
 | **How: wakeup** | Fired prompts queue and run between turns. | Due jobs run in parallel and deliver to chat. | Due work waits for idle, then queues one turn. At-least-once. |
 

--- a/sections/14-scheduling/README.zh-CN.md
+++ b/sections/14-scheduling/README.zh-CN.md
@@ -134,9 +134,9 @@ for task in sched.drain():                            # src/demo.py · between t
 | | Claude Code | Hermes Agent | deepseek-harness |
 | --- | --- | --- | --- |
 | **Pros** | 简单又私密。durable 的 schedule 能在重启后存活。 | 不需要托管服务，无人看管也能 fire。 | 提醒跟着 session 一起重放。错过的几次会并成一个 turn。 |
-| **Cons** | 只在 session 运行时才会 tick。remote trigger 要托管服务。 | gateway 得一直跑，共享 job store 还要靠锁。 | 只能固定间隔，没有 cron。session 关掉就什么都不会 fire。 |
+| **Cons** | 只在 session 运行时才会 tick，remote trigger 还要托管服务。 | gateway 得一直跑，共享 job store 还要靠锁。 | 只能固定间隔。session 关掉就什么都不会 fire。 |
 | **Why** | 假设本地有 session 开着。 | gateway 是 server process，无人看管也能 fire。 | 提醒就是对话状态，所以归 session log 管。 |
-| **How: trigger** | Cron、sleep 和 remote trigger，由 ticker 定期检查。 | gateway tick 上的 cron 表达式。 | 几秒后、某个时间点，或固定间隔，最短五分钟。 |
+| **How: trigger** | Cron、sleep 和 remote trigger，由 ticker 定期检查。 | gateway tick 上的 cron，跟着用户的时区走。 | 延迟多久后、某个时间点，或固定间隔，最快五分钟一次。 |
 | **How: durability** | session 状态，或存成一个带锁的 JSON 文件。 | CLI 和 gateway 共享一个 JSON job store，认领是原子的。 | 写进 session log 的事件。fork 保留历史，但不带走提醒。 |
 | **How: wakeup** | fire 出来的 prompt 进 queue，在 turn 之间执行。 | 到点的 job 并行跑，输出投递到聊天平台。 | 等 agent 完全闲下来，才排一个 turn。至少送达一次。 |
 

--- a/sections/14-scheduling/README.zh-CN.md
+++ b/sections/14-scheduling/README.zh-CN.md
@@ -131,14 +131,14 @@ for task in sched.drain():                            # src/demo.py · between t
 
 各个 agent 如何决定何时执行调度工作。
 
-| | Claude Code | Hermes Agent |
-| --- | --- | --- |
-| **Pros** | 简单又私密。durable 的 schedule 能在重启后存活。 | 不需要托管服务，无人看管也能 fire。heartbeat 文件分得出 ticker 是整个停掉，还是还在跑但一直失败。 |
-| **Cons** | 只在 session 运行时才会 tick。remote trigger 需要托管服务和 auth。 | gateway 得一直跑着才行。共享的 job store 需要锁来避免重复 fire。 |
-| **Why** | 假设本地有 session 开着。要在没有本地 process 时 fire，就交给托管 trigger。 | gateway 是一个 server process，所以 schedule 能在无人看管下 fire。 |
-| **How: trigger** | Cron、sleep，以及 remote trigger。ticker 以固定间隔检查 cron 条目。 | gateway tick 上的 cron 表达式，跟着用户配置的时区走。 |
-| **How: durability** | 分成 session 和 durable 两种。durable 的存成本地 JSON 文件，一把锁避免多个 session 重复 fire。 | CLI 和 gateway 共享一个 JSON job store，靠锁保护，一个 job 只会被认领走一次。 |
-| **How: wakeup** | fire 出来的 prompt 进 queue 排在后面，在 turn 之间执行。 | 到了预定时间的 job 在并行 thread 上跑，toolset 受限。输出投递到聊天平台，除非标了 [SILENT]。 |
+| | Claude Code | Hermes Agent | deepseek-harness |
+| --- | --- | --- | --- |
+| **Pros** | 简单又私密。durable 的 schedule 能在重启后存活。 | 不需要托管服务，无人看管也能 fire。 | 提醒跟着 session 一起重放。错过的几次会并成一个 turn。 |
+| **Cons** | 只在 session 运行时才会 tick。remote trigger 要托管服务。 | gateway 得一直跑，共享 job store 还要靠锁。 | 只能固定间隔，没有 cron。session 关掉就什么都不会 fire。 |
+| **Why** | 假设本地有 session 开着。 | gateway 是 server process，无人看管也能 fire。 | 提醒就是对话状态，所以归 session log 管。 |
+| **How: trigger** | Cron、sleep 和 remote trigger，由 ticker 定期检查。 | gateway tick 上的 cron 表达式。 | 几秒后、某个时间点，或固定间隔，最短五分钟。 |
+| **How: durability** | session 状态，或存成一个带锁的 JSON 文件。 | CLI 和 gateway 共享一个 JSON job store，认领是原子的。 | 写进 session log 的事件。fork 保留历史，但不带走提醒。 |
+| **How: wakeup** | fire 出来的 prompt 进 queue，在 turn 之间执行。 | 到点的 job 并行跑，输出投递到聊天平台。 | 等 agent 完全闲下来，才排一个 turn。至少送达一次。 |
 
 ---
 
@@ -177,6 +177,9 @@ uv run python sections/14-scheduling/src/demo.py  # live demo, needs a key
   `tools/ScheduleCronTool/`、`tools/RemoteTriggerTool/`、`tools/SleepTool/`、`utils/cronScheduler.ts`、`hooks/useScheduledTasks.ts`、`utils/queueProcessor.ts`。
 - [Hermes Agent 源码](https://github.com/NousResearch/hermes-agent)：
   `cron/scheduler.py`（`tick`、`_resolve_cron_disabled_toolsets`）、`cron/jobs.py`（`_jobs_lock`、`claim_dispatch`）、`hermes_time.py`。
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness)（`dsh-v0.1.0-rc.7`）：
+  `packages/schedule/schedule/src/runtime.ts`、`packages/schedule/schedule/src/persistence.ts`、`packages/schedule/schedule/src/tools.ts`、
+  `docs/subsystems/schedule.md`、`docs/tool-catalog.md`。
 - [learn-claude-code · s14_cron_scheduler](https://github.com/shareAI-lab/learn-claude-code)：章节框架。
 - [ai-agent-book](https://github.com/bojieli/ai-agent-book)：`book/chapter4.md`，以中文原版为准。
   带判断的 heartbeat 唤醒、通知疲劳，以及时间驱动触发的极限。

--- a/sections/14-scheduling/README.zh-TW.md
+++ b/sections/14-scheduling/README.zh-TW.md
@@ -131,14 +131,14 @@ for task in sched.drain():                            # src/demo.py · between t
 
 各個 agent 如何決定何時執行排程工作。
 
-| | Claude Code | Hermes Agent |
-| --- | --- | --- |
-| **Pros** | 簡單又私密。durable 的 schedule 能在重啟後存活。 | 不需要託管服務，無人看管也能 fire。heartbeat 檔案分得出 ticker 是整個停掉，還是還在跑但一直失敗。 |
-| **Cons** | 只在 session 運行時才會 tick。remote trigger 需要託管服務和 auth。 | gateway 得一直跑著才行。共享的 job store 需要鎖來避免重複 fire。 |
-| **Why** | 假設本地有 session 開著。要在沒有本地 process 時 fire，就交給託管 trigger。 | gateway 是一個 server process，所以 schedule 能在無人看管下 fire。 |
-| **How: trigger** | Cron、sleep，以及 remote trigger。ticker 以固定間隔檢查 cron 項目。 | gateway tick 上的 cron 表達式，跟著使用者設定的時區走。 |
-| **How: durability** | 分成 session 和 durable 兩種。durable 的存成本地 JSON 檔案，一把鎖避免多個 session 重複 fire。 | CLI 和 gateway 共享一個 JSON job store，靠鎖保護，一個 job 只會被認領走一次。 |
-| **How: wakeup** | fire 出來的 prompt 進 queue 排在後面，在 turn 之間執行。 | 到了預定時間的 job 在平行 thread 上跑，toolset 受限。輸出投遞到聊天平台，除非標了 [SILENT]。 |
+| | Claude Code | Hermes Agent | deepseek-harness |
+| --- | --- | --- | --- |
+| **Pros** | 簡單又私密。durable 的 schedule 能在重啟後存活。 | 不需要託管服務，無人看管也能 fire。 | 提醒跟著 session 一起重放。錯過的幾次會併成一個 turn。 |
+| **Cons** | 只在 session 運行時才會 tick。remote trigger 要託管服務。 | gateway 得一直跑，共享 job store 還要靠鎖。 | 只能固定間隔，沒有 cron。session 關掉就什麼都不會 fire。 |
+| **Why** | 假設本地有 session 開著。 | gateway 是 server process，無人看管也能 fire。 | 提醒就是對話狀態，所以歸 session log 管。 |
+| **How: trigger** | Cron、sleep 和 remote trigger，由 ticker 定期檢查。 | gateway tick 上的 cron 表達式。 | 幾秒後、某個時間點，或固定間隔，最短五分鐘。 |
+| **How: durability** | session 狀態，或存成一個帶鎖的 JSON 檔。 | CLI 和 gateway 共享一個 JSON job store，認領是原子的。 | 寫進 session log 的事件。fork 保留歷史，但不帶走提醒。 |
+| **How: wakeup** | fire 出來的 prompt 進 queue，在 turn 之間執行。 | 到點的 job 平行跑，輸出投遞到聊天平台。 | 等 agent 完全閒下來，才排一個 turn。至少送達一次。 |
 
 ---
 
@@ -177,6 +177,9 @@ uv run python sections/14-scheduling/src/demo.py  # live demo, needs a key
   `tools/ScheduleCronTool/`、`tools/RemoteTriggerTool/`、`tools/SleepTool/`、`utils/cronScheduler.ts`、`hooks/useScheduledTasks.ts`、`utils/queueProcessor.ts`。
 - [Hermes Agent 原始碼](https://github.com/NousResearch/hermes-agent)：
   `cron/scheduler.py`（`tick`、`_resolve_cron_disabled_toolsets`）、`cron/jobs.py`（`_jobs_lock`、`claim_dispatch`）、`hermes_time.py`。
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness)（`dsh-v0.1.0-rc.7`）：
+  `packages/schedule/schedule/src/runtime.ts`、`packages/schedule/schedule/src/persistence.ts`、`packages/schedule/schedule/src/tools.ts`、
+  `docs/subsystems/schedule.md`、`docs/tool-catalog.md`。
 - [learn-claude-code · s14_cron_scheduler](https://github.com/shareAI-lab/learn-claude-code)：章節框架。
 - [ai-agent-book](https://github.com/bojieli/ai-agent-book)：`book/chapter4.md`，以中文原版為準。
   帶判斷的 heartbeat 喚醒、通知疲乏，以及時間驅動觸發的極限。

--- a/sections/14-scheduling/README.zh-TW.md
+++ b/sections/14-scheduling/README.zh-TW.md
@@ -134,9 +134,9 @@ for task in sched.drain():                            # src/demo.py · between t
 | | Claude Code | Hermes Agent | deepseek-harness |
 | --- | --- | --- | --- |
 | **Pros** | 簡單又私密。durable 的 schedule 能在重啟後存活。 | 不需要託管服務，無人看管也能 fire。 | 提醒跟著 session 一起重放。錯過的幾次會併成一個 turn。 |
-| **Cons** | 只在 session 運行時才會 tick。remote trigger 要託管服務。 | gateway 得一直跑，共享 job store 還要靠鎖。 | 只能固定間隔，沒有 cron。session 關掉就什麼都不會 fire。 |
+| **Cons** | 只在 session 運行時才會 tick，remote trigger 還要託管服務。 | gateway 得一直跑，共享 job store 還要靠鎖。 | 只能固定間隔。session 關掉就什麼都不會 fire。 |
 | **Why** | 假設本地有 session 開著。 | gateway 是 server process，無人看管也能 fire。 | 提醒就是對話狀態，所以歸 session log 管。 |
-| **How: trigger** | Cron、sleep 和 remote trigger，由 ticker 定期檢查。 | gateway tick 上的 cron 表達式。 | 幾秒後、某個時間點，或固定間隔，最短五分鐘。 |
+| **How: trigger** | Cron、sleep 和 remote trigger，由 ticker 定期檢查。 | gateway tick 上的 cron，跟著使用者的時區走。 | 延遲多久後、某個時間點，或固定間隔，最快五分鐘一次。 |
 | **How: durability** | session 狀態，或存成一個帶鎖的 JSON 檔。 | CLI 和 gateway 共享一個 JSON job store，認領是原子的。 | 寫進 session log 的事件。fork 保留歷史，但不帶走提醒。 |
 | **How: wakeup** | fire 出來的 prompt 進 queue，在 turn 之間執行。 | 到點的 job 平行跑，輸出投遞到聊天平台。 | 等 agent 完全閒下來，才排一個 turn。至少送達一次。 |
 


### PR DESCRIPTION
Closes #76. Part of PRD #72.

## What changed

- Sections 12, 13, 14 each gain a deepseek-harness column, mirrored in `README.zh-TW.md` and `README.zh-CN.md`.
- Section 15 gets nothing, per the PRD: dsh has no worktree analogue at this tag.
- Section 13's zh-TW table used padded, aligned pipes; it now matches the compact row style used everywhere else.
- Existing cells were tightened where a new column pushed a row past 180 characters.
- No src changes in this batch.

## Verification

- `python sections/1{2,3,4}/src/test.py` still pass offline.
- No line over 180 characters, no em or en dashes, table column counts consistent across all three languages.