### PR TITLE
docs: rename repo to learn-agent-architecture

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,4 +1,4 @@
-<h1 align="center" style="margin-top: 0;">Awesome Agent Architecture</h1>
+<h1 align="center" style="margin-top: 0;">Learn Agent Architecture</h1>
 
 <p align="center">
   <strong>現代の AI agent が LLM の周りにどう組み立てられているかを学びます。</strong><br>
@@ -15,7 +15,7 @@
 </p>
 
 <p align="center">
-  <img src="https://github.com/user-attachments/assets/472d8152-5e46-4e39-9f09-e77dcd07936a" alt="Awesome Agent Architecture">
+  <img src="https://github.com/user-attachments/assets/472d8152-5e46-4e39-9f09-e77dcd07936a" alt="Learn Agent Architecture">
 </p>
 
 <p align="center">
@@ -133,7 +133,7 @@ loop そのものは小さいです。工学の大部分はその周りにあり
 24 本のセクション解説がすべて揃っています。`00-harness-thesis/` から `23-evaluation/` までです。
 
 ```text
-awesome-agent-architecture/
+learn-agent-architecture/
 ├── README.md                  # top-level map
 ├── sections/                  # one folder per section
 │   ├── 00-harness-thesis/     # README.md per section

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,4 +1,4 @@
-<h1 align="center" style="margin-top: 0;">Awesome Agent Architecture</h1>
+<h1 align="center" style="margin-top: 0;">Learn Agent Architecture</h1>
 
 <p align="center">
   <strong>최신 AI agent가 LLM을 중심으로 어떻게 만들어지는지 배웁니다.</strong><br>
@@ -15,7 +15,7 @@
 </p>
 
 <p align="center">
-  <img src="https://github.com/user-attachments/assets/472d8152-5e46-4e39-9f09-e77dcd07936a" alt="Awesome Agent Architecture">
+  <img src="https://github.com/user-attachments/assets/472d8152-5e46-4e39-9f09-e77dcd07936a" alt="Learn Agent Architecture">
 </p>
 
 <p align="center">
@@ -133,7 +133,7 @@ loop는 작습니다. 엔지니어링 대부분은 그 주위에 있습니다. t
 `00-harness-thesis/`부터 `23-evaluation/`까지 섹션 글 24개가 모두 있습니다.
 
 ```text
-awesome-agent-architecture/
+learn-agent-architecture/
 ├── README.md                  # top-level map
 ├── sections/                  # one folder per section
 │   ├── 00-harness-thesis/     # README.md per section

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1 align="center" style="margin-top: 0;">Awesome Agent Architecture</h1>
+<h1 align="center" style="margin-top: 0;">Learn Agent Architecture</h1>
 
 <p align="center">
   <strong>Learn how modern AI agents are built around the LLM.</strong><br>
@@ -15,7 +15,7 @@
 </p>
 
 <p align="center">
-  <img src="https://github.com/user-attachments/assets/472d8152-5e46-4e39-9f09-e77dcd07936a" alt="Awesome Agent Architecture">
+  <img src="https://github.com/user-attachments/assets/472d8152-5e46-4e39-9f09-e77dcd07936a" alt="Learn Agent Architecture">
 </p>
 
 <p align="center">
@@ -133,7 +133,7 @@ Eight layers, from the basic loop to a harness that runs itself. Each row links 
 All 24 section writeups are present, from `00-harness-thesis/` through `23-evaluation/`.
 
 ```text
-awesome-agent-architecture/
+learn-agent-architecture/
 ├── README.md                  # top-level map
 ├── sections/                  # one folder per section
 │   ├── 00-harness-thesis/     # README.md per section

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,4 +1,4 @@
-<h1 align="center" style="margin-top: 0;">Awesome Agent Architecture</h1>
+<h1 align="center" style="margin-top: 0;">Learn Agent Architecture</h1>
 
 <p align="center">
   <strong>学会现代 AI agent 如何围绕 LLM 打造。</strong><br>
@@ -15,7 +15,7 @@
 </p>
 
 <p align="center">
-  <img src="https://github.com/user-attachments/assets/472d8152-5e46-4e39-9f09-e77dcd07936a" alt="Awesome Agent Architecture">
+  <img src="https://github.com/user-attachments/assets/472d8152-5e46-4e39-9f09-e77dcd07936a" alt="Learn Agent Architecture">
 </p>
 
 <p align="center">
@@ -132,7 +132,7 @@
 24 篇章节说明都已备齐，从 `00-harness-thesis/` 一路到 `23-evaluation/`。
 
 ```text
-awesome-agent-architecture/
+learn-agent-architecture/
 ├── README.md                  # 最上层地图
 ├── sections/                  # 每个章节一个文件夹
 │   ├── 00-harness-thesis/     # 每章一份 README.md

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,4 +1,4 @@
-<h1 align="center" style="margin-top: 0;">Awesome Agent Architecture</h1>
+<h1 align="center" style="margin-top: 0;">Learn Agent Architecture</h1>
 
 <p align="center">
   <strong>學會現代 AI agent 如何圍繞 LLM 打造。</strong><br>
@@ -15,7 +15,7 @@
 </p>
 
 <p align="center">
-  <img src="https://github.com/user-attachments/assets/472d8152-5e46-4e39-9f09-e77dcd07936a" alt="Awesome Agent Architecture">
+  <img src="https://github.com/user-attachments/assets/472d8152-5e46-4e39-9f09-e77dcd07936a" alt="Learn Agent Architecture">
 </p>
 
 <p align="center">
@@ -132,7 +132,7 @@
 24 篇章節說明都已備齊，從 `00-harness-thesis/` 一路到 `23-evaluation/`。
 
 ```text
-awesome-agent-architecture/
+learn-agent-architecture/
 ├── README.md                  # 最上層地圖
 ├── sections/                  # 每個章節一個資料夾
 │   ├── 00-harness-thesis/     # 每章一份 README.md


### PR DESCRIPTION
GitHub repo renamed from `awesome-agent-architecture` to `learn-agent-architecture`. Old URLs 301 to the new path.

This PR updates the README title, banner alt text, and the directory tree root in all five language READMEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QynExqMgVk1ciTxBR8oD1k