### PR TITLE
fix: close PRD #72 acceptance gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ To learn from this repo:
 
 Each system is a worked example for the sections below.
 
-| System                 | Why people use it                                                               | Read it for                        | Sections             | Version studied |
-| ---------------------- | ------------------------------------------------------------------------------- | ---------------------------------- | -------------------- | --------------- |
+| System | Why people use it | Read it for | Sections | Version studied |
+| --- | --- | --- | --- | --- |
 | **Claude Code**  | Frontier coding agent: edits files, runs commands, ships changes in real repos. | The full harness, start here       | 0 to 23 (all)        | v2.1.88         |
 | **Hermes Agent** | Long-term assistant: remembers you, learns workflows, runs anywhere. | Memory, skills, always-on channels | 7, 9, 14, 16, 19, 21, 22 | v2026.7.1 |
 | **mini-swe-agent** | Research baseline: one bash tool, about 150 lines. | The smallest complete loop, budgets, eval harness | 0 to 3, 8, 10, 11, 20 to 23 | v2.4.5 |
-| **deepseek-harness** | Plugin-first harness: every part, including the loop, is a replaceable plugin. | Plugin seams, durable session log, ACP | 1 to 8, 10 to 14, 16 to 21 | dsh-v0.1.0-rc.7 |
-| *(more soon)*        |                                                                                 |                                    |                      |                 |
+| **deepseek-harness** | Plugin-first harness: even the loop is a replaceable plugin. | Plugin seams, durable session log, ACP | 1 to 8, 10 to 14, 16 to 21 | dsh-v0.1.0-rc.7 |
+| *(more soon)* | | | | |
 
 > More systems can be added later, including OpenClaw and aider.
 > The memory layer also has a companion repo: [learn-agent-memory](https://github.com/hardness1020/learn-agent-memory).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -66,7 +66,7 @@
 | **Claude Code**    | 目前最强的 coding agent：改文件、跑命令，直接在真实 repo 里完成改动。 | 完整 harness 架构，从这里读起         | 0 到 23（全部）           | v2.1.88   |
 | **Hermes Agent**   | 长期助理：记得你、学会你的工作流程，还能跨平台跑任务。                | Memory、skills、always-on channels    | 7、9、14、16、19、21、22  | v2026.7.1 |
 | **mini-swe-agent** | 研究基准：一个 bash 工具，约 150 行。                                 | 最小的完整 loop、budget、eval harness | 0 到 3、8、10、11、20 到 23 | v2.4.5    |
-| **deepseek-harness** | Plugin 优先的 harness：每个部件（连 loop 在内）都是可替换的 plugin。 | Plugin 接缝、durable session log、ACP | 1 到 8、10 到 14、16 到 21 | dsh-v0.1.0-rc.7 |
+| **deepseek-harness** | Plugin 优先的 harness：连 loop 都是可替换的 plugin。 | Plugin 接缝、durable session log、ACP | 1 到 8、10 到 14、16 到 21 | dsh-v0.1.0-rc.7 |
 | *(更多陆续加入)*       |                                                                       |                                       |                           |           |
 
 > 之后可以再加入更多系统，例如 OpenClaw 和 aider。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -66,7 +66,7 @@
 | **Claude Code**    | 目前最強的 coding agent：改檔案、跑指令，直接在真實 repo 裡完成改動。 | 完整 harness 架構，從這裡讀起         | 0 到 23（全部）           | v2.1.88   |
 | **Hermes Agent**   | 長期助理：記得你、學會你的工作流程，還能跨平台跑任務。                | Memory、skills、always-on channels    | 7、9、14、16、19、21、22  | v2026.7.1 |
 | **mini-swe-agent** | 研究基準：一個 bash 工具，約 150 行。                                 | 最小的完整 loop、budget、eval harness | 0 到 3、8、10、11、20 到 23 | v2.4.5    |
-| **deepseek-harness** | Plugin 優先的 harness：每個部件（連 loop 在內）都是可替換的 plugin。 | Plugin 接縫、durable session log、ACP | 1 到 8、10 到 14、16 到 21 | dsh-v0.1.0-rc.7 |
+| **deepseek-harness** | Plugin 優先的 harness：連 loop 都是可替換的 plugin。 | Plugin 接縫、durable session log、ACP | 1 到 8、10 到 14、16 到 21 | dsh-v0.1.0-rc.7 |
 | *(更多陸續加入)*       |                                                                       |                                       |                           |           |
 
 > 之後可以再加入更多系統，例如 OpenClaw 和 aider。

--- a/sections/01-agent-loop/README.md
+++ b/sections/01-agent-loop/README.md
@@ -92,7 +92,7 @@ How each agent owns the loop and decides when to stop.
 | **Cons** | The loop sits inside a larger runtime. | No side-effect gate, no streaming, no parallel tools. | The most moving parts. Needs turn, step, and inbox vocabulary. |
 | **Why** | Keep one core branch, add features around it. | A minimal loop is the point. The environment, not the model, detects completion. | The loop is one plugin among peers. |
 | **How: loop driver** | An async generator. Tools plug in via one contract. | A while loop. Ask the model for a command, run it. | A swappable plugin over a durable event log. |
-| **How: stop signal** | `stop_reason: end_turn`. | The environment sees a submit marker and appends `role: "exit"`. | Nothing owed, no checkpoint objection, or `concludesTurn`. |
+| **How: stop signal** | `stop_reason: end_turn`. | The environment sees a submit marker and appends `role: "exit"`. | Nothing owed, no checkpoint block, or a turn-ending result. |
 | **How: parallel tools** | Yes. Calls in one model turn can run in parallel. | No. Actions run in order. | Yes. Exclusive calls form barriers; safe calls share a bounded pool. |
 | **How: streaming** | Yes. Yields model tokens, tool calls, and tool results as they happen. | No. | Yes. Stream chunks land in the session log as durable events. |
 

--- a/sections/01-agent-loop/README.zh-CN.md
+++ b/sections/01-agent-loop/README.zh-CN.md
@@ -89,7 +89,7 @@ for user_text in turns:                              # the outer loop: one itera
 | **Cons** | loop 包在一个更大的 runtime 里，不能单独拿出来用。 | 无法把关副作用、流式传输进度，或并行执行工具。 | 活动零件最多。得先懂 turn、step、inbox 这套词汇。 |
 | **Why** | 核心分支保持不变，功能都加在外围。 | 小 loop 本身就是目的。检测任务是否完成的是环境，不是模型。 | loop 就是众多 plugin 里的一个。 |
 | **How: loop driver** | 一个 async generator。每个工具通过同一份契约接进 dispatch。 | 一个 while loop。每一步跟模型要一条命令，再执行。 | 一个可换掉的 plugin，跑在一份 durable 事件 log 上。 |
-| **How: stop signal** | `stop_reason: end_turn`。 | 由环境检测提交标记，附加一条 `role: "exit"` 消息。 | 模型没欠任何事、检查点没反对，或 tool result 带 `concludesTurn`。 |
+| **How: stop signal** | `stop_reason: end_turn`。 | 由环境检测提交标记，附加一条 `role: "exit"` 消息。 | 模型没欠任何事、检查点也没反对，或某个 tool result 直接把这一轮收掉。 |
 | **How: parallel tools** | 有。同一次模型轮次中的工具调用可以并行执行。 | 没有，action 依序执行。 | 有。exclusive 调用形成 barrier，安全调用共用一个有上限的池。 |
 | **How: streaming** | 有。模型 token、工具调用与工具结果发生的当下就逐一送出。 | 没有。 | 有。流式 chunk 以 durable 事件写进 session log。 |
 

--- a/sections/01-agent-loop/README.zh-TW.md
+++ b/sections/01-agent-loop/README.zh-TW.md
@@ -89,7 +89,7 @@ for user_text in turns:                              # the outer loop: one itera
 | **Cons** | loop 包在一個更大的 runtime 裡，不能單獨拿出來用。 | 無法把關副作用、串流進度，或平行執行工具。 | 活動零件最多。得先懂 turn、step、inbox 這套詞彙。 |
 | **Why** | 核心分支保持不變，功能都加在外圍。 | 小 loop 本身就是目的。偵測任務是否完成的是環境，不是模型。 | loop 就是眾多 plugin 裡的一個。 |
 | **How: loop driver** | 一個 async generator。每個工具透過同一份契約接進 dispatch。 | 一個 while loop。每一步跟模型要一道指令，再執行。 | 一個可換掉的 plugin，跑在一份 durable 事件 log 上。 |
-| **How: stop signal** | `stop_reason: end_turn`。 | 由環境偵測提交標記，附加一則 `role: "exit"` 訊息。 | 模型沒欠任何事、檢查點沒反對，或 tool result 帶 `concludesTurn`。 |
+| **How: stop signal** | `stop_reason: end_turn`。 | 由環境偵測提交標記，附加一則 `role: "exit"` 訊息。 | 模型沒欠任何事、檢查點也沒反對，或某個 tool result 直接把這一輪收掉。 |
 | **How: parallel tools** | 有。同一次模型輪次中的工具呼叫可以平行執行。 | 沒有，action 依序執行。 | 有。exclusive 呼叫形成 barrier，安全呼叫共用一個有上限的池。 |
 | **How: streaming** | 有。模型 token、工具呼叫與工具結果發生的當下就逐一送出。 | 沒有。 | 有。串流 chunk 以 durable 事件寫進 session log。 |
 


### PR DESCRIPTION
Verification pass over the merged dsh work (#79 to #84) against the acceptance criteria in #72. Two gaps found and closed.

## Fixes

- **Line length.** The systems-table row locked in the PRD is 193 characters, over the 180 limit. Shortened the description to "even the loop is a replaceable plugin" and trimmed the table's padding whitespace. The header, separator, and `*(more soon)*` rows were already over at 184 to 186.
- **Function name in a cell.** The section 1 stop-signal cell exposed the internal field name `concludesTurn`, against the rule that cells read without opening the source. Now reads "a turn-ending result".

Both edits mirrored into `README.zh-TW.md` and `README.zh-CN.md`.

## Verification

| Criterion | Result |
| --- | --- |
| 19 dsh columns, sections 1 to 8, 10 to 14, 16 to 21 | all present, row order Pros/Cons/Why/How, 0 ragged rows |
| No column: sections 9, 15, 23 | 0 mentions each |
| Section 0 prose mention, section 22 Sources cite | present, no table column |
| Sources grounded at the pin | every column section carries a `dsh-v0.1.0-rc.7` bullet |
| src demos, sections 4, 8, 10 | `test.py` passes offline in all three |
| README row and references entry | present in all three languages |
| No em or en dashes | 0 hits |
| Line length across all 27 files | 0 violations |

`sections/22-graph-engineering/README.md:208` trips `awk` at 196 but is 178 characters. That is a CJK byte-count artifact, not a violation, so it is left alone.

Closes #72.