### PR TITLE
docs: swap the count badges for one badge per system

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,12 @@
 
 <p align="center">
   <a href="#sections"><img src="https://img.shields.io/badge/Focus-Harness_Engineering-8250df" alt="Focus: Harness Engineering"></a>
-  <a href="#systems-under-study"><img src="https://img.shields.io/badge/Systems-3+-0969da" alt="Systems"></a>
-  <a href="#sections"><img src="https://img.shields.io/badge/Sections-24-2da44e" alt="Sections"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-d29922" alt="License"></a>
+  <br>
+  <a href="https://github.com/anthropics/claude-code"><img src="https://img.shields.io/badge/Claude_Code-D97757" alt="Claude Code"></a>
+  <a href="https://github.com/NousResearch/hermes-agent"><img src="https://img.shields.io/badge/Hermes_Agent-1A1A1A" alt="Hermes Agent"></a>
+  <a href="https://github.com/swe-agent/mini-swe-agent"><img src="https://img.shields.io/badge/mini--swe--agent-7E56D8" alt="mini-swe-agent"></a>
+  <a href="https://github.com/deepseek-ai/deepseek-harness"><img src="https://img.shields.io/badge/deepseek--harness-4D6BFE" alt="deepseek-harness"></a>
 </p>
 
 <p align="center">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,9 +6,12 @@
 
 <p align="center">
   <a href="#研究的系统"><img src="https://img.shields.io/badge/Focus-Harness_Engineering-8250df" alt="Focus: Harness Engineering"></a>
-  <a href="#研究的系统"><img src="https://img.shields.io/badge/Systems-3+-0969da" alt="Systems"></a>
-  <a href="#各章节"><img src="https://img.shields.io/badge/Sections-24-2da44e" alt="Sections"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-d29922" alt="License"></a>
+  <br>
+  <a href="https://github.com/anthropics/claude-code"><img src="https://img.shields.io/badge/Claude_Code-D97757" alt="Claude Code"></a>
+  <a href="https://github.com/NousResearch/hermes-agent"><img src="https://img.shields.io/badge/Hermes_Agent-1A1A1A" alt="Hermes Agent"></a>
+  <a href="https://github.com/swe-agent/mini-swe-agent"><img src="https://img.shields.io/badge/mini--swe--agent-7E56D8" alt="mini-swe-agent"></a>
+  <a href="https://github.com/deepseek-ai/deepseek-harness"><img src="https://img.shields.io/badge/deepseek--harness-4D6BFE" alt="deepseek-harness"></a>
 </p>
 
 <p align="center">

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -6,9 +6,12 @@
 
 <p align="center">
   <a href="#研究的系統"><img src="https://img.shields.io/badge/Focus-Harness_Engineering-8250df" alt="Focus: Harness Engineering"></a>
-  <a href="#研究的系統"><img src="https://img.shields.io/badge/Systems-3+-0969da" alt="Systems"></a>
-  <a href="#各章節"><img src="https://img.shields.io/badge/Sections-24-2da44e" alt="Sections"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-d29922" alt="License"></a>
+  <br>
+  <a href="https://github.com/anthropics/claude-code"><img src="https://img.shields.io/badge/Claude_Code-D97757" alt="Claude Code"></a>
+  <a href="https://github.com/NousResearch/hermes-agent"><img src="https://img.shields.io/badge/Hermes_Agent-1A1A1A" alt="Hermes Agent"></a>
+  <a href="https://github.com/swe-agent/mini-swe-agent"><img src="https://img.shields.io/badge/mini--swe--agent-7E56D8" alt="mini-swe-agent"></a>
+  <a href="https://github.com/deepseek-ai/deepseek-harness"><img src="https://img.shields.io/badge/deepseek--harness-4D6BFE" alt="deepseek-harness"></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Replaces the two count badges in the README header with one badge per system under study.

## Why

The `Systems-3+` badge was stale once deepseek-harness landed in v1.5.0, and both count badges only pointed back into the same page. A badge per system carries more information and links out to each project.

## Changes

- Removed the `Systems-3+` and `Sections-24` badges.
- Added Claude Code, Hermes Agent, mini-swe-agent, and deepseek-harness on a second centered line, each linked to its source repo.
- Focus and License stay on the first line. Seven badges in one row crowd on narrow screens.

| Badge | Color | Basis |
| --- | --- | --- |
| Claude Code | `D97757` | Anthropic brand clay |
| Hermes Agent | `1A1A1A` | Nous Research monochrome mark |
| mini-swe-agent | `7E56D8` | SWE-agent violet |
| deepseek-harness | `4D6BFE` | DeepSeek logo blue |

The Anthropic and DeepSeek hexes are the real brand values. The Hermes and mini-swe-agent hexes are approximations of their branding, so swap them if there is a canonical value.

## Verification

All four shields URLs and all four repo links return 200. No `Systems-3` or `Sections-24` references remain. Applied identically to `README.md`, `README.zh-TW.md`, and `README.zh-CN.md`.