### PR TITLE
dsh batch 5: sections 16-18 columns

### DIFF
--- a/sections/16-coordination/README.md
+++ b/sections/16-coordination/README.md
@@ -248,7 +248,7 @@ How one design spawns cooperating agents and spreads work across them.
 | **Pros** | Peers talk directly. File inboxes cross processes. | Children pause and interrupt from any surface. | A script fans out many children under hard caps. |
 | **Cons** | Polling and lock cost. Memory inboxes die with the process. | No peer inboxes. A clarify blocks its thread. | Children cannot talk. A send gets no reply. |
 | **Why** | Peers need inboxes, plus a route to a human approver. | Coordination stays parent to child. | Coordination is ownership. Each child has one parent. |
-| **How: teammates** | In-process or remote, each running its own loop. | Delegated children on threads, with a pause flag. | A model-written script spawns them. |
+| **How: teammates** | In-process or remote, each runs its own loop. | Delegated children on threads, with a pause flag. | A model-written script spawns them; some stay resident. |
 | **How: channel** | SendMessage writes to inboxes and can broadcast. | Completion queue plus gateway calls. | Parent to child only. The child answers with a report tool. |
 | **How: shared memory** | Team task list and a team memory directory. | Shared session DB, plus lineage markers. | The parent's directory. A fork also copies its finished turns. |
 | **How: permission bubbling** | Remote requests become local approval prompts. | Clarify goes to chat; children auto-deny or approve. | A request walks up the parent chain. |

--- a/sections/16-coordination/README.md
+++ b/sections/16-coordination/README.md
@@ -243,15 +243,15 @@ The cost is that only one agent holds control, so nothing runs at the same time.
 
 How one design spawns cooperating agents and spreads work across them.
 
-| | Claude Code | Hermes Agent |
-| --- | --- | --- |
-| **Pros** | Peers talk directly. File inboxes are durable and cross processes or machines. | Children can be paused, checked, and interrupted from any connected surface. |
-| **Cons** | File inboxes add polling and lock cost. In-memory inboxes die with the process. | No peer inboxes, so children cannot collaborate. A clarify blocks its thread. |
-| **Why** | Teammates are peers that need inboxes to talk and a route to a human approver. | Coordination stays parent to child. A human on chat answers escalations. |
-| **How: teammates** | In-process or remote. Each runs its own loop, folding messages between turns. | Delegated children on threads. A pause flag stops new spawns mid-run. |
-| **How: channel** | SendMessage writes to memory or locked file inboxes and can broadcast. | Completion queue plus gateway RPCs. The parent folds results in when idle. |
-| **How: shared memory** | Team task list and a team memory directory. | Shared session DB. Lineage markers record who spawned whom, for cascade cleanup. |
-| **How: permission bubbling** | Remote requests become local approval prompts. | Clarify requests route to the user's chat. Children get auto-deny or auto-approve, logged. |
+| | Claude Code | Hermes Agent | deepseek-harness |
+| --- | --- | --- | --- |
+| **Pros** | Peers talk directly. File inboxes cross processes. | Children pause and interrupt from any surface. | A script fans out many children under hard caps. |
+| **Cons** | Polling and lock cost. Memory inboxes die with the process. | No peer inboxes, so children cannot collaborate. | Children cannot talk to each other. |
+| **Why** | Peers need inboxes, plus a route to a human approver. | Coordination stays parent to child. | Coordination is ownership. Each child has one parent. |
+| **How: teammates** | In-process or remote, each running its own loop. | Delegated children on threads, with a pause flag. | A written script spawns them; some stay resident. |
+| **How: channel** | SendMessage writes to inboxes and can broadcast. | Completion queue plus gateway calls. | Parent to child only. The child answers with a report tool. |
+| **How: shared memory** | Team task list and a team memory directory. | Shared session DB, plus lineage markers. | The parent's directory. A fork also copies its finished turns. |
+| **How: permission bubbling** | Remote requests become local approval prompts. | Clarify goes to chat; children auto-deny or approve. | A request walks up the parent chain. |
 
 ---
 
@@ -299,6 +299,9 @@ uv run python sections/16-coordination/src/demo.py  # live demo, needs a key
 - [Claude Code teammates](https://github.com/yasasbanukaofficial/claude-code):
   `tasks/InProcessTeammateTask/`, `tasks/RemoteAgentTask/`, `remote/remotePermissionBridge.ts`, `memdir/teamMemPaths.ts`.
 - [Hermes Agent source](https://github.com/NousResearch/hermes-agent): `tools/delegate_tool.py`, `tools/async_delegation.py`, `tools/clarify_gateway.py`, `tools/interrupt.py`.
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness) at `dsh-v0.1.0-rc.7`:
+  `docs/subsystems/workflow.md`, `docs/subsystems/subagent.md`, `docs/subsystems/core.md`,
+  `packages/workflow/workflow-worker-thread/README.md`, `packages/subagent/tool-subagent-report/README.md`.
 - [learn-claude-code · s15_agent_teams](https://github.com/shareAI-lab/learn-claude-code): section framing.
 - [ai-agent-book](https://github.com/bojieli/ai-agent-book): `book/chapter10.md` (多 Agent 协作), Chinese original canonical.
   Context sharing, topology taxonomy, filesystem regions, handoff packets. The role-transfer demo is the author's own experiment.

--- a/sections/16-coordination/README.md
+++ b/sections/16-coordination/README.md
@@ -246,9 +246,9 @@ How one design spawns cooperating agents and spreads work across them.
 | | Claude Code | Hermes Agent | deepseek-harness |
 | --- | --- | --- | --- |
 | **Pros** | Peers talk directly. File inboxes cross processes. | Children pause and interrupt from any surface. | A script fans out many children under hard caps. |
-| **Cons** | Polling and lock cost. Memory inboxes die with the process. | No peer inboxes, so children cannot collaborate. | Children cannot talk to each other. |
+| **Cons** | Polling and lock cost. Memory inboxes die with the process. | No peer inboxes. A clarify blocks its thread. | Children cannot talk. A send gets no reply. |
 | **Why** | Peers need inboxes, plus a route to a human approver. | Coordination stays parent to child. | Coordination is ownership. Each child has one parent. |
-| **How: teammates** | In-process or remote, each running its own loop. | Delegated children on threads, with a pause flag. | A written script spawns them; some stay resident. |
+| **How: teammates** | In-process or remote, each running its own loop. | Delegated children on threads, with a pause flag. | A model-written script spawns them. |
 | **How: channel** | SendMessage writes to inboxes and can broadcast. | Completion queue plus gateway calls. | Parent to child only. The child answers with a report tool. |
 | **How: shared memory** | Team task list and a team memory directory. | Shared session DB, plus lineage markers. | The parent's directory. A fork also copies its finished turns. |
 | **How: permission bubbling** | Remote requests become local approval prompts. | Clarify goes to chat; children auto-deny or approve. | A request walks up the parent chain. |

--- a/sections/16-coordination/README.zh-CN.md
+++ b/sections/16-coordination/README.zh-CN.md
@@ -240,15 +240,15 @@ sender 的原始历史不放进去。那东西很长、里面都是走不通的�
 
 一种设计如何 spawn 出协作的 agent 并把工作分散给它们。
 
-| | Claude Code | Hermes Agent |
-| --- | --- | --- |
-| **Pros** | 队友之间能直接交谈。文件 inbox 具耐久性，能跨越 process 或机器边界。 | 子代可以从任何已连接的界面暂停、查看、中断。 |
-| **Cons** | 文件 inbox 增加 poll 与 lock 成本。in-memory inbox 会随 process 一起死掉。 | 没有对等的 inbox，子代之间无法协作。clarify 会 block 住自己的 thread。 |
-| **Why** | 队友彼此对等：需要 inbox 来交谈，也需要一条把权限请求送回用户的路。 | 协调维持 parent 对 child。升级的问题由聊天上的人回答，不是 lead agent。 |
-| **How: teammates** | in-process 或 remote；各自跑自己的 loop，在 turn 之间把消息并入。 | thread 上的委派子代。全局暂停标志可以在运行中途停止新的 spawn。 |
-| **How: channel** | SendMessage 写入 in-memory 或带 lock 的文件 inbox，也能 broadcast。 | completion queue 加 gateway RPC。parent 空闲时把结果并入新的 turn。 |
-| **How: shared memory** | team task list 与团队 memory 目录。 | 共享的 session DB。lineage 标记记录谁 spawn 了谁，供连锁清理使用。 |
-| **How: permission bubbling** | remote 权限请求转成本地的审核提示。 | clarify 请求导向用户的聊天平台。子代拿到自动 deny 或自动 approve，留下审计记录。 |
+| | Claude Code | Hermes Agent | deepseek-harness |
+| --- | --- | --- | --- |
+| **Pros** | 队友能直接交谈，文件 inbox 还能跨 process 或机器。 | 子代可以从任何已连接的界面暂停、中断。 | 一支脚本就能在硬性上限之下开出大量子代。 |
+| **Cons** | 文件 inbox 有 poll 和 lock 成本，内存 inbox 随 process 死。 | 没有对等 inbox，子代之间无法协作。 | 子代彼此不能讲话。发消息也不会有回复。 |
+| **Why** | 队友彼此对等，需要 inbox 交谈，也需要一条送回人的路。 | 协调维持 parent 对 child。 | 协调就是归属关系，每个子代只有一个 parent。 |
+| **How: teammates** | in-process 或 remote，各自跑自己的 loop。 | thread 上的委派子代，有暂停标志。 | 由模型写的脚本开出子代，长命的那种会常驻。 |
+| **How: channel** | SendMessage 写进 inbox，也能 broadcast。 | completion queue 加 gateway RPC。 | 只有 parent 对 child。子代用 report 工具回话。 |
+| **How: shared memory** | team task list 与团队 memory 目录。 | 共享的 session DB，外加 lineage 标记。 | parent 的工作目录。fork 还会复制它跑完的 turn。 |
+| **How: permission bubbling** | remote 权限请求转成本地的审核提示。 | clarify 导向聊天平台，子代自动 deny 或 approve。 | 权限请求沿着 parent 这条线往上问。 |
 
 ---
 
@@ -295,6 +295,9 @@ uv run python sections/16-coordination/src/demo.py  # live demo, needs a key
 - [Claude Code 队友](https://github.com/yasasbanukaofficial/claude-code)：
   `tasks/InProcessTeammateTask/`、`tasks/RemoteAgentTask/`、`remote/remotePermissionBridge.ts`、`memdir/teamMemPaths.ts`。
 - [Hermes Agent 源码](https://github.com/NousResearch/hermes-agent)：`tools/delegate_tool.py`、`tools/async_delegation.py`、`tools/clarify_gateway.py`、`tools/interrupt.py`。
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness)（`dsh-v0.1.0-rc.7`）：
+  `docs/subsystems/workflow.md`、`docs/subsystems/subagent.md`、`docs/subsystems/core.md`、
+  `packages/workflow/workflow-worker-thread/README.md`、`packages/subagent/tool-subagent-report/README.md`。
 - [learn-claude-code · s15_agent_teams](https://github.com/shareAI-lab/learn-claude-code)：章节框架。
 - [ai-agent-book](https://github.com/bojieli/ai-agent-book)：`book/chapter10.md`（多 Agent 协作），以中文原文为准。
   context 共不共享、拓扑分类、文件系统分区、handoff 包裹。角色互转那个演示是作者自己的实验。

--- a/sections/16-coordination/README.zh-CN.md
+++ b/sections/16-coordination/README.zh-CN.md
@@ -243,7 +243,7 @@ sender 的原始历史不放进去。那东西很长、里面都是走不通的�
 | | Claude Code | Hermes Agent | deepseek-harness |
 | --- | --- | --- | --- |
 | **Pros** | 队友能直接交谈，文件 inbox 还能跨 process 或机器。 | 子代可以从任何已连接的界面暂停、中断。 | 一支脚本就能在硬性上限之下开出大量子代。 |
-| **Cons** | 文件 inbox 有 poll 和 lock 成本，内存 inbox 随 process 死。 | 没有对等 inbox，子代之间无法协作。 | 子代彼此不能讲话。发消息也不会有回复。 |
+| **Cons** | 文件 inbox 有 poll 和 lock 成本，内存 inbox 随 process 死。 | 没有对等 inbox，clarify 还会卡住自己的 thread。 | 子代彼此不能讲话，发消息也不会有回复。 |
 | **Why** | 队友彼此对等，需要 inbox 交谈，也需要一条送回人的路。 | 协调维持 parent 对 child。 | 协调就是归属关系，每个子代只有一个 parent。 |
 | **How: teammates** | in-process 或 remote，各自跑自己的 loop。 | thread 上的委派子代，有暂停标志。 | 由模型写的脚本开出子代，长命的那种会常驻。 |
 | **How: channel** | SendMessage 写进 inbox，也能 broadcast。 | completion queue 加 gateway RPC。 | 只有 parent 对 child。子代用 report 工具回话。 |

--- a/sections/16-coordination/README.zh-TW.md
+++ b/sections/16-coordination/README.zh-TW.md
@@ -243,7 +243,7 @@ sender 的原始歷史不放進去。那東西很長、裡面都是走不通的�
 | | Claude Code | Hermes Agent | deepseek-harness |
 | --- | --- | --- | --- |
 | **Pros** | 隊友能直接交談，檔案 inbox 還能跨 process 或機器。 | 子代可以從任何已連接的介面暫停、中斷。 | 一支腳本就能在硬性上限之下開出大量子代。 |
-| **Cons** | 檔案 inbox 有 poll 和 lock 成本，記憶體 inbox 隨 process 死。 | 沒有對等 inbox，子代之間無法協作。 | 子代彼此不能講話。送訊息也不會有回覆。 |
+| **Cons** | 檔案 inbox 有 poll 和 lock 成本，記憶體 inbox 隨 process 死。 | 沒有對等 inbox，clarify 還會卡住自己的 thread。 | 子代彼此不能講話，送訊息也不會有回覆。 |
 | **Why** | 隊友彼此對等，需要 inbox 交談，也需要一條送回人的路。 | 協調維持 parent 對 child。 | 協調就是歸屬關係，每個子代只有一個 parent。 |
 | **How: teammates** | in-process 或 remote，各自跑自己的 loop。 | thread 上的委派子代，有暫停旗標。 | 由模型寫的腳本開出子代，長命的那種會常駐。 |
 | **How: channel** | SendMessage 寫進 inbox，也能 broadcast。 | completion queue 加 gateway RPC。 | 只有 parent 對 child。子代用 report 工具回話。 |

--- a/sections/16-coordination/README.zh-TW.md
+++ b/sections/16-coordination/README.zh-TW.md
@@ -240,15 +240,15 @@ sender 的原始歷史不放進去。那東西很長、裡面都是走不通的�
 
 一種設計如何 spawn 出協作的 agent 並把工作分散給它們。
 
-| | Claude Code | Hermes Agent |
-| --- | --- | --- |
-| **Pros** | 隊友之間能直接交談。檔案 inbox 具耐久性，能跨越 process 或機器邊界。 | 子代可以從任何已連接的介面暫停、查看、中斷。 |
-| **Cons** | 檔案 inbox 增加 poll 與 lock 成本。in-memory inbox 會隨 process 一起死掉。 | 沒有對等的 inbox，子代之間無法協作。clarify 會 block 住自己的 thread。 |
-| **Why** | 隊友彼此對等：需要 inbox 來交談，也需要一條把權限請求送回使用者的路。 | 協調維持 parent 對 child。升級的問題由聊天上的人回答，不是 lead agent。 |
-| **How: teammates** | in-process 或 remote；各自跑自己的 loop，在 turn 之間把訊息併入。 | thread 上的委派子代。全域暫停旗標可以在執行中途停止新的 spawn。 |
-| **How: channel** | SendMessage 寫入 in-memory 或帶 lock 的檔案 inbox，也能 broadcast。 | completion queue 加 gateway RPC。parent 閒置時把結果併入新的 turn。 |
-| **How: shared memory** | team task list 與團隊 memory 目錄。 | 共用的 session DB。lineage 標記記錄誰 spawn 了誰，供連鎖清理使用。 |
-| **How: permission bubbling** | remote 權限請求轉成本地的審核提示。 | clarify 請求導向使用者的聊天平台。子代拿到自動 deny 或自動 approve，留下稽核記錄。 |
+| | Claude Code | Hermes Agent | deepseek-harness |
+| --- | --- | --- | --- |
+| **Pros** | 隊友能直接交談，檔案 inbox 還能跨 process 或機器。 | 子代可以從任何已連接的介面暫停、中斷。 | 一支腳本就能在硬性上限之下開出大量子代。 |
+| **Cons** | 檔案 inbox 有 poll 和 lock 成本，記憶體 inbox 隨 process 死。 | 沒有對等 inbox，子代之間無法協作。 | 子代彼此不能講話。送訊息也不會有回覆。 |
+| **Why** | 隊友彼此對等，需要 inbox 交談，也需要一條送回人的路。 | 協調維持 parent 對 child。 | 協調就是歸屬關係，每個子代只有一個 parent。 |
+| **How: teammates** | in-process 或 remote，各自跑自己的 loop。 | thread 上的委派子代，有暫停旗標。 | 由模型寫的腳本開出子代，長命的那種會常駐。 |
+| **How: channel** | SendMessage 寫進 inbox，也能 broadcast。 | completion queue 加 gateway RPC。 | 只有 parent 對 child。子代用 report 工具回話。 |
+| **How: shared memory** | team task list 與團隊 memory 目錄。 | 共用的 session DB，外加 lineage 標記。 | parent 的工作目錄。fork 還會複製它跑完的 turn。 |
+| **How: permission bubbling** | remote 權限請求轉成本地的審核提示。 | clarify 導向聊天平台，子代自動 deny 或 approve。 | 權限請求沿著 parent 這條線往上問。 |
 
 ---
 
@@ -295,6 +295,9 @@ uv run python sections/16-coordination/src/demo.py  # live demo, needs a key
 - [Claude Code 隊友](https://github.com/yasasbanukaofficial/claude-code)：
   `tasks/InProcessTeammateTask/`、`tasks/RemoteAgentTask/`、`remote/remotePermissionBridge.ts`、`memdir/teamMemPaths.ts`。
 - [Hermes Agent 原始碼](https://github.com/NousResearch/hermes-agent)：`tools/delegate_tool.py`、`tools/async_delegation.py`、`tools/clarify_gateway.py`、`tools/interrupt.py`。
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness)（`dsh-v0.1.0-rc.7`）：
+  `docs/subsystems/workflow.md`、`docs/subsystems/subagent.md`、`docs/subsystems/core.md`、
+  `packages/workflow/workflow-worker-thread/README.md`、`packages/subagent/tool-subagent-report/README.md`。
 - [learn-claude-code · s15_agent_teams](https://github.com/shareAI-lab/learn-claude-code)：章節框架。
 - [ai-agent-book](https://github.com/bojieli/ai-agent-book)：`book/chapter10.md`（多 Agent 协作），以中文原文為準。
   context 共不共用、拓撲分類、檔案系統分區、handoff 包裹。角色互轉那個示範是作者自己的實驗。

--- a/sections/17-protocols/README.md
+++ b/sections/17-protocols/README.md
@@ -187,14 +187,14 @@ A caller across a boundary keeps both. The request states say whether this one m
 
 How one design shapes requests, gates plans, and stops agents cleanly.
 
-| | Claude Code |
-| --- | --- |
-| **Pros** | Every stop is confirmed and every risky plan is gated. In flight work and task records survive a stop. |
-| **Cons** | Each handshake costs round trips and protocol state. A fire and forget kill is faster. |
-| **Why** | A kill mid edit leaves a half written file and an open task record. A risky plan should be approved before work starts. |
-| **How: message shape** | One typed union on a `type` field. A `request_id` ties each reply to its request. |
-| **How: plan approval** | The teammate requests and waits. The lead's reply carries the verdict, optional feedback, and the permission mode the work runs under. |
-| **How: shutdown** | The lead requests, the teammate confirms, then the kill runs. The task is marked notified and a terminated event goes out. |
+| | Claude Code | deepseek-harness |
+| --- | --- | --- |
+| **Pros** | Every stop is confirmed and every risky plan is gated. | Any client or server speaking the public protocol interoperates. |
+| **Cons** | Each handshake costs round trips and protocol state. | Output lands only when committed, so live progress stays hidden. |
+| **Why** | A kill mid edit leaves a half written file and an open task record. | The other side is a process you may not own, so use a public contract. |
+| **How: message shape** | One typed union on a `type` field, with a `request_id` per reply. | JSON-RPC methods keyed by session id. One prompt in flight per session. |
+| **How: plan approval** | The teammate waits. The lead's reply carries verdict, feedback, and mode. | The plan goes to a human. A rejection returns as a failed call. |
+| **How: shutdown** | The lead requests, the teammate confirms, then the kill runs. | Cancel, end the input, signal, then kill. Every tier is time-bounded. |
 
 ---
 
@@ -236,6 +236,9 @@ uv run python sections/17-protocols/src/demo.py  # live demo, needs a key
 - [Claude Code protocol shape](https://github.com/yasasbanukaofficial/claude-code): `tools/SendMessageTool/SendMessageTool.ts`, `utils/teammateMailbox.ts`.
 - [Claude Code plan and stop](https://github.com/yasasbanukaofficial/claude-code):
   `tools/ExitPlanModeTool/ExitPlanModeV2Tool.ts`, `tasks/stopTask.ts`, `coordinator/coordinatorMode.ts`.
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness) at `dsh-v0.1.0-rc.7`:
+  `packages/acp/acp/README.md`, `packages/subagent/subagent-acp/README.md`, `docs/subsystems/session.md`,
+  `docs/subsystems/plan.md`, `docs/subsystems/approval.md`.
 - [learn-claude-code · s16_team_protocols](https://github.com/shareAI-lab/learn-claude-code): section framing.
 - [ai-agent-book](https://github.com/bojieli/ai-agent-book): `book/chapter10.md` (多 Agent 协作), Chinese original canonical.
   A stop that cleans up and acks, a kill as the fallback tier, and stopping a whole fan out on first success with a lock so the race settles once.

--- a/sections/17-protocols/README.md
+++ b/sections/17-protocols/README.md
@@ -191,9 +191,9 @@ How one design shapes requests, gates plans, and stops agents cleanly.
 | --- | --- | --- |
 | **Pros** | Every stop is confirmed and every risky plan is gated. | Any client or server speaking the public protocol interoperates. |
 | **Cons** | Each handshake costs round trips and protocol state. | Output lands only when committed, so live progress stays hidden. |
-| **Why** | A kill mid edit leaves a half written file and an open task record. | The other side is a process you may not own, so use a public contract. |
+| **Why** | A kill mid edit leaves a half written file. Risky plans need approval first. | The other side is a process you may not own, so use a public contract. |
 | **How: message shape** | One typed union on a `type` field, with a `request_id` per reply. | JSON-RPC methods keyed by session id. One prompt in flight per session. |
-| **How: plan approval** | The teammate waits. The lead's reply carries verdict, feedback, and mode. | The plan goes to a human. A rejection returns as a failed call. |
+| **How: plan approval** | The teammate waits. The lead's reply carries verdict, feedback, mode. | The plan goes to a human. A rejection returns as a failed call with feedback. |
 | **How: shutdown** | The lead requests, the teammate confirms, then the kill runs. | Cancel, end the input, signal, then kill. Every tier is time-bounded. |
 
 ---

--- a/sections/17-protocols/README.zh-CN.md
+++ b/sections/17-protocols/README.zh-CN.md
@@ -189,7 +189,7 @@ task 的 id 之后还查得到：回复收到之后、中途停下来要信息�
 | --- | --- | --- |
 | **Pros** | 每一次停止都经过确认，有风险的计划都设了闸门。 | 只要按公开协议讲话，任何 client 或 server 都能接上来。 |
 | **Cons** | 每次 handshake 都要付出往返次数和 protocol 状态。 | 输出要等到定案才发出，中途的进度看不到。 |
-| **Why** | 编辑到一半被强制停掉，会留下写一半的文件和开着的 task。 | 对面是一个你未必拥有的 process，所以用公开契约讲话。 |
+| **Why** | 编辑到一半被强制停掉，会留下写一半的文件。有风险的计划也该先审核。 | 对面是一个你未必拥有的 process，所以用公开契约讲话。 |
 | **How: message shape** | 在 `type` 上区分的 typed union，`request_id` 对应每条回复。 | 用 session id 分辨的 JSON-RPC 方法，一个 session 同时只跑一个 prompt。 |
 | **How: plan approval** | 队友请求后等待，lead 的回复带着裁决、feedback 和权限模式。 | 计划送到人面前。被打回来时，会以带着意见的失败调用返回。 |
 | **How: shutdown** | lead 先请求，队友确认后才 kill。 | 先取消、再关掉输入、再发 signal、最后强杀，每一阶都有时限。 |

--- a/sections/17-protocols/README.zh-CN.md
+++ b/sections/17-protocols/README.zh-CN.md
@@ -185,14 +185,14 @@ task 的 id 之后还查得到：回复收到之后、中途停下来要信息�
 
 一种设计如何定出请求的格式、为计划设闸门，并干净地停止 agent。
 
-| | Claude Code |
-| --- | --- |
-| **Pros** | 每一次停止都经过确认，每一个有风险的计划都设了闸门。不会丢掉进行中的工作，也不会泄漏 task 记录。 |
-| **Cons** | 每次 handshake 都要付出往返次数和 protocol 状态，比 fire and forget 的 kill 慢。 |
-| **Why** | 队友编辑到一半就被强制停掉，会留下写到一半的文件和开着的 task 记录。有风险的计划要在行动前先审核。 |
-| **How: message shape** | 在 `type` 上区分的 typed union。`request_id` 把每条回复对应到它的请求。 |
-| **How: plan approval** | 队友请求后等待，lead 审核。回复带着裁决、可选的 feedback，以及工作所在的权限模式。 |
-| **How: shutdown** | lead 先请求，队友确认后才 kill。task 会被标记为 notified，并发出 terminated 事件。 |
+| | Claude Code | deepseek-harness |
+| --- | --- | --- |
+| **Pros** | 每一次停止都经过确认，有风险的计划都设了闸门。 | 只要按公开协议讲话，任何 client 或 server 都能接上来。 |
+| **Cons** | 每次 handshake 都要付出往返次数和 protocol 状态。 | 输出要等到定案才发出，中途的进度看不到。 |
+| **Why** | 编辑到一半被强制停掉，会留下写一半的文件和开着的 task。 | 对面是一个你未必拥有的 process，所以用公开契约讲话。 |
+| **How: message shape** | 在 `type` 上区分的 typed union，`request_id` 对应每条回复。 | 用 session id 分辨的 JSON-RPC 方法，一个 session 同时只跑一个 prompt。 |
+| **How: plan approval** | 队友请求后等待，lead 的回复带着裁决、feedback 和权限模式。 | 计划送到人面前。被打回来时，会以带着意见的失败调用返回。 |
+| **How: shutdown** | lead 先请求，队友确认后才 kill。 | 先取消、再关掉输入、再发 signal、最后强杀，每一阶都有时限。 |
 
 ---
 
@@ -233,6 +233,9 @@ uv run python sections/17-protocols/src/demo.py  # live demo, needs a key
 
 - [Claude Code 的 protocol 格式](https://github.com/yasasbanukaofficial/claude-code)：`tools/SendMessageTool/SendMessageTool.ts`、`utils/teammateMailbox.ts`。
 - [Claude Code plan 与 stop](https://github.com/yasasbanukaofficial/claude-code)：`tools/ExitPlanModeTool/ExitPlanModeV2Tool.ts`、`tasks/stopTask.ts`、`coordinator/coordinatorMode.ts`。
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness)（`dsh-v0.1.0-rc.7`）：
+  `packages/acp/acp/README.md`、`packages/subagent/subagent-acp/README.md`、`docs/subsystems/session.md`、
+  `docs/subsystems/plan.md`、`docs/subsystems/approval.md`。
 - [learn-claude-code · s16_team_protocols](https://github.com/shareAI-lab/learn-claude-code)：章节框架。
 - [ai-agent-book](https://github.com/bojieli/ai-agent-book)：`book/chapter10.md`（多 Agent 协作），以中文原版为准。
   先收尾再回 ack 的停止、砍掉那一层备援，以及第一个做成功就把整批停掉、靠一把锁让这件事只结算一次。

--- a/sections/17-protocols/README.zh-TW.md
+++ b/sections/17-protocols/README.zh-TW.md
@@ -189,7 +189,7 @@ task 的 id 之後還查得到：回覆收到之後、中途停下來要資訊�
 | --- | --- | --- |
 | **Pros** | 每一次停止都經過確認，有風險的計畫都設了閘門。 | 只要照公開協定講話，任何 client 或 server 都能接上來。 |
 | **Cons** | 每次 handshake 都要付出往返次數和 protocol 狀態。 | 輸出要等到定案才送出，中途的進度看不到。 |
-| **Why** | 編輯到一半被強制停掉，會留下寫一半的檔案和開著的 task。 | 對面是一個你未必擁有的 process，所以用公開契約講話。 |
+| **Why** | 編輯到一半被強制停掉，會留下寫一半的檔案。有風險的計畫也該先審核。 | 對面是一個你未必擁有的 process，所以用公開契約講話。 |
 | **How: message shape** | 在 `type` 上區分的 typed union，`request_id` 對應每則回覆。 | 用 session id 分辨的 JSON-RPC 方法，一個 session 同時只跑一個 prompt。 |
 | **How: plan approval** | 隊友請求後等待，lead 的回覆帶著裁決、feedback 和權限模式。 | 計畫送到人面前。被打回來時，會以帶著意見的失敗呼叫回傳。 |
 | **How: shutdown** | lead 先請求，隊友確認後才 kill。 | 先取消、再關掉輸入、再送 signal、最後強殺，每一階都有時限。 |

--- a/sections/17-protocols/README.zh-TW.md
+++ b/sections/17-protocols/README.zh-TW.md
@@ -185,14 +185,14 @@ task 的 id 之後還查得到：回覆收到之後、中途停下來要資訊�
 
 一種設計如何定出請求的格式、為計畫設閘門，並乾淨地停止 agent。
 
-|                              | Claude Code                                                                                        |
-| ---------------------------- | -------------------------------------------------------------------------------------------------- |
-| **Pros**               | 每一次停止都經過確認，每一個有風險的計畫都設了閘門。不會丟掉進行中的工作，也不會洩漏 task 記錄。   |
-| **Cons**               | 每次 handshake 都要付出往返次數和 protocol 狀態，比 fire and forget 的 kill 慢。                   |
-| **Why**                | 隊友編輯到一半就被強制停掉，會留下寫到一半的檔案和開著的 task 記錄。有風險的計畫要在行動前先審核。 |
-| **How: message shape** | 在`type` 上區分的 typed union。`request_id` 把每則回覆對應到它的請求。                         |
-| **How: plan approval** | 隊友請求後等待，lead 審核。回覆帶著裁決、可選的 feedback，以及工作所在的權限模式。                 |
-| **How: shutdown**      | lead 先請求，隊友確認後才 kill。task 會被標記為 notified，並發出 terminated 事件。                 |
+| | Claude Code | deepseek-harness |
+| --- | --- | --- |
+| **Pros** | 每一次停止都經過確認，有風險的計畫都設了閘門。 | 只要照公開協定講話，任何 client 或 server 都能接上來。 |
+| **Cons** | 每次 handshake 都要付出往返次數和 protocol 狀態。 | 輸出要等到定案才送出，中途的進度看不到。 |
+| **Why** | 編輯到一半被強制停掉，會留下寫一半的檔案和開著的 task。 | 對面是一個你未必擁有的 process，所以用公開契約講話。 |
+| **How: message shape** | 在 `type` 上區分的 typed union，`request_id` 對應每則回覆。 | 用 session id 分辨的 JSON-RPC 方法，一個 session 同時只跑一個 prompt。 |
+| **How: plan approval** | 隊友請求後等待，lead 的回覆帶著裁決、feedback 和權限模式。 | 計畫送到人面前。被打回來時，會以帶著意見的失敗呼叫回傳。 |
+| **How: shutdown** | lead 先請求，隊友確認後才 kill。 | 先取消、再關掉輸入、再送 signal、最後強殺，每一階都有時限。 |
 
 ---
 
@@ -233,6 +233,9 @@ uv run python sections/17-protocols/src/demo.py  # live demo, needs a key
 
 - [Claude Code 的 protocol 格式](https://github.com/yasasbanukaofficial/claude-code)：`tools/SendMessageTool/SendMessageTool.ts`、`utils/teammateMailbox.ts`。
 - [Claude Code plan 與 stop](https://github.com/yasasbanukaofficial/claude-code)：`tools/ExitPlanModeTool/ExitPlanModeV2Tool.ts`、`tasks/stopTask.ts`、`coordinator/coordinatorMode.ts`。
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness)（`dsh-v0.1.0-rc.7`）：
+  `packages/acp/acp/README.md`、`packages/subagent/subagent-acp/README.md`、`docs/subsystems/session.md`、
+  `docs/subsystems/plan.md`、`docs/subsystems/approval.md`。
 - [learn-claude-code · s16_team_protocols](https://github.com/shareAI-lab/learn-claude-code)：章節框架。
 - [ai-agent-book](https://github.com/bojieli/ai-agent-book)：`book/chapter10.md`（多 Agent 协作），以中文原版為準。
   先收尾再回 ack 的停止、砍掉那一層備援，以及第一個做成功就把整批停掉、靠一把鎖讓這件事只結算一次。

--- a/sections/18-autonomy/README.md
+++ b/sections/18-autonomy/README.md
@@ -190,12 +190,12 @@ How an idle agent finds and claims its own work.
 
 | | Claude Code | deepseek-harness |
 | --- | --- | --- |
-| **Pros** | No dispatcher bottleneck. Idle agents pull work until the board is empty. | Unattended runs are predictable, and the continuation state is durable. |
+| **Pros** | No dispatcher bottleneck. A watcher even picks up tasks made elsewhere. | Unattended runs are predictable, and the continuation state is durable. |
 | **Cons** | Two idle agents can eye one task, so a lock settles the race. | One agent, one goal. The model itself judges when the goal is met. |
 | **Why** | A lead that hands out every task becomes the bottleneck. | Autonomy is a budgeted permission level, not a mode. |
 | **How: idle behavior** | A 500ms poll: shutdown, then unread messages, then a claim. | When fully idle it reserves the next round and queues one prompt. |
-| **How: work claim** | Writes ownership of an unblocked task under a lock, so one claimer wins. | Reserves the next round number against the goal's exact revision. |
-| **How: self-organization** | Workers pull from the shared task board (section 12). | No board. The agent continues its own goal, and fan-out is capped. |
+| **How: work claim** | Writes ownership of an unblocked task under a lock, so one claimer wins. | Reserves the next round against the goal's exact revision, or fails. |
+| **How: self-organization** | Workers pull from the board (section 12). The lead synthesizes, never routes. | No board. The agent continues its own goal, and fan-out is capped. |
 
 ---
 

--- a/sections/18-autonomy/README.md
+++ b/sections/18-autonomy/README.md
@@ -188,14 +188,14 @@ That result comes from the book's own experiment, so one source backs it. Treat 
 
 How an idle agent finds and claims its own work.
 
-| | Claude Code |
-| --- | --- |
-| **Pros** | No dispatcher bottleneck. Idle agents keep pulling work until the board is empty, and externally created tasks are picked up too. |
-| **Cons** | Two idle agents can eye one task, so a real lock and a freshness check settle the race. A lead-assigns model needs no lock but cannot scale past the lead. |
-| **Why** | A lead that hands out every task becomes the bottleneck, and a worker that idles wastes its loaded context. So workers organize themselves. |
-| **How: idle behavior** | Short poll loop, a 500ms cycle. Checks shutdown first, then unread messages (lead before peers), then tries a claim. Announces it is available. |
-| **How: work claim** | Picks an unowned task that nothing blocks, then writes ownership under a lock, so one claimer wins. A watcher also auto-claims tasks created outside. |
-| **How: self-organization** | Workers pull from the shared task board (section 12). The lead is a synthesizer that spawns workers, not a task router. |
+| | Claude Code | deepseek-harness |
+| --- | --- | --- |
+| **Pros** | No dispatcher bottleneck. Idle agents pull work until the board is empty. | Unattended runs are predictable, and the continuation state is durable. |
+| **Cons** | Two idle agents can eye one task, so a lock settles the race. | One agent, one goal. The model itself judges when the goal is met. |
+| **Why** | A lead that hands out every task becomes the bottleneck. | Autonomy is a budgeted permission level, not a mode. |
+| **How: idle behavior** | A 500ms poll: shutdown, then unread messages, then a claim. | When fully idle it reserves the next round and queues one prompt. |
+| **How: work claim** | Writes ownership of an unblocked task under a lock, so one claimer wins. | Reserves the next round number against the goal's exact revision. |
+| **How: self-organization** | Workers pull from the shared task board (section 12). | No board. The agent continues its own goal, and fan-out is capped. |
 
 ---
 
@@ -241,6 +241,9 @@ uv run python sections/18-autonomy/src/demo.py  # live demo, needs a key
   `utils/swarm/inProcessRunner.ts` (`runInProcessTeammate`, `waitForNextPromptOrShutdown`, `findAvailableTask`, `tryClaimNextTask`, `sendIdleNotification`).
 - [Claude Code claim and watch](https://github.com/yasasbanukaofficial/claude-code):
   `utils/tasks.ts` (`claimTask`, `claimTaskWithBusyCheck` under `proper-lockfile`), `hooks/useTaskListWatcher.ts`, `coordinator/coordinatorMode.ts`.
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness) at `dsh-v0.1.0-rc.7`:
+  `packages/bundle/headless/README.md`, `packages/goal/goal-round-driver/README.md`, `packages/workflow/tool-ralph/README.md`,
+  `docs/subsystems/permission-presets.md`, `docs/subsystems/goal.md`.
 - [learn-claude-code · s17 autonomous agents](https://github.com/shareAI-lab/learn-claude-code): section framing.
 - [ai-agent-book · chapter 10](https://github.com/bojieli/ai-agent-book/blob/main/book/chapter10.md) (《深入理解 AI Agent》, 李博杰; the Chinese original is canonical):
   why a pull-style status query is weak, progress files and trajectory tailing, mtime stall detection, the manager pattern's central assignment,

--- a/sections/18-autonomy/README.zh-CN.md
+++ b/sections/18-autonomy/README.zh-CN.md
@@ -187,14 +187,14 @@ def run_teammate(team, store, me, lead, work):         # src/autonomy.py
 
 一个闲置 agent 如何找到并认领属于自己的工作。
 
-| | Claude Code |
-| --- | --- |
-| **Pros** | 没有派工者瓶颈。闲置 agent 会持续拉工作，直到看板清空，外部建立的 task 也会被接手。 |
-| **Cons** | 两个闲置 agent 可能盯上同一个 task，得靠一个真正的 lock 加一次新鲜度检查来裁定竞争。lead 指派不需要 lock，但无法扩展到超过 lead 的处理能力。 |
-| **Why** | lead 逐一派 task 会成为瓶颈，worker 一做完就闲置又浪费刚载入的 context，所以让 worker 自我组织。 |
-| **How: idle behavior** | 短 poll loop，500ms 一个周期。先查 shutdown，再看未读消息（lead 先于 peer），然后尝试认领，并宣告自己有空。 |
-| **How: work claim** | 挑一个无人拥有、也没有被阻挡的 task，在 lock 之下写入拥有权，两个 agent 不会抢到同一个。watcher 也会自动认领外部建立的 task。 |
-| **How: self-organization** | Worker 从共享看板拉取工作（第 12 章）。lead 是 spawn worker 的整合者，不是 task 路由器。 |
+| | Claude Code | deepseek-harness |
+| --- | --- | --- |
+| **Pros** | 没有派工者瓶颈。闲置 agent 会一直拉工作，直到看板清空。 | 无人看管的运行结果可预期，续跑状态也存得住。 |
+| **Cons** | 两个闲置 agent 可能盯上同一个 task，得靠一把锁裁定。 | 一个 agent 只顾一个 goal。做完了没，也是模型自己判断。 |
+| **Why** | lead 逐一派 task 会成为瓶颈，所以让 worker 自我组织。 | 自主不是一种模式，而是一个有预算的权限等级。 |
+| **How: idle behavior** | 500ms 一轮的 poll：先查 shutdown，再看未读消息，然后认领。 | 整个 agent 闲下来时，先订走下一轮，再排一条 prompt。 |
+| **How: work claim** | 在锁之下写入没被阻挡的 task 的拥有权，只有一个人抢得到。 | 拿 goal 当下的版本号去订下一轮，版本对不上就订不到。 |
+| **How: self-organization** | worker 从共享看板拉工作（第 12 章）。 | 没有看板。agent 续跑自己的 goal，往外开的量也有上限。 |
 
 ---
 
@@ -240,6 +240,9 @@ uv run python sections/18-autonomy/src/demo.py  # live demo, needs a key
   `utils/swarm/inProcessRunner.ts`（`runInProcessTeammate`、`waitForNextPromptOrShutdown`、`findAvailableTask`、`tryClaimNextTask`、`sendIdleNotification`）。
 - [Claude Code claim and watch](https://github.com/yasasbanukaofficial/claude-code)：
   `utils/tasks.ts`（`proper-lockfile` 之下的 `claimTask`、`claimTaskWithBusyCheck`）、`hooks/useTaskListWatcher.ts`、`coordinator/coordinatorMode.ts`。
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness)（`dsh-v0.1.0-rc.7`）：
+  `packages/bundle/headless/README.md`、`packages/goal/goal-round-driver/README.md`、`packages/workflow/tool-ralph/README.md`、
+  `docs/subsystems/permission-presets.md`、`docs/subsystems/goal.md`。
 - [learn-claude-code · s17 autonomous agents](https://github.com/shareAI-lab/learn-claude-code)：章节定位。
 - [ai-agent-book · 第 10 章](https://github.com/bojieli/ai-agent-book/blob/main/book/chapter10.md)（《深入理解 AI Agent》，李博杰，以中文原版为准）：
   为什么主动去拉的状态查询很弱、进度文件与跟读 trajectory、用 mtime 判断停摆、manager 模式的集中指派，

--- a/sections/18-autonomy/README.zh-CN.md
+++ b/sections/18-autonomy/README.zh-CN.md
@@ -189,12 +189,12 @@ def run_teammate(team, store, me, lead, work):         # src/autonomy.py
 
 | | Claude Code | deepseek-harness |
 | --- | --- | --- |
-| **Pros** | 没有派工者瓶颈。闲置 agent 会一直拉工作，直到看板清空。 | 无人看管的运行结果可预期，续跑状态也存得住。 |
+| **Pros** | 没有派工者瓶颈。watcher 连别处建立的 task 也会接手。 | 无人看管的运行结果可预期，续跑状态也存得住。 |
 | **Cons** | 两个闲置 agent 可能盯上同一个 task，得靠一把锁裁定。 | 一个 agent 只顾一个 goal。做完了没，也是模型自己判断。 |
 | **Why** | lead 逐一派 task 会成为瓶颈，所以让 worker 自我组织。 | 自主不是一种模式，而是一个有预算的权限等级。 |
 | **How: idle behavior** | 500ms 一轮的 poll：先查 shutdown，再看未读消息，然后认领。 | 整个 agent 闲下来时，先订走下一轮，再排一条 prompt。 |
 | **How: work claim** | 在锁之下写入没被阻挡的 task 的拥有权，只有一个人抢得到。 | 拿 goal 当下的版本号去订下一轮，版本对不上就订不到。 |
-| **How: self-organization** | worker 从共享看板拉工作（第 12 章）。 | 没有看板。agent 续跑自己的 goal，往外开的量也有上限。 |
+| **How: self-organization** | worker 从看板拉工作（第 12 章）。lead 只做整合，不派工。 | 没有看板。agent 续跑自己的 goal，往外开的量也有上限。 |
 
 ---
 

--- a/sections/18-autonomy/README.zh-TW.md
+++ b/sections/18-autonomy/README.zh-TW.md
@@ -187,14 +187,14 @@ def run_teammate(team, store, me, lead, work):         # src/autonomy.py
 
 一個閒置 agent 如何找到並認領屬於自己的工作。
 
-| | Claude Code |
-| --- | --- |
-| **Pros** | 沒有派工者瓶頸。閒置 agent 會持續拉工作，直到看板清空，外部建立的 task 也會被接手。 |
-| **Cons** | 兩個閒置 agent 可能盯上同一個 task，得靠一個真正的 lock 加一次新鮮度檢查來裁定競爭。lead 指派不需要 lock，但無法擴展到超過 lead 的處理能力。 |
-| **Why** | lead 逐一派 task 會成為瓶頸，worker 一做完就閒置又浪費剛載入的 context，所以讓 worker 自我組織。 |
-| **How: idle behavior** | 短 poll loop，500ms 一個週期。先查 shutdown，再看未讀訊息（lead 先於 peer），接著嘗試認領，並宣告自己有空。 |
-| **How: work claim** | 挑一個無人擁有、也沒有被阻擋的 task，在 lock 之下寫入擁有權，兩個 agent 不會搶到同一個。watcher 也會自動認領外部建立的 task。 |
-| **How: self-organization** | Worker 從共享看板拉取工作（第 12 章）。lead 是 spawn worker 的整合者，不是 task 路由器。 |
+| | Claude Code | deepseek-harness |
+| --- | --- | --- |
+| **Pros** | 沒有派工者瓶頸。閒置 agent 會一直拉工作，直到看板清空。 | 無人看管的執行結果可預期，續跑狀態也存得住。 |
+| **Cons** | 兩個閒置 agent 可能盯上同一個 task，得靠一把鎖裁定。 | 一個 agent 只顧一個 goal。做完了沒，也是模型自己判斷。 |
+| **Why** | lead 逐一派 task 會成為瓶頸，所以讓 worker 自我組織。 | 自主不是一種模式，而是一個有預算的權限等級。 |
+| **How: idle behavior** | 500ms 一輪的 poll：先查 shutdown，再看未讀訊息，接著認領。 | 整個 agent 閒下來時，先訂走下一輪，再排一則 prompt。 |
+| **How: work claim** | 在鎖之下寫入沒被阻擋的 task 的擁有權，只有一個人搶得到。 | 拿 goal 當下的版本號去訂下一輪，版本對不上就訂不到。 |
+| **How: self-organization** | worker 從共享看板拉工作（第 12 章）。 | 沒有看板。agent 續跑自己的 goal，往外開的量也有上限。 |
 
 ---
 
@@ -240,6 +240,9 @@ uv run python sections/18-autonomy/src/demo.py  # live demo, needs a key
   `utils/swarm/inProcessRunner.ts`（`runInProcessTeammate`、`waitForNextPromptOrShutdown`、`findAvailableTask`、`tryClaimNextTask`、`sendIdleNotification`）。
 - [Claude Code claim and watch](https://github.com/yasasbanukaofficial/claude-code)：
   `utils/tasks.ts`（`proper-lockfile` 之下的 `claimTask`、`claimTaskWithBusyCheck`）、`hooks/useTaskListWatcher.ts`、`coordinator/coordinatorMode.ts`。
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness)（`dsh-v0.1.0-rc.7`）：
+  `packages/bundle/headless/README.md`、`packages/goal/goal-round-driver/README.md`、`packages/workflow/tool-ralph/README.md`、
+  `docs/subsystems/permission-presets.md`、`docs/subsystems/goal.md`。
 - [learn-claude-code · s17 autonomous agents](https://github.com/shareAI-lab/learn-claude-code)：章節定位。
 - [ai-agent-book · 第 10 章](https://github.com/bojieli/ai-agent-book/blob/main/book/chapter10.md)（《深入理解 AI Agent》，李博杰，以中文原版為準）：
   為什麼主動去拉的狀態查詢很弱、進度檔與跟讀 trajectory、用 mtime 判斷停擺、manager 模式的集中指派，

--- a/sections/18-autonomy/README.zh-TW.md
+++ b/sections/18-autonomy/README.zh-TW.md
@@ -189,12 +189,12 @@ def run_teammate(team, store, me, lead, work):         # src/autonomy.py
 
 | | Claude Code | deepseek-harness |
 | --- | --- | --- |
-| **Pros** | 沒有派工者瓶頸。閒置 agent 會一直拉工作，直到看板清空。 | 無人看管的執行結果可預期，續跑狀態也存得住。 |
+| **Pros** | 沒有派工者瓶頸。watcher 連別處建立的 task 也會接手。 | 無人看管的執行結果可預期，續跑狀態也存得住。 |
 | **Cons** | 兩個閒置 agent 可能盯上同一個 task，得靠一把鎖裁定。 | 一個 agent 只顧一個 goal。做完了沒，也是模型自己判斷。 |
 | **Why** | lead 逐一派 task 會成為瓶頸，所以讓 worker 自我組織。 | 自主不是一種模式，而是一個有預算的權限等級。 |
 | **How: idle behavior** | 500ms 一輪的 poll：先查 shutdown，再看未讀訊息，接著認領。 | 整個 agent 閒下來時，先訂走下一輪，再排一則 prompt。 |
 | **How: work claim** | 在鎖之下寫入沒被阻擋的 task 的擁有權，只有一個人搶得到。 | 拿 goal 當下的版本號去訂下一輪，版本對不上就訂不到。 |
-| **How: self-organization** | worker 從共享看板拉工作（第 12 章）。 | 沒有看板。agent 續跑自己的 goal，往外開的量也有上限。 |
+| **How: self-organization** | worker 從看板拉工作（第 12 章）。lead 只做整合，不派工。 | 沒有看板。agent 續跑自己的 goal，往外開的量也有上限。 |
 
 ---
 


### PR DESCRIPTION
Closes #77. Part of PRD #72.

## What changed

- Sections 16, 17, 18 each gain a deepseek-harness column, mirrored in `README.zh-TW.md` and `README.zh-CN.md`.
- Section 17's zh-TW table used padded, aligned pipes; it now matches the compact row style used everywhere else.
- Existing cells were tightened where a new column pushed a row past 180 characters.
- No src changes in this batch.

## Verification

- `python sections/1{6,7,8}/src/test.py` still pass offline.
- No line over 180 characters, no em or en dashes, table column counts consistent across all three languages.