### PR TITLE
dsh batch 6: sections 19-21 columns, section 0 mention, section 22 cite

### DIFF
--- a/sections/00-harness-thesis/README.md
+++ b/sections/00-harness-thesis/README.md
@@ -48,6 +48,10 @@ Each layer covers something the current model cannot do alone. That gives every 
 So harness engineering is not only adding. When the model changes, re-evaluate each layer: keep what still helps, delete what the new model covers.
 Sections 20 and 21 build the measurements for this. mini-swe-agent is the extreme case: almost no harness, so almost nothing to re-evaluate.
 
+deepseek-harness answers the same problem from the other end. Every part is a plugin, the loop included, and no core is privileged over the rest.
+Each capability is published at a named seam, and one plugin claims it: tools at one seam, permissions at another, context handling at a third.
+So re-evaluating a layer is a config change, not a fork. Deleting a layer means not loading that plugin.
+
 ### Further reading
 
 Two framings from ai-agent-book. Claims to test, not this repo's own findings.
@@ -106,5 +110,7 @@ What the model decides versus what the surrounding code builds.
 - [Claude Code source (`cc-src/src`)](https://github.com/yasasbanukaofficial/claude-code): `QueryEngine.ts`, `query/`, `Tool.ts`, `tools/`, `hooks/`, `types/permissions.ts`.
 - [mini-swe-agent source](https://github.com/swe-agent/mini-swe-agent): `agents/default.py`, `environments/local.py`, protocols in `__init__.py`.
 - [mini-swe-agent README](https://github.com/swe-agent/mini-swe-agent): the case for a minimal harness as models improve.
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness) at `dsh-v0.1.0-rc.7`:
+  `docs/architecture.md`, `docs/capability-seams.md`, `docs/cordis-primer.md`, `docs/subsystems/core.md`.
 - [learn-claude-code · s20_comprehensive](https://github.com/shareAI-lab/learn-claude-code): section framing.
 - [ai-agent-book](https://github.com/bojieli/ai-agent-book): `book/chapter5.md`, Chinese original canonical. Boundary framing and the task quadrant, both single-source.

--- a/sections/00-harness-thesis/README.zh-CN.md
+++ b/sections/00-harness-thesis/README.zh-CN.md
@@ -48,6 +48,10 @@ harness 必须：
 所以 harness engineering 不是只有加，也包含删。模型换代时，重新评估每一层：还有帮助的留下，新模型自己就做得到的就删掉。
 怎么量测，见第 20、21 章。mini-swe-agent 就是最极端的例子：几乎没有 harness，也就几乎没有东西需要重新评估。
 
+deepseek-harness 是从另一端回答同一个问题。它每个部分都是 plugin，连 loop 也是，没有哪一块算是特权内核。
+每种能力都挂在一个有名字的接缝上，由一个 plugin 认领：工具一个接缝、权限一个接缝、context 处理又一个。
+所以重新评估某一层只是改配置，不用 fork。要删掉一层，就是不要加载那个 plugin。
+
 ### 延伸阅读
 
 以下两个框架出自 ai-agent-book，是可以拿去验的说法，不是本项目的结论。
@@ -106,5 +110,7 @@ harness 必须：
 - [Claude Code source (`cc-src/src`)](https://github.com/yasasbanukaofficial/claude-code)：`QueryEngine.ts`、`query/`、`Tool.ts`、`tools/`、`hooks/`、`types/permissions.ts`。
 - [mini-swe-agent source](https://github.com/swe-agent/mini-swe-agent)：`agents/default.py`、`environments/local.py`、`__init__.py` 里的 protocol。
 - [mini-swe-agent README](https://github.com/swe-agent/mini-swe-agent)：模型变强之后，harness 可以更小的理由。
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness)（`dsh-v0.1.0-rc.7`）：
+  `docs/architecture.md`、`docs/capability-seams.md`、`docs/cordis-primer.md`、`docs/subsystems/core.md`。
 - [learn-claude-code · s20_comprehensive](https://github.com/shareAI-lab/learn-claude-code)：章节框架。
 - [ai-agent-book](https://github.com/bojieli/ai-agent-book)：`book/chapter5.md`，以中文原版为准。界线框架与任务象限，两者都只有单一来源。

--- a/sections/00-harness-thesis/README.zh-CN.md
+++ b/sections/00-harness-thesis/README.zh-CN.md
@@ -48,7 +48,7 @@ harness 必须：
 所以 harness engineering 不是只有加，也包含删。模型换代时，重新评估每一层：还有帮助的留下，新模型自己就做得到的就删掉。
 怎么量测，见第 20、21 章。mini-swe-agent 就是最极端的例子：几乎没有 harness，也就几乎没有东西需要重新评估。
 
-deepseek-harness 是从另一端回答同一个问题。它每个部分都是 plugin，连 loop 也是，没有哪一块算是特权内核。
+deepseek-harness 是从另一端回答同一个问题。它每个部分都是 plugin，连 loop 也是，没有哪一块算是特权核心。
 每种能力都挂在一个有名字的接缝上，由一个 plugin 认领：工具一个接缝、权限一个接缝、context 处理又一个。
 所以重新评估某一层只是改配置，不用 fork。要删掉一层，就是不要加载那个 plugin。
 

--- a/sections/00-harness-thesis/README.zh-TW.md
+++ b/sections/00-harness-thesis/README.zh-TW.md
@@ -48,6 +48,10 @@ harness 必須：
 所以 harness engineering 不是只有加，也包含刪。模型換代時，重新評估每一層：還有幫助的留下，新模型自己就做得到的就刪掉。
 怎麼量測，見第 20、21 章。mini-swe-agent 就是最極端的例子：幾乎沒有 harness，也就幾乎沒有東西需要重新評估。
 
+deepseek-harness 是從另一端回答同一個問題。它每個部分都是 plugin，連 loop 也是，沒有哪一塊算是特權核心。
+每種能力都掛在一個有名字的接縫上，由一個 plugin 認領：工具一個接縫、權限一個接縫、context 處理又一個。
+所以重新評估某一層只是改設定，不用 fork。要刪掉一層，就是不要載入那個 plugin。
+
 ### 延伸閱讀
 
 以下兩個框架出自 ai-agent-book，是可以拿去驗的說法，不是本專案的結論。
@@ -106,5 +110,7 @@ harness 必須：
 - [Claude Code source (`cc-src/src`)](https://github.com/yasasbanukaofficial/claude-code)：`QueryEngine.ts`、`query/`、`Tool.ts`、`tools/`、`hooks/`、`types/permissions.ts`。
 - [mini-swe-agent source](https://github.com/swe-agent/mini-swe-agent)：`agents/default.py`、`environments/local.py`、`__init__.py` 裡的 protocol。
 - [mini-swe-agent README](https://github.com/swe-agent/mini-swe-agent)：模型變強之後，harness 可以更小的理由。
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness)（`dsh-v0.1.0-rc.7`）：
+  `docs/architecture.md`、`docs/capability-seams.md`、`docs/cordis-primer.md`、`docs/subsystems/core.md`。
 - [learn-claude-code · s20_comprehensive](https://github.com/shareAI-lab/learn-claude-code)：章節框架。
 - [ai-agent-book](https://github.com/bojieli/ai-agent-book)：`book/chapter5.md`，以中文原版為準。界線框架與任務象限，兩者都只有單一來源。

--- a/sections/19-mcp-plugins-channels/README.md
+++ b/sections/19-mcp-plugins-channels/README.md
@@ -186,11 +186,11 @@ How the harness reaches outside itself.
 | | Claude Code | Hermes Agent | deepseek-harness |
 | --- | --- | --- | --- |
 | **Pros** | Any service, any language, no harness edits. | Other clients can drive it as an MCP server. | A server is config, so one can swap without a restart. |
-| **Cons** | Each server is new attack surface. The tool list bloats. | Anyone can send to a channel, spam included. | Tools only, and no chat channels to push messages in. |
+| **Cons** | New attack surface, on self-reported annotations. | Anyone can send to a channel: spam, or steering text. | Tools only, and no chat channels to push messages in. |
 | **Why** | Without MCP, capability is frozen at what shipped. | The agent is MCP client and server at once. | Everything is a plugin, so a server is one more plugin. |
-| **How: transports** | Six, from local stdio to remote http. | MCP both ways, plus chat platform adapters. | Local stdio and streaming http, one plugin per server. |
+| **How: transports** | Six, from stdio to remote http, in separate pools. | MCP both ways, plus chat adapters. | Local stdio and streaming http, one plugin per server. |
 | **How: plugin format** | A plugin bundles servers, hooks, and skills, merged by precedence. | A manifest plus a register entry. | Config rows. A patch replaces one row by id. |
-| **How: tool pool assembly** | Each server tool is cloned, namespaced, merged. | Plugin and MCP tools join one registry. | A server's tools swap as one set, or roll back whole. |
+| **How: tool pool assembly** | Cloned and namespaced; annotations feed the gate. | Plugin and MCP tools join one registry. | A server's tools swap as one set, or roll back. |
 
 ---
 

--- a/sections/19-mcp-plugins-channels/README.md
+++ b/sections/19-mcp-plugins-channels/README.md
@@ -183,14 +183,14 @@ So deferred loading is a setting to check in your own harness. A server cannot a
 
 How the harness reaches outside itself.
 
-| | Claude Code | Hermes Agent |
-| --- | --- | --- |
-| **Pros** | Any service, any language, no harness edits. Loop and gate stay unchanged. | Other clients can drive it as an MCP server. Inbound messages are gated first. |
-| **Cons** | Each server is new attack surface with self reported annotations. The tool list bloats. | Anyone can send to a channel: spam or steering instructions arrive too. |
-| **Why** | Without MCP, capability is frozen at whatever shipped in the binary. | The agent is MCP client and server at once, and chat platforms are its two-way surface. |
-| **How: transports** | Six, from local stdio to remote http/sse/ws, in separate connection pools. | MCP both ways, plus chat platform adapters. Voice rides the same channels. |
-| **How: plugin format** | A plugin bundles servers, hooks, skills. Config merges by precedence. | A manifest plus a register entry. Built-in overrides need operator opt-in. |
-| **How: tool pool assembly** | Each server tool cloned, namespaced, merged with built-ins. Annotations feed the gate. | Plugin and MCP tools join one import-time registry. |
+| | Claude Code | Hermes Agent | deepseek-harness |
+| --- | --- | --- | --- |
+| **Pros** | Any service, any language, no harness edits. | Other clients can drive it as an MCP server. | A server is config, so one can swap without a restart. |
+| **Cons** | Each server is new attack surface. The tool list bloats. | Anyone can send to a channel, spam included. | Tools only, and no chat channels to push messages in. |
+| **Why** | Without MCP, capability is frozen at what shipped. | The agent is MCP client and server at once. | Everything is a plugin, so a server is one more plugin. |
+| **How: transports** | Six, from local stdio to remote http. | MCP both ways, plus chat platform adapters. | Local stdio and streaming http, one plugin per server. |
+| **How: plugin format** | A plugin bundles servers, hooks, and skills, merged by precedence. | A manifest plus a register entry. | Config rows. A patch replaces one row by id. |
+| **How: tool pool assembly** | Each server tool is cloned, namespaced, merged. | Plugin and MCP tools join one registry. | A server's tools swap as one set, or roll back whole. |
 
 ---
 
@@ -238,6 +238,8 @@ uv run python sections/19-mcp-plugins-channels/src/demo.py  # live demo, needs a
   `services/mcp/types.ts` (`TransportSchema`), `client.ts` (`MCPTool` cloning, `buildMcpToolName`), `normalization.ts` (`normalizeNameForMCP`).
 - [Claude Code MCP config and channels](https://github.com/yasasbanukaofficial/claude-code):
   `config.ts` (precedence), `channelNotification.ts` (`CHANNEL_TAG`), plus `McpAuthTool`, `ListMcpResourcesTool`, `ReadMcpResourceTool`.
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness) at `dsh-v0.1.0-rc.7`:
+  `docs/architecture.md`, `docs/cordis-primer.md`, `packages/acp/acp/README.md`, `packages/extensions/tool-cordis/README.md`.
 - [Claude Code plugins](https://github.com/yasasbanukaofficial/claude-code): `plugins/builtinPlugins.ts`, `plugins/bundled/`, `types/plugin.ts`, plus `remote/` and `bridge/`.
 - [Hermes Agent source](https://github.com/NousResearch/hermes-agent):
   `mcp_serve.py`, `hermes_cli/plugins.py` (`PluginManager`, `VALID_HOOKS`), `gateway/platforms/`, `gateway/platform_registry.py`, `plugins/platforms/`.

--- a/sections/19-mcp-plugins-channels/README.zh-CN.md
+++ b/sections/19-mcp-plugins-channels/README.zh-CN.md
@@ -180,14 +180,14 @@ run_turn([...goal...], model, reg, Session(mode=DEFAULT))   # the one agent call
 
 harness 如何伸手触及自身之外。
 
-| | Claude Code | Hermes Agent |
-| --- | --- | --- |
-| **Pros** | 任何服务、任何语言都接得上，不用改 harness。loop 与 gate 都不变。 | 其他 client 能把它当 MCP server 来用。每条从平台进来的消息都先过 gate。 |
-| **Cons** | 每个连上的 server 都是新的攻击面，annotation 又是自我陈报的。工具清单会膨胀。 | channel 的消息谁都能发：垃圾消息、想操纵 agent 的指令也会进来。 |
-| **Why** | 少了 MCP，能力就停在安装当下内建的那一套。 | agent 同时是 MCP client 和 MCP server，聊天平台就是它的双向接口。 |
-| **How: transports** | 六种，从 stdio 到 http/sse/ws。本地与远端 server 各连各的池。 | MCP 双向，加上聊天平台 adapter。语音走同样的 channel。 |
-| **How: plugin format** | 一个 plugin 打包 server、hook、skill。配置按优先级分层合并。 | 一份 manifest 加一个注册入口。要覆盖内建工具，操作者得明确同意。 |
-| **How: tool pool assembly** | 每个 server 工具被复制、加命名空间，并与内建工具合并。annotation 成为 gate 的权限提示。 | plugin 与 MCP 工具加入同一个 import 时建立的 registry。 |
+| | Claude Code | Hermes Agent | deepseek-harness |
+| --- | --- | --- | --- |
+| **Pros** | 任何服务、任何语言都接得上，不用改 harness。 | 其他 client 能把它当 MCP server 来用。 | server 就是一份配置，不重启也能换掉一台。 |
+| **Cons** | 每个 server 都是新的攻击面，工具清单也会膨胀。 | channel 谁都能发消息，垃圾消息也一样。 | 只接工具，也没有聊天 channel 能把消息推进来。 |
+| **Why** | 少了 MCP，能力就停在安装当下内建的那一套。 | agent 同时是 MCP client 和 MCP server。 | 每样东西都是 plugin，MCP server 也只是其中一个。 |
+| **How: transports** | 六种，从本地 stdio 到远端 http，各连各的池。 | MCP 双向，加上聊天平台 adapter。 | 本地 stdio 和 streaming http，一台 server 一个 plugin。 |
+| **How: plugin format** | 一个 plugin 打包 server、hook、skill，按优先级合并。 | 一份 manifest 加一个注册入口。 | 一行一行的配置。patch 用 id 整行换掉。 |
+| **How: tool pool assembly** | 每个 server 工具被复制、加命名空间，再与内建工具合并。 | plugin 与 MCP 工具进同一个 registry。 | 一台 server 的工具整批换上，出错就整批回滚。 |
 
 ---
 
@@ -235,6 +235,8 @@ uv run python sections/19-mcp-plugins-channels/src/demo.py  # live demo, needs a
   `services/mcp/types.ts`（`TransportSchema`）、`client.ts`（`MCPTool` cloning、`buildMcpToolName`）、`normalization.ts`（`normalizeNameForMCP`）。
 - [Claude Code MCP config and channels](https://github.com/yasasbanukaofficial/claude-code)：
   `config.ts`（precedence）、`channelNotification.ts`（`CHANNEL_TAG`），加上 `McpAuthTool`、`ListMcpResourcesTool`、`ReadMcpResourceTool`。
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness)（`dsh-v0.1.0-rc.7`）：
+  `docs/architecture.md`、`docs/cordis-primer.md`、`packages/acp/acp/README.md`、`packages/extensions/tool-cordis/README.md`。
 - [Claude Code plugins](https://github.com/yasasbanukaofficial/claude-code)：`plugins/builtinPlugins.ts`、`plugins/bundled/`、`types/plugin.ts`，加上 `remote/` 与 `bridge/`。
 - [Hermes Agent 源码](https://github.com/NousResearch/hermes-agent)：
   `mcp_serve.py`、`hermes_cli/plugins.py`（`PluginManager`、`VALID_HOOKS`）、`gateway/platforms/`、`gateway/platform_registry.py`、`plugins/platforms/`。

--- a/sections/19-mcp-plugins-channels/README.zh-CN.md
+++ b/sections/19-mcp-plugins-channels/README.zh-CN.md
@@ -183,11 +183,11 @@ harness 如何伸手触及自身之外。
 | | Claude Code | Hermes Agent | deepseek-harness |
 | --- | --- | --- | --- |
 | **Pros** | 任何服务、任何语言都接得上，不用改 harness。 | 其他 client 能把它当 MCP server 来用。 | server 就是一份配置，不重启也能换掉一台。 |
-| **Cons** | 每个 server 都是新的攻击面，工具清单也会膨胀。 | channel 谁都能发消息，垃圾消息也一样。 | 只接工具，也没有聊天 channel 能把消息推进来。 |
+| **Cons** | 每个 server 都是新的攻击面，annotation 还是自己报的。 | channel 谁都能发：垃圾消息，想操纵 agent 的话也一样。 | 只接工具，也没有聊天 channel 能把消息推进来。 |
 | **Why** | 少了 MCP，能力就停在安装当下内建的那一套。 | agent 同时是 MCP client 和 MCP server。 | 每样东西都是 plugin，MCP server 也只是其中一个。 |
 | **How: transports** | 六种，从本地 stdio 到远端 http，各连各的池。 | MCP 双向，加上聊天平台 adapter。 | 本地 stdio 和 streaming http，一台 server 一个 plugin。 |
 | **How: plugin format** | 一个 plugin 打包 server、hook、skill，按优先级合并。 | 一份 manifest 加一个注册入口。 | 一行一行的配置。patch 用 id 整行换掉。 |
-| **How: tool pool assembly** | 每个 server 工具被复制、加命名空间，再与内建工具合并。 | plugin 与 MCP 工具进同一个 registry。 | 一台 server 的工具整批换上，出错就整批回滚。 |
+| **How: tool pool assembly** | 复制、加命名空间，annotation 成为 gate 的权限提示。 | plugin 与 MCP 工具进同一个 registry。 | 一台 server 的工具整批换上，出错就整批回滚。 |
 
 ---
 

--- a/sections/19-mcp-plugins-channels/README.zh-TW.md
+++ b/sections/19-mcp-plugins-channels/README.zh-TW.md
@@ -180,14 +180,14 @@ run_turn([...goal...], model, reg, Session(mode=DEFAULT))   # the one agent call
 
 harness 如何伸手觸及自身之外。
 
-| | Claude Code | Hermes Agent |
-| --- | --- | --- |
-| **Pros** | 任何服務、任何語言都接得上，不用改 harness。loop 與 gate 都不變。 | 其他 client 能把它當 MCP server 來用。每則從平台進來的訊息都先過 gate。 |
-| **Cons** | 每個連上的 server 都是新的攻擊面，annotation 又是自我陳報的。工具清單會膨脹。 | channel 的訊息誰都能發：垃圾訊息、想操縱 agent 的指令也會進來。 |
-| **Why** | 少了 MCP，能力就停在安裝當下內建的那一套。 | agent 同時是 MCP client 和 MCP server，聊天平台就是它的雙向介面。 |
-| **How: transports** | 六種，從 stdio 到 http/sse/ws。本地與遠端 server 各連各的池。 | MCP 雙向，加上聊天平台 adapter。語音走同樣的 channel。 |
-| **How: plugin format** | 一個 plugin 打包 server、hook、skill。設定按優先序分層合併。 | 一份 manifest 加一個註冊進入點。要覆蓋內建工具，操作者得明確同意。 |
-| **How: tool pool assembly** | 每個 server 工具被複製、加命名空間，並與內建工具合併。annotation 成為 gate 的權限提示。 | plugin 與 MCP 工具加入同一個 import 時建立的 registry。 |
+| | Claude Code | Hermes Agent | deepseek-harness |
+| --- | --- | --- | --- |
+| **Pros** | 任何服務、任何語言都接得上，不用改 harness。 | 其他 client 能把它當 MCP server 來用。 | server 就是一份設定，不重啟也能換掉一台。 |
+| **Cons** | 每個 server 都是新的攻擊面，工具清單也會膨脹。 | channel 誰都能發訊息，垃圾訊息也一樣。 | 只接工具，也沒有聊天 channel 能把訊息推進來。 |
+| **Why** | 少了 MCP，能力就停在安裝當下內建的那一套。 | agent 同時是 MCP client 和 MCP server。 | 每樣東西都是 plugin，MCP server 也只是其中一個。 |
+| **How: transports** | 六種，從本地 stdio 到遠端 http，各連各的池。 | MCP 雙向，加上聊天平台 adapter。 | 本地 stdio 和 streaming http，一台 server 一個 plugin。 |
+| **How: plugin format** | 一個 plugin 打包 server、hook、skill，按優先序合併。 | 一份 manifest 加一個註冊進入點。 | 一列一列的設定。patch 用 id 整列換掉。 |
+| **How: tool pool assembly** | 每個 server 工具被複製、加命名空間，再與內建工具合併。 | plugin 與 MCP 工具進同一個 registry。 | 一台 server 的工具整批換上，出錯就整批回滾。 |
 
 ---
 
@@ -235,6 +235,8 @@ uv run python sections/19-mcp-plugins-channels/src/demo.py  # live demo, needs a
   `services/mcp/types.ts`（`TransportSchema`）、`client.ts`（`MCPTool` cloning、`buildMcpToolName`）、`normalization.ts`（`normalizeNameForMCP`）。
 - [Claude Code MCP config and channels](https://github.com/yasasbanukaofficial/claude-code)：
   `config.ts`（precedence）、`channelNotification.ts`（`CHANNEL_TAG`），加上 `McpAuthTool`、`ListMcpResourcesTool`、`ReadMcpResourceTool`。
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness)（`dsh-v0.1.0-rc.7`）：
+  `docs/architecture.md`、`docs/cordis-primer.md`、`packages/acp/acp/README.md`、`packages/extensions/tool-cordis/README.md`。
 - [Claude Code plugins](https://github.com/yasasbanukaofficial/claude-code)：`plugins/builtinPlugins.ts`、`plugins/bundled/`、`types/plugin.ts`，加上 `remote/` 與 `bridge/`。
 - [Hermes Agent 原始碼](https://github.com/NousResearch/hermes-agent)：
   `mcp_serve.py`、`hermes_cli/plugins.py`（`PluginManager`、`VALID_HOOKS`）、`gateway/platforms/`、`gateway/platform_registry.py`、`plugins/platforms/`。

--- a/sections/19-mcp-plugins-channels/README.zh-TW.md
+++ b/sections/19-mcp-plugins-channels/README.zh-TW.md
@@ -183,11 +183,11 @@ harness 如何伸手觸及自身之外。
 | | Claude Code | Hermes Agent | deepseek-harness |
 | --- | --- | --- | --- |
 | **Pros** | 任何服務、任何語言都接得上，不用改 harness。 | 其他 client 能把它當 MCP server 來用。 | server 就是一份設定，不重啟也能換掉一台。 |
-| **Cons** | 每個 server 都是新的攻擊面，工具清單也會膨脹。 | channel 誰都能發訊息，垃圾訊息也一樣。 | 只接工具，也沒有聊天 channel 能把訊息推進來。 |
+| **Cons** | 每個 server 都是新的攻擊面，annotation 還是自己報的。 | channel 誰都能發：垃圾訊息，想操縱 agent 的話也一樣。 | 只接工具，也沒有聊天 channel 能把訊息推進來。 |
 | **Why** | 少了 MCP，能力就停在安裝當下內建的那一套。 | agent 同時是 MCP client 和 MCP server。 | 每樣東西都是 plugin，MCP server 也只是其中一個。 |
 | **How: transports** | 六種，從本地 stdio 到遠端 http，各連各的池。 | MCP 雙向，加上聊天平台 adapter。 | 本地 stdio 和 streaming http，一台 server 一個 plugin。 |
 | **How: plugin format** | 一個 plugin 打包 server、hook、skill，按優先序合併。 | 一份 manifest 加一個註冊進入點。 | 一列一列的設定。patch 用 id 整列換掉。 |
-| **How: tool pool assembly** | 每個 server 工具被複製、加命名空間，再與內建工具合併。 | plugin 與 MCP 工具進同一個 registry。 | 一台 server 的工具整批換上，出錯就整批回滾。 |
+| **How: tool pool assembly** | 複製、加命名空間，annotation 成為 gate 的權限提示。 | plugin 與 MCP 工具進同一個 registry。 | 一台 server 的工具整批換上，出錯就整批回滾。 |
 
 ---
 

--- a/sections/20-observability/README.md
+++ b/sections/20-observability/README.md
@@ -157,14 +157,14 @@ Do this continuously and the eval set follows what users actually do. Section 23
 
 How each agent emits telemetry, tracks spend, and feeds the eval set.
 
-| | Claude Code | mini-swe-agent |
-| --- | --- | --- |
-| **Pros** | Rich production visibility, cheap and safe. A bad sink never stalls the loop. | Even a crashed run leaves a file. Files double as audit log and eval corpus. |
-| **Cons** | Only says what happened, not if the answer was good. Sampling and scrubbing drop part of the record. | Almost no production telemetry. No live event stream to watch. |
-| **Why** | Production must be watched for crashes and cost spikes, without touching the loop. | Quality is graded offline by benchmark, so the full run record matters most. |
-| **How: telemetry** | Events queue until a sink attaches, then sample, scrub, and fan out. | One trajectory file per run: messages, config, cost, exit status, saved each step. |
-| **How: cost tracking** | Per-model tokens priced into one session USD total, shown on exit. | litellm prices each call into run and global totals; unknown models raise errors. |
-| **How: eval feed** | Not in source; reconstruction: scrubbed traces become regression cases. | Saved trajectories are the corpus; a shipped benchmark runner grades a task set. |
+| | Claude Code | mini-swe-agent | deepseek-harness |
+| --- | --- | --- | --- |
+| **Pros** | Rich production visibility, cheap and safe. | Even a crashed run leaves a file. | Nothing extra to instrument: what the model sees is logged. |
+| **Cons** | Says what happened, not whether the answer was good. | Almost no production telemetry. | Ships no redaction rules. Delivery can lose or repeat. |
+| **Why** | Production must be watched without touching the loop. | Quality is graded offline, so the run record matters. | The session log is already the record, so export it. |
+| **How: telemetry** | Events queue for a sink, then sample and scrub. | One trajectory file per run, saved each step. | Session events mirror out through a redaction pass. |
+| **How: cost tracking** | Per-model tokens priced into one session total. | Per-call prices roll into run totals. | A replay pass prices the log in tokens, never dollars. |
+| **How: eval feed** | Not in source; scrubbed traces become regression cases. | Saved trajectories feed a benchmark runner. | Recorded runs replay with no key, as fixtures. |
 
 ---
 
@@ -206,6 +206,8 @@ uv run python sections/20-observability/src/demo.py  # live demo, needs a key
   `services/analytics/index.ts` (queue + `logEvent`), `sink.ts`, `datadog.ts`, `firstPartyEventLogger.ts`, `sinkKillswitch.ts`, `shouldSampleEvent`.
 - [Claude Code cost and diagnostics](https://github.com/yasasbanukaofficial/claude-code):
   `cost-tracker.ts`, `utils/modelCost.ts`, `costHook.ts` (`formatTotalCost`), `diagnosticTracking.ts`, `upstreamproxy/relay.ts`.
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness) at `dsh-v0.1.0-rc.7`:
+  `docs/subsystems/telemetry.md`, `docs/subsystems/token-meter.md`, `packages/llm/llm-replay/README.md`, `docs/subsystems/invariants.md`.
 - [ai-agent-book](https://github.com/bojieli/ai-agent-book): `book/chapter6.md`, Chinese original canonical.
   The span tree, nonlinear agent cost with per-task caps, and production traces recycled into the eval set.
   The cost analysis carries no external citation there, so it is single-source.

--- a/sections/20-observability/README.md
+++ b/sections/20-observability/README.md
@@ -161,9 +161,9 @@ How each agent emits telemetry, tracks spend, and feeds the eval set.
 | --- | --- | --- | --- |
 | **Pros** | Rich production visibility, cheap and safe. | Even a crashed run leaves a file. | Nothing extra to instrument: what the model sees is logged. |
 | **Cons** | Says what happened, not whether the answer was good. | Almost no production telemetry. | Ships no redaction rules. Delivery can lose or repeat. |
-| **Why** | Production must be watched without touching the loop. | Quality is graded offline, so the run record matters. | The session log is already the record, so export it. |
+| **Why** | Production must be watched without touching the loop. | A benchmark grades offline, so the full record matters. | The session log is already the record, so export it. |
 | **How: telemetry** | Events queue for a sink, then sample and scrub. | One trajectory file per run, saved each step. | Session events mirror out through a redaction pass. |
-| **How: cost tracking** | Per-model tokens priced into one session total. | Per-call prices roll into run totals. | A replay pass prices the log in tokens, never dollars. |
+| **How: cost tracking** | Per-model tokens priced into a session total. | Per-call prices roll into run and global totals. | A replay pass prices the log in tokens, not dollars. |
 | **How: eval feed** | Not in source; scrubbed traces become regression cases. | Saved trajectories feed a benchmark runner. | Recorded runs replay with no key, as fixtures. |
 
 ---

--- a/sections/20-observability/README.zh-CN.md
+++ b/sections/20-observability/README.zh-CN.md
@@ -152,14 +152,14 @@ context 里多出来的任何东西，后面每一轮都得再付一遍，总额
 
 每个 agent 如何发出 telemetry、追踪花费，以及怎么喂养 eval 集。
 
-| | Claude Code | mini-swe-agent |
-| --- | --- | --- |
-| **Pros** | 低成本又安全地换来丰富的正式环境可见度。坏掉的 sink 卡不住也弄不垮 loop。 | crash 掉的 run 也留得下可重建的文件。轨迹文件既是审计记录，也是 eval 语料。 |
-| **Cons** | 只告诉你发生了什么，答案好不好看不出来。采样和 scrub 会丢掉记录的一部分。 | 正式环境 telemetry 几乎没有，run 进行中没有 event 流可看。 |
-| **Why** | 正式环境得盯住崩溃和成本暴涨，而且 telemetry 不能碰 loop 的控制流。 | 质量靠离线 benchmark 评分，所以每趟 run 的完整记录比实时 event 更重要。 |
-| **How: telemetry** | event 先排队，等 sink 接上再采样、scrub，送给每个 sink。 | 每趟 run 一个轨迹文件：完整消息历史加 config、成本、exit status，每一步都存。 |
-| **How: cost tracking** | 每模型 token 按定价滚进一个 session USD 总额，退出时打印。 | litellm 逐次计价，汇总成 run 与全局总额；没定价的模型默认直接报错。 |
-| **How: eval feed** | 源码中没有；为重建。一般做法：trace 脱敏后变成 regression 案例。 | 存下来的轨迹就是语料；repo 内置的 benchmark runner 为一整组 task 评分。 |
+| | Claude Code | mini-swe-agent | deepseek-harness |
+| --- | --- | --- | --- |
+| **Pros** | 低成本又安全地换来丰富的正式环境可见度。 | crash 掉的 run 也留得下文件。 | 不用另外埋点：模型看得到的，log 里就有。 |
+| **Cons** | 只说发生了什么，答案好不好看不出来。 | 正式环境 telemetry 几乎没有。 | 没附任何脱敏规则。发出去可能会漏，也可能重复。 |
+| **Why** | 正式环境得盯住崩溃和成本，又不能碰 loop。 | 质量靠离线 benchmark 评分，完整记录最重要。 | session log 本来就是记录，直接把它发出去就好。 |
+| **How: telemetry** | event 先排队，等 sink 接上再采样、scrub。 | 每趟 run 一个轨迹文件，每一步都存。 | 每一条 session 事件都经过脱敏那一关再镜像出去。 |
+| **How: cost tracking** | 每模型 token 按定价滚成一个 session 总额。 | 逐次计价，汇总成 run 与全局总额。 | 重放整份 log 算出 token 数，从不换算成钱。 |
+| **How: eval feed** | 源码中没有；trace 脱敏后变成 regression 案例。 | 存下来的轨迹喂给 benchmark runner。 | 录下来的 run 不用密钥就能重放，当成固定样本。 |
 
 ---
 
@@ -201,6 +201,8 @@ uv run python sections/20-observability/src/demo.py  # live demo, needs a key
   `services/analytics/index.ts`（queue + `logEvent`）、`sink.ts`、`datadog.ts`、`firstPartyEventLogger.ts`、`sinkKillswitch.ts`、`shouldSampleEvent`。
 - [Claude Code cost and diagnostics](https://github.com/yasasbanukaofficial/claude-code)：
   `cost-tracker.ts`、`utils/modelCost.ts`、`costHook.ts`（`formatTotalCost`）、`diagnosticTracking.ts`、`upstreamproxy/relay.ts`。
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness)（`dsh-v0.1.0-rc.7`）：
+  `docs/subsystems/telemetry.md`、`docs/subsystems/token-meter.md`、`packages/llm/llm-replay/README.md`、`docs/subsystems/invariants.md`。
 - [ai-agent-book](https://github.com/bojieli/ai-agent-book)：`book/chapter6.md`，以中文原书为准。
   span 树、非线性的 agent 成本与每任务上限，还有正式环境 trace 回流成 eval 集。
   书里的成本分析没有引用外部来源，属于单一来源。

--- a/sections/20-observability/README.zh-TW.md
+++ b/sections/20-observability/README.zh-TW.md
@@ -152,14 +152,14 @@ context 裡多出來的任何東西，後面每一輪都得再付一遍，總額
 
 每個 agent 如何發出 telemetry、追蹤花費，以及怎麼餵養 eval 集。
 
-| | Claude Code | mini-swe-agent |
-| --- | --- | --- |
-| **Pros** | 低成本又安全地換來豐富的正式環境可見度。壞掉的 sink 卡不住也弄不垮 loop。 | crash 掉的 run 也留得下可重建的檔案。軌跡檔既是稽核紀錄，也是 eval 語料。 |
-| **Cons** | 只告訴你發生了什麼，答案好不好看不出來。採樣和 scrub 會丟掉紀錄的一部分。 | 正式環境 telemetry 幾乎沒有，run 進行中沒有 event 流可看。 |
-| **Why** | 正式環境得盯住當機和成本暴衝，而且 telemetry 不能碰 loop 的控制流。 | 品質靠離線 benchmark 評分，所以每趟 run 的完整紀錄比即時 event 更重要。 |
-| **How: telemetry** | event 先排隊，等 sink 接上再採樣、scrub，送給每個 sink。 | 每趟 run 一個軌跡檔：完整訊息歷史加 config、成本、exit status，每一步都存。 |
-| **How: cost tracking** | 每模型 token 按定價滾進一個 session USD 總額，退出時印出。 | litellm 逐次計價，彙總成 run 與全域總額；沒定價的模型預設直接報錯。 |
-| **How: eval feed** | 原始碼中沒有；為重建。一般做法：trace 脫敏後變成 regression 案例。 | 存下來的軌跡就是語料；repo 內建的 benchmark runner 為一整組 task 評分。 |
+| | Claude Code | mini-swe-agent | deepseek-harness |
+| --- | --- | --- | --- |
+| **Pros** | 低成本又安全地換來豐富的正式環境可見度。 | crash 掉的 run 也留得下檔案。 | 不用另外埋點：模型看得到的，log 裡就有。 |
+| **Cons** | 只說發生了什麼，答案好不好看不出來。 | 正式環境 telemetry 幾乎沒有。 | 沒附任何脫敏規則。送出去可能會漏，也可能重複。 |
+| **Why** | 正式環境得盯住當機和成本，又不能碰 loop。 | 品質靠離線 benchmark 評分，完整紀錄最重要。 | session log 本來就是紀錄，直接把它送出去就好。 |
+| **How: telemetry** | event 先排隊，等 sink 接上再採樣、scrub。 | 每趟 run 一個軌跡檔，每一步都存。 | 每一則 session 事件都經過脫敏那一關再鏡射出去。 |
+| **How: cost tracking** | 每模型 token 按定價滾成一個 session 總額。 | 逐次計價，彙總成 run 與全域總額。 | 重放整份 log 算出 token 數，從不換算成錢。 |
+| **How: eval feed** | 原始碼中沒有；trace 脫敏後變成 regression 案例。 | 存下來的軌跡餵給 benchmark runner。 | 錄下來的 run 不用金鑰就能重放，當成固定樣本。 |
 
 ---
 
@@ -201,6 +201,8 @@ uv run python sections/20-observability/src/demo.py  # live demo, needs a key
   `services/analytics/index.ts`（queue + `logEvent`）、`sink.ts`、`datadog.ts`、`firstPartyEventLogger.ts`、`sinkKillswitch.ts`、`shouldSampleEvent`。
 - [Claude Code cost and diagnostics](https://github.com/yasasbanukaofficial/claude-code)：
   `cost-tracker.ts`、`utils/modelCost.ts`、`costHook.ts`（`formatTotalCost`）、`diagnosticTracking.ts`、`upstreamproxy/relay.ts`。
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness)（`dsh-v0.1.0-rc.7`）：
+  `docs/subsystems/telemetry.md`、`docs/subsystems/token-meter.md`、`packages/llm/llm-replay/README.md`、`docs/subsystems/invariants.md`。
 - [ai-agent-book](https://github.com/bojieli/ai-agent-book)：`book/chapter6.md`，以中文原書為準。
   span 樹、非線性的 agent 成本與每任務上限，還有正式環境 trace 回流成 eval 集。
   書裡的成本分析沒有引用外部來源，屬於單一來源。

--- a/sections/21-loop-engineering/README.md
+++ b/sections/21-loop-engineering/README.md
@@ -179,14 +179,14 @@ Read both. With only the first, a skill that is correct but never loads looks li
 
 How each agent composes its outer loops.
 
-| | Claude Code | Hermes Agent | mini-swe-agent |
-| --- | --- | --- | --- |
-| **Pros** | Both halves: scripted verify and hard budgets. | Budgets plus an improvement loop with rollback. | Every run has a hard bill. A budget stop can be a checkpoint. |
-| **Cons** | No closed improvement loop in source. | No built-in grade-and-retry loop. | Only the budget half. Grading waits for offline eval. |
-| **Why** | The outer loop is a program you script and cap. | Goal: an improvement loop that reaches the model itself. | Assumes one run is one benchmark task, graded offline. |
-| **How: verification** | Scripted verify stages: adversarial verify, judge panel. | Maker and checker via delegation, plus offline tests. | None. SWE-bench grades offline. |
-| **How: event loop** | Cron, self-paced wakeups, remote triggers. | Cron with restricted toolsets, plus watch patterns. | None. The batch runner schedules instances, not time. |
-| **How: improvement loop** | Resumable runs: finished steps replay from cache. | A curator prunes skills; runs become training data. | None. Budgets are the only outer control. |
+| | Claude Code | Hermes Agent | mini-swe-agent | deepseek-harness |
+| --- | --- | --- | --- | --- |
+| **Pros** | Scripted verify plus hard budgets. | Budgets, and rollback on improvement. | Every run has a hard bill. | Outer loops attach as plugins on published events. |
+| **Cons** | No closed improvement loop in source. | No grade-and-retry loop. | Only the budget half. | Nothing checks the work. Rounds are the only budget. |
+| **Why** | The outer loop is a program you script. | Improvement should reach the model. | One run is one graded task. | The loop is itself a plugin, so control attaches to it. |
+| **How: verification** | Scripted stages, judge panels. | Maker and checker, plus offline tests. | None. SWE-bench grades offline. | None built in; completion is self-declared. |
+| **How: event loop** | Cron, self-paced wakeups, remote triggers. | Cron with restricted toolsets. | None. The runner schedules tasks. | Reminders replay from the log as a turn. |
+| **How: improvement loop** | Resumable runs replay from cache. | A curator prunes skills. | None. Budgets only. | None shipped; the attach points exist. |
 
 ---
 
@@ -233,6 +233,8 @@ uv run python sections/21-loop-engineering/src/demo.py  # live demo, needs a key
 
 ## Sources
 
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness) at `dsh-v0.1.0-rc.7`:
+  `docs/subsystems/core.md`, `packages/workflow/tool-ralph/README.md`, `packages/schedule/schedule/README.md`, `docs/subsystems/goal.md`.
 - [cobusgreyling/loop-engineering](https://github.com/cobusgreyling/loop-engineering): building blocks and readiness levels.
 - [LangChain · The art of loop engineering](https://www.langchain.com/blog/the-art-of-loop-engineering): the four stacked loops.
 - [Addy Osmani · Loop engineering](https://addyosmani.com/blog/loop-engineering/): the composed building blocks.

--- a/sections/21-loop-engineering/README.md
+++ b/sections/21-loop-engineering/README.md
@@ -181,12 +181,12 @@ How each agent composes its outer loops.
 
 | | Claude Code | Hermes Agent | mini-swe-agent | deepseek-harness |
 | --- | --- | --- | --- | --- |
-| **Pros** | Scripted verify plus hard budgets. | Budgets, and rollback on improvement. | Every run has a hard bill. | Outer loops attach as plugins on published events. |
-| **Cons** | No closed improvement loop in source. | No grade-and-retry loop. | Only the budget half. | Nothing checks the work. Rounds are the only budget. |
+| **Pros** | Scripted verify plus hard budgets. | Budgets, plus an improvement loop with rollback. | A hard bill per run. | Outer loops attach as plugins on published events. |
+| **Cons** | No closed improvement loop in source. | No built-in grade-and-retry loop. | Only the budget half. | Nothing checks the work; rounds are the only budget. |
 | **Why** | The outer loop is a program you script. | Improvement should reach the model. | One run is one graded task. | The loop is itself a plugin, so control attaches to it. |
 | **How: verification** | Scripted stages, judge panels. | Maker and checker, plus offline tests. | None. SWE-bench grades offline. | None built in; completion is self-declared. |
-| **How: event loop** | Cron, self-paced wakeups, remote triggers. | Cron with restricted toolsets. | None. The runner schedules tasks. | Reminders replay from the log as a turn. |
-| **How: improvement loop** | Resumable runs replay from cache. | A curator prunes skills. | None. Budgets only. | None shipped; the attach points exist. |
+| **How: event loop** | Cron, wakeups, remote triggers. | Cron with restricted toolsets. | None. The runner schedules tasks, not time. | Reminders replay from the log as a turn. |
+| **How: improvement loop** | Resumable workflows replay from cache. | Runs become training data. | None. Budgets only. | None shipped; the attach points exist. |
 
 ---
 

--- a/sections/21-loop-engineering/README.zh-CN.md
+++ b/sections/21-loop-engineering/README.zh-CN.md
@@ -184,8 +184,8 @@ loop 能搜的范围是一道阶梯。最底下那阶是 prompt 里的一条规�
 | **Cons** | 改进 loop 在源码中没有闭环。 | 没有内置的评分重试 loop。 | 只做了 budget 这一半。 | 没有东西检查成果，只有轮数当预算。 |
 | **Why** | 把外层 loop 当成一段可编排的程序。 | 目标是让改进闭合到 model。 | 一趟 run 就是一个评分任务。 | loop 本身就是 plugin，控制自然挂在它上面。 |
 | **How: verification** | verify 阶段用代码编排：judge panel。 | maker 和 checker 分工，加离线测试。 | 没有，SWE-bench 离线评分。 | 没有内置，做完了没由模型自己说。 |
-| **How: event loop** | Cron、自定节奏唤醒、remote trigger。 | gateway cron 加受限 toolset。 | 没有，runner 排的是 instance。 | 提醒从 log 重放，以一个 turn 的形式进来。 |
-| **How: improvement loop** | workflow 可断点续跑，从 cache 重放。 | curator 修剪 skill。 | 没有，只有 budget。 | 没有现成的，但接的地方都留好了。 |
+| **How: event loop** | Cron、自定节奏唤醒、remote trigger。 | gateway cron 加受限 toolset。 | 没有，runner 排的是任务，不是时间。 | 提醒从 log 重放，以一个 turn 的形式进来。 |
+| **How: improvement loop** | workflow 可断点续跑，从 cache 重放。 | run 会变成训练数据。 | 没有，只有 budget。 | 没有现成的，但接的地方都留好了。 |
 
 ---
 

--- a/sections/21-loop-engineering/README.zh-CN.md
+++ b/sections/21-loop-engineering/README.zh-CN.md
@@ -178,14 +178,14 @@ loop 能搜的范围是一道阶梯。最底下那阶是 prompt 里的一条规�
 
 各个 agent 如何组合自己的外层 loop。
 
-| | Claude Code | Hermes Agent | mini-swe-agent |
-| --- | --- | --- | --- |
-| **Pros** | 验证和 budget 两半都有：verify 用代码编排，budget 是硬上限。 | 有 budget，改进 loop 也能回滚。 | 每趟 run 的账单都有硬上限；撞到预算可以当检查点。 |
-| **Cons** | 改进 loop 在源码中没有闭环。 | 没有内置的评分重试 loop。 | 只做了 budget 这一半，评分要等离线 eval。 |
-| **Why** | 把外层 loop 当成一段可以编排、可以设上限的程序。 | 目标是让改进 loop 一路闭合到 model 本身。 | 假设一趟 run 就是一个 benchmark 任务，评分离线做。 |
-| **How: verification** | verify 阶段用代码编排：adversarial verify、judge panel。 | maker 和 checker 靠 delegation 分工，加上离线测试。 | 没有内置，评分在 SWE-bench 离线进行。 |
-| **How: event loop** | Cron、自定节奏唤醒、remote trigger。 | gateway cron 加受限 toolset，watch pattern 也能唤醒。 | 没有，batch runner 排的是 instance，不是时间。 |
-| **How: improvement loop** | workflow 可断点续跑，跑完的步骤从 cache 重放。 | curator 从使用情况整合、修剪 skill；run 变成训练数据。 | 没有，budget 是唯一的外层控制。 |
+| | Claude Code | Hermes Agent | mini-swe-agent | deepseek-harness |
+| --- | --- | --- | --- | --- |
+| **Pros** | verify 用代码编排，budget 是硬上限。 | 有 budget，改进也能回滚。 | 每趟 run 的账单都有硬上限。 | 外层 loop 以 plugin 挂在公开的事件上。 |
+| **Cons** | 改进 loop 在源码中没有闭环。 | 没有内置的评分重试 loop。 | 只做了 budget 这一半。 | 没有东西检查成果，只有轮数当预算。 |
+| **Why** | 把外层 loop 当成一段可编排的程序。 | 目标是让改进闭合到 model。 | 一趟 run 就是一个评分任务。 | loop 本身就是 plugin，控制自然挂在它上面。 |
+| **How: verification** | verify 阶段用代码编排：judge panel。 | maker 和 checker 分工，加离线测试。 | 没有，SWE-bench 离线评分。 | 没有内置，做完了没由模型自己说。 |
+| **How: event loop** | Cron、自定节奏唤醒、remote trigger。 | gateway cron 加受限 toolset。 | 没有，runner 排的是 instance。 | 提醒从 log 重放，以一个 turn 的形式进来。 |
+| **How: improvement loop** | workflow 可断点续跑，从 cache 重放。 | curator 修剪 skill。 | 没有，只有 budget。 | 没有现成的，但接的地方都留好了。 |
 
 ---
 
@@ -232,6 +232,8 @@ uv run python sections/21-loop-engineering/src/demo.py  # live demo, needs a key
 
 ## 出处
 
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness)（`dsh-v0.1.0-rc.7`）：
+  `docs/subsystems/core.md`、`packages/workflow/tool-ralph/README.md`、`packages/schedule/schedule/README.md`、`docs/subsystems/goal.md`。
 - [cobusgreyling/loop-engineering](https://github.com/cobusgreyling/loop-engineering)：building block 与成熟度分级。
 - [LangChain · The art of loop engineering](https://www.langchain.com/blog/the-art-of-loop-engineering)：四层堆叠的 loop。
 - [Addy Osmani · Loop engineering](https://addyosmani.com/blog/loop-engineering/)：building block 的组合方式。

--- a/sections/21-loop-engineering/README.zh-TW.md
+++ b/sections/21-loop-engineering/README.zh-TW.md
@@ -178,14 +178,14 @@ loop 能搜的範圍是一道階梯。最底下那階是 prompt 裡的一條規�
 
 各個 agent 如何組合自己的外層 loop。
 
-| | Claude Code | Hermes Agent | mini-swe-agent |
-| --- | --- | --- | --- |
-| **Pros** | 驗證和 budget 兩半都有：verify 用程式編排，budget 是硬上限。 | 有 budget，改進 loop 也能回滾。 | 每趟 run 的帳單都有硬上限；撞到預算可以當檢查點。 |
-| **Cons** | 改進 loop 在原始碼中沒有閉環。 | 沒有內建的評分重試 loop。 | 只做了 budget 這一半，評分要等離線 eval。 |
-| **Why** | 把外層 loop 當成一段可以編排、可以設上限的程式。 | 目標是讓改進 loop 一路閉合到 model 本身。 | 假設一趟 run 就是一個 benchmark 任務，評分離線做。 |
-| **How: verification** | verify 階段用程式編排：adversarial verify、judge panel。 | maker 和 checker 靠 delegation 分工，加上離線測試。 | 沒有內建，評分在 SWE-bench 離線進行。 |
-| **How: event loop** | Cron、自訂節奏喚醒、remote trigger。 | gateway cron 加受限 toolset，watch pattern 也能喚醒。 | 沒有，batch runner 排的是 instance，不是時間。 |
-| **How: improvement loop** | workflow 可斷點續跑，跑完的步驟從 cache 重放。 | curator 從使用情況整併、修剪 skill；run 變成訓練資料。 | 沒有，budget 是唯一的外層控制。 |
+| | Claude Code | Hermes Agent | mini-swe-agent | deepseek-harness |
+| --- | --- | --- | --- | --- |
+| **Pros** | verify 用程式編排，budget 是硬上限。 | 有 budget，改進也能回滾。 | 每趟 run 的帳單都有硬上限。 | 外層 loop 以 plugin 掛在公開的事件上。 |
+| **Cons** | 改進 loop 在原始碼中沒有閉環。 | 沒有內建的評分重試 loop。 | 只做了 budget 這一半。 | 沒有東西檢查成果，只有輪數當預算。 |
+| **Why** | 把外層 loop 當成一段可編排的程式。 | 目標是讓改進閉合到 model。 | 一趟 run 就是一個評分任務。 | loop 本身就是 plugin，控制自然掛在它上面。 |
+| **How: verification** | verify 階段用程式編排：judge panel。 | maker 和 checker 分工，加離線測試。 | 沒有，SWE-bench 離線評分。 | 沒有內建，做完了沒由模型自己說。 |
+| **How: event loop** | Cron、自訂節奏喚醒、remote trigger。 | gateway cron 加受限 toolset。 | 沒有，runner 排的是 instance。 | 提醒從 log 重放，以一個 turn 的形式進來。 |
+| **How: improvement loop** | workflow 可斷點續跑，從 cache 重放。 | curator 修剪 skill。 | 沒有，只有 budget。 | 沒有現成的，但接的地方都留好了。 |
 
 ---
 
@@ -232,6 +232,8 @@ uv run python sections/21-loop-engineering/src/demo.py  # live demo, needs a key
 
 ## 出處
 
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness)（`dsh-v0.1.0-rc.7`）：
+  `docs/subsystems/core.md`、`packages/workflow/tool-ralph/README.md`、`packages/schedule/schedule/README.md`、`docs/subsystems/goal.md`。
 - [cobusgreyling/loop-engineering](https://github.com/cobusgreyling/loop-engineering)：building block 與成熟度分級。
 - [LangChain · The art of loop engineering](https://www.langchain.com/blog/the-art-of-loop-engineering)：四層堆疊的 loop。
 - [Addy Osmani · Loop engineering](https://addyosmani.com/blog/loop-engineering/)：building block 的組合方式。

--- a/sections/21-loop-engineering/README.zh-TW.md
+++ b/sections/21-loop-engineering/README.zh-TW.md
@@ -184,8 +184,8 @@ loop 能搜的範圍是一道階梯。最底下那階是 prompt 裡的一條規�
 | **Cons** | 改進 loop 在原始碼中沒有閉環。 | 沒有內建的評分重試 loop。 | 只做了 budget 這一半。 | 沒有東西檢查成果，只有輪數當預算。 |
 | **Why** | 把外層 loop 當成一段可編排的程式。 | 目標是讓改進閉合到 model。 | 一趟 run 就是一個評分任務。 | loop 本身就是 plugin，控制自然掛在它上面。 |
 | **How: verification** | verify 階段用程式編排：judge panel。 | maker 和 checker 分工，加離線測試。 | 沒有，SWE-bench 離線評分。 | 沒有內建，做完了沒由模型自己說。 |
-| **How: event loop** | Cron、自訂節奏喚醒、remote trigger。 | gateway cron 加受限 toolset。 | 沒有，runner 排的是 instance。 | 提醒從 log 重放，以一個 turn 的形式進來。 |
-| **How: improvement loop** | workflow 可斷點續跑，從 cache 重放。 | curator 修剪 skill。 | 沒有，只有 budget。 | 沒有現成的，但接的地方都留好了。 |
+| **How: event loop** | Cron、自訂節奏喚醒、remote trigger。 | gateway cron 加受限 toolset。 | 沒有，runner 排的是任務，不是時間。 | 提醒從 log 重放，以一個 turn 的形式進來。 |
+| **How: improvement loop** | workflow 可斷點續跑，從 cache 重放。 | run 會變成訓練資料。 | 沒有，只有 budget。 | 沒有現成的，但接的地方都留好了。 |
 
 ---
 

--- a/sections/22-graph-engineering/README.md
+++ b/sections/22-graph-engineering/README.md
@@ -203,8 +203,7 @@ uv run python sections/22-graph-engineering/src/demo.py  # live demo, needs a ke
   From tool schemas and documented behavior, not the source backup.
 - [Hermes Agent source](https://github.com/NousResearch/hermes-agent): `tools/delegate_tool.py`, `tools/async_delegation.py`, `batch_runner.py`.
 - [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness) at `dsh-v0.1.0-rc.7`:
-  `docs/subsystems/workflow.md`, `packages/workflow/tool-workflow/README.md`. The model writes a fresh script per run,
-  each call spawns one child, and nothing persists as a graph, so it answers this section the same way the Claude Code column does.
+  `docs/subsystems/workflow.md`, `packages/workflow/tool-workflow/README.md`: a model-written script per run, no persistent graph.
 - [mini-swe-agent source](https://github.com/swe-agent/mini-swe-agent): the run loop and budgets in `agents/default.py`, `run/benchmarks/swebench.py`.
 - [ai-agent-book · chapter 10](https://github.com/bojieli/ai-agent-book/blob/main/book/chapter10.md) (《深入理解 AI Agent》, 李博杰, 多 Agent 协作; the Chinese original is canonical):
   multi-stage role switching on one trajectory: a system prompt and a tool set per phase, phase gates as tool calls, and review routing back to implementation.

--- a/sections/22-graph-engineering/README.md
+++ b/sections/22-graph-engineering/README.md
@@ -202,6 +202,9 @@ uv run python sections/22-graph-engineering/src/demo.py  # live demo, needs a ke
 - [Claude Code](https://code.claude.com/docs): the `Workflow` script contract (pipelines, parallel fan-out, structured output, resume).
   From tool schemas and documented behavior, not the source backup.
 - [Hermes Agent source](https://github.com/NousResearch/hermes-agent): `tools/delegate_tool.py`, `tools/async_delegation.py`, `batch_runner.py`.
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness) at `dsh-v0.1.0-rc.7`:
+  `docs/subsystems/workflow.md`, `packages/workflow/tool-workflow/README.md`. The model writes a fresh script per run,
+  each call spawns one child, and nothing persists as a graph, so it answers this section the same way the Claude Code column does.
 - [mini-swe-agent source](https://github.com/swe-agent/mini-swe-agent): the run loop and budgets in `agents/default.py`, `run/benchmarks/swebench.py`.
 - [ai-agent-book · chapter 10](https://github.com/bojieli/ai-agent-book/blob/main/book/chapter10.md) (《深入理解 AI Agent》, 李博杰, 多 Agent 协作; the Chinese original is canonical):
   multi-stage role switching on one trajectory: a system prompt and a tool set per phase, phase gates as tool calls, and review routing back to implementation.

--- a/sections/22-graph-engineering/README.zh-CN.md
+++ b/sections/22-graph-engineering/README.zh-CN.md
@@ -201,8 +201,7 @@ uv run python sections/22-graph-engineering/src/demo.py  # live demo, needs a ke
 - [Claude Code](https://code.claude.com/docs)：`Workflow` script 的约定（pipeline、并行分发、结构化输出、续跑）。内容依据 tool schema 和文档记载的行为，不是 source backup。
 - [Hermes Agent 源码](https://github.com/NousResearch/hermes-agent)：`tools/delegate_tool.py`、`tools/async_delegation.py`、`batch_runner.py`。
 - [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness)（`dsh-v0.1.0-rc.7`）：
-  `docs/subsystems/workflow.md`、`packages/workflow/tool-workflow/README.md`。每次运行都由模型现写一段脚本，
-  每个调用开一个 child，没有任何东西以图的形式留下来，所以它对这一章的回答跟 Claude Code 那一栏一样。
+  `docs/subsystems/workflow.md`、`packages/workflow/tool-workflow/README.md`：每次运行由模型现写脚本，不留下任何图。
 - [mini-swe-agent source](https://github.com/swe-agent/mini-swe-agent)：`agents/default.py` 的 run loop 与 budget、`run/benchmarks/swebench.py`。
 - [ai-agent-book · 第 10 章](https://github.com/bojieli/ai-agent-book/blob/main/book/chapter10.md)（《深入理解 AI Agent》，李博杰，多 Agent 协作，以中文原版为准）：
   在同一条 trajectory 上做多阶段角色转换：每个 phase 一份 system prompt 和一套 tool，phase 之间用 tool call 当关卡，review 可以绕回实现。

--- a/sections/22-graph-engineering/README.zh-CN.md
+++ b/sections/22-graph-engineering/README.zh-CN.md
@@ -200,6 +200,9 @@ uv run python sections/22-graph-engineering/src/demo.py  # live demo, needs a ke
 - [Google · Why we built ADK 2.0](https://developers.googleblog.com/en/why-we-built-adk-20/)：用代码选路、node 之间的 context 隔离、在 workflow 的 node 上挂 agent。
 - [Claude Code](https://code.claude.com/docs)：`Workflow` script 的约定（pipeline、并行分发、结构化输出、续跑）。内容依据 tool schema 和文档记载的行为，不是 source backup。
 - [Hermes Agent 源码](https://github.com/NousResearch/hermes-agent)：`tools/delegate_tool.py`、`tools/async_delegation.py`、`batch_runner.py`。
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness)（`dsh-v0.1.0-rc.7`）：
+  `docs/subsystems/workflow.md`、`packages/workflow/tool-workflow/README.md`。每次运行都由模型现写一段脚本，
+  每个调用开一个 child，没有任何东西以图的形式留下来，所以它对这一章的回答跟 Claude Code 那一栏一样。
 - [mini-swe-agent source](https://github.com/swe-agent/mini-swe-agent)：`agents/default.py` 的 run loop 与 budget、`run/benchmarks/swebench.py`。
 - [ai-agent-book · 第 10 章](https://github.com/bojieli/ai-agent-book/blob/main/book/chapter10.md)（《深入理解 AI Agent》，李博杰，多 Agent 协作，以中文原版为准）：
   在同一条 trajectory 上做多阶段角色转换：每个 phase 一份 system prompt 和一套 tool，phase 之间用 tool call 当关卡，review 可以绕回实现。

--- a/sections/22-graph-engineering/README.zh-TW.md
+++ b/sections/22-graph-engineering/README.zh-TW.md
@@ -200,6 +200,9 @@ uv run python sections/22-graph-engineering/src/demo.py  # live demo, needs a ke
 - [Google · Why we built ADK 2.0](https://developers.googleblog.com/en/why-we-built-adk-20/)：用程式碼選路、node 之間的 context 隔離、在 workflow 的 node 上掛 agent。
 - [Claude Code](https://code.claude.com/docs)：`Workflow` script 的約定（pipeline、平行分派、結構化輸出、續跑）。內容依據 tool schema 和文件記載的行為，不是 source backup。
 - [Hermes Agent 原始碼](https://github.com/NousResearch/hermes-agent)：`tools/delegate_tool.py`、`tools/async_delegation.py`、`batch_runner.py`。
+- [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness)（`dsh-v0.1.0-rc.7`）：
+  `docs/subsystems/workflow.md`、`packages/workflow/tool-workflow/README.md`。每次執行都由模型現寫一段腳本，
+  每個呼叫開一個 child，沒有任何東西以圖的形式留下來，所以它對這一章的回答跟 Claude Code 那一欄一樣。
 - [mini-swe-agent source](https://github.com/swe-agent/mini-swe-agent)：`agents/default.py` 的 run loop 與 budget、`run/benchmarks/swebench.py`。
 - [ai-agent-book · 第 10 章](https://github.com/bojieli/ai-agent-book/blob/main/book/chapter10.md)（《深入理解 AI Agent》，李博杰，多 Agent 协作，以中文原版為準）：
   在同一條 trajectory 上做多階段角色轉換：每個 phase 一份 system prompt 和一套 tool，phase 之間用 tool call 當關卡，review 可以繞回實作。

--- a/sections/22-graph-engineering/README.zh-TW.md
+++ b/sections/22-graph-engineering/README.zh-TW.md
@@ -201,8 +201,7 @@ uv run python sections/22-graph-engineering/src/demo.py  # live demo, needs a ke
 - [Claude Code](https://code.claude.com/docs)：`Workflow` script 的約定（pipeline、平行分派、結構化輸出、續跑）。內容依據 tool schema 和文件記載的行為，不是 source backup。
 - [Hermes Agent 原始碼](https://github.com/NousResearch/hermes-agent)：`tools/delegate_tool.py`、`tools/async_delegation.py`、`batch_runner.py`。
 - [deepseek-harness source](https://github.com/deepseek-ai/deepseek-harness)（`dsh-v0.1.0-rc.7`）：
-  `docs/subsystems/workflow.md`、`packages/workflow/tool-workflow/README.md`。每次執行都由模型現寫一段腳本，
-  每個呼叫開一個 child，沒有任何東西以圖的形式留下來，所以它對這一章的回答跟 Claude Code 那一欄一樣。
+  `docs/subsystems/workflow.md`、`packages/workflow/tool-workflow/README.md`：每次執行由模型現寫腳本，不留下任何圖。
 - [mini-swe-agent source](https://github.com/swe-agent/mini-swe-agent)：`agents/default.py` 的 run loop 與 budget、`run/benchmarks/swebench.py`。
 - [ai-agent-book · 第 10 章](https://github.com/bojieli/ai-agent-book/blob/main/book/chapter10.md)（《深入理解 AI Agent》，李博杰，多 Agent 协作，以中文原版為準）：
   在同一條 trajectory 上做多階段角色轉換：每個 phase 一份 system prompt 和一套 tool，phase 之間用 tool call 當關卡，review 可以繞回實作。


### PR DESCRIPTION
Closes #78. Part of PRD #72. Final batch of the deepseek-harness track.

## What changed

- Sections 19, 20, 21 each gain a deepseek-harness column, mirrored in `README.zh-TW.md` and `README.zh-CN.md`.
- Section 0 gains a prose mention only: every part is a plugin including the loop, and each capability is published at a named seam. No table column.
- Section 22 gains a Sources cite only, saying dsh answers the section's question the same way the Claude Code column does.
- Section 23 gets nothing, per the PRD.
- Existing cells were tightened where a new column pushed a row past 180 characters. Section 21 now carries five columns.

## Verification

- `python sections/{19,20,21,22}/src/test.py` still pass offline.
- No line over 180 characters, no em or en dashes, table column counts consistent across all three languages.