### PR TITLE
docs: link learn-deepseek-harness companion repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ it runs tools, keeps state across calls, gates side effects, and coordinates loo
 This repo explains the harness section by section: loop, tools, memory, permissions, context, tasks, and interfaces.
 Learn it once and you can read many agents, since a coding tool, chat assistant, and autonomous runner mostly differ in harness choices.
 
+Two companion repos go deeper than one section can:
+
+- [learn-agent-memory](https://github.com/hardness1020/learn-agent-memory): scales the memory loop into a production memory subsystem.
+- [learn-deepseek-harness](https://github.com/hardness1020/learn-deepseek-harness): learns deepseek-harness from scratch, one plugin seam at a time.
+
 **Contents:** [Loop](#the-agent-loop) · [Method](#how-to-learn) · [Systems](#systems-under-study) ·
 [Sections](#sections) · [Structure](#repository-structure) · [Running](#running-the-demos)
 
@@ -73,7 +78,8 @@ Each system is a worked example for the sections below.
 | *(more soon)* | | | | |
 
 > More systems can be added later, including OpenClaw and aider.
-> The memory layer also has a companion repo: [learn-agent-memory](https://github.com/hardness1020/learn-agent-memory).
+> Two companion repos go deeper: [learn-agent-memory](https://github.com/hardness1020/learn-agent-memory) for the memory layer,
+> and [learn-deepseek-harness](https://github.com/hardness1020/learn-deepseek-harness) for learning deepseek-harness from scratch.
 
 ---
 
@@ -143,7 +149,8 @@ Sections 1 to 23 also carry a runnable `src/`. The code accumulates section by s
 Each section adds one mechanism and evolves `loop.py`, so a diff between adjacent sections shows what changed.
 
 Deep dives that outgrow one section live in their own repos.
-[learn-agent-memory](https://github.com/hardness1020/learn-agent-memory) is the first: it scales the section 9 loop into a full memory subsystem.
+[learn-agent-memory](https://github.com/hardness1020/learn-agent-memory) scales the section 9 loop into a full memory subsystem.
+[learn-deepseek-harness](https://github.com/hardness1020/learn-deepseek-harness) learns deepseek-harness from scratch, one plugin seam at a time.
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -28,6 +28,11 @@
 
 学会这一套之后，你就有能力看懂很多种 agent，因为写代码的工具、聊天助手和自动执行器，差别大多只在 harness 的设计选择上。
 
+有两个延伸 repo，讲得比单一章节更深：
+
+- [learn-agent-memory](https://github.com/hardness1020/learn-agent-memory)：把 memory loop 放大成 production 规模的 memory 子系统。
+- [learn-deepseek-harness](https://github.com/hardness1020/learn-deepseek-harness)：从零开始学 deepseek-harness，一次拆一个 plugin 接缝。
+
 **目录：** [Agent loop](#agent-loop) · [学习方法](#学习方法) · [研究的系统](#研究的系统) ·
 [各章节](#各章节) · [文件结构](#文件结构) · [运行示范](#运行示范)
 
@@ -73,7 +78,8 @@
 | *(更多陆续加入)*       |                                                                       |                                       |                           |           |
 
 > 之后可以再加入更多系统，例如 OpenClaw 和 aider。
-> memory 这一层另外有一个专门的 repo：[learn-agent-memory](https://github.com/hardness1020/learn-agent-memory)。
+> 另外有两个延伸 repo：[learn-agent-memory](https://github.com/hardness1020/learn-agent-memory) 专讲 memory 这一层，
+> [learn-deepseek-harness](https://github.com/hardness1020/learn-deepseek-harness) 则是从零开始学 deepseek-harness。
 
 ---
 
@@ -143,7 +149,8 @@ awesome-agent-architecture/
 每一章新增一个机制，并让 `loop.py` 演进，所以对比相邻两章的 diff，就能看出改了什么。
 
 超出单一章节篇幅的深入主题，会独立成自己的 repo。
-第一个是 [learn-agent-memory](https://github.com/hardness1020/learn-agent-memory)，把第 9 章的 memory loop 放大成完整的子系统。
+[learn-agent-memory](https://github.com/hardness1020/learn-agent-memory) 把第 9 章的 memory loop 放大成完整的子系统。
+[learn-deepseek-harness](https://github.com/hardness1020/learn-deepseek-harness) 从零开始学 deepseek-harness，一次拆一个 plugin 接缝。
 
 ---
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -28,6 +28,11 @@
 
 學會這一套之後，你就有能力看懂很多種 agent，因為寫程式的工具、聊天助理和自動執行器，差別大多只在 harness 的設計選擇上。
 
+有兩個延伸 repo，講得比單一章節更深：
+
+- [learn-agent-memory](https://github.com/hardness1020/learn-agent-memory)：把 memory loop 放大成 production 規模的 memory 子系統。
+- [learn-deepseek-harness](https://github.com/hardness1020/learn-deepseek-harness)：從零開始學 deepseek-harness，一次拆一個 plugin 接縫。
+
 **目錄：** [Agent loop](#agent-loop) · [學習方法](#學習方法) · [研究的系統](#研究的系統) ·
 [各章節](#各章節) · [檔案結構](#檔案結構) · [執行示範](#執行示範)
 
@@ -73,7 +78,8 @@
 | *(更多陸續加入)*       |                                                                       |                                       |                           |           |
 
 > 之後可以再加入更多系統，例如 OpenClaw 和 aider。
-> memory 這一層另外有一個專門的 repo：[learn-agent-memory](https://github.com/hardness1020/learn-agent-memory)。
+> 另外有兩個延伸 repo：[learn-agent-memory](https://github.com/hardness1020/learn-agent-memory) 專講 memory 這一層，
+> [learn-deepseek-harness](https://github.com/hardness1020/learn-deepseek-harness) 則是從零開始學 deepseek-harness。
 
 ---
 
@@ -143,7 +149,8 @@ awesome-agent-architecture/
 每一章新增一個機制，並讓 `loop.py` 演進，所以對比相鄰兩章的 diff，就能看出改了什麼。
 
 超出單一章節份量的深入主題，會獨立成自己的 repo。
-第一個是 [learn-agent-memory](https://github.com/hardness1020/learn-agent-memory)，把第 9 章的 memory loop 放大成完整的子系統。
+[learn-agent-memory](https://github.com/hardness1020/learn-agent-memory) 把第 9 章的 memory loop 放大成完整的子系統。
+[learn-deepseek-harness](https://github.com/hardness1020/learn-deepseek-harness) 從零開始學 deepseek-harness，一次拆一個 plugin 接縫。
 
 ---
 


### PR DESCRIPTION
Adds an explicit link to [learn-deepseek-harness](https://github.com/hardness1020/learn-deepseek-harness) in the root README.

- intro: bullet list naming both companion repos
- systems note and repo structure: one line each
- mirrored at all three spots in `README.zh-TW.md` and `README.zh-CN.md`

No lines over 180 chars in any of the three files.