### PR TITLE
docs: add acknowledgements section to root READMEs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -213,3 +213,13 @@ PR のチェックリスト全体は [CONTRIBUTING.md](CONTRIBUTING.md) を見�
 - [Anthropic · Building effective agents](https://www.anthropic.com/engineering/building-effective-agents): ワークフローと agent の違い、および 5 つのワークフロー類型。
 - [Google · Why we built ADK 2.0](https://developers.googleblog.com/en/why-we-built-adk-20/): コードで書くルーティングと、ノード間の context 分離。
 - [ai-agent-book](https://github.com/bojieli/ai-agent-book): 李博杰 著『深入理解 AI Agent』(Apache-2.0)。第 6 章が評価のセクションの土台です。
+
+---
+
+## 謝辞
+
+本プロジェクトを掲載してくれた以下のコレクションに感謝します。
+
+- [walkinglabs/awesome-harness-engineering](https://github.com/walkinglabs/awesome-harness-engineering)
+- [Jenqyang/Awesome-AI-Agents](https://github.com/Jenqyang/Awesome-AI-Agents)
+- [WenyuChiou/awesome-agentic-ai-zh](https://github.com/WenyuChiou/awesome-agentic-ai-zh)

--- a/README.ko.md
+++ b/README.ko.md
@@ -213,3 +213,13 @@ uv run python sections/01-agent-loop/src/demo.py  # live
 - [Anthropic · Building effective agents](https://www.anthropic.com/engineering/building-effective-agents): workflow와 agent의 대비, 그리고 다섯 가지 workflow 형태.
 - [Google · Why we built ADK 2.0](https://developers.googleblog.com/en/why-we-built-adk-20/): 코드로 하는 라우팅과 노드 사이의 context 격리.
 - [ai-agent-book](https://github.com/bojieli/ai-agent-book): 李博杰의 《深入理解 AI Agent》(Apache-2.0). 6장이 평가 섹션의 근거입니다.
+
+---
+
+## 감사의 말
+
+이 프로젝트를 실어 준 다음 컬렉션에 감사드립니다.
+
+- [walkinglabs/awesome-harness-engineering](https://github.com/walkinglabs/awesome-harness-engineering)
+- [Jenqyang/Awesome-AI-Agents](https://github.com/Jenqyang/Awesome-AI-Agents)
+- [WenyuChiou/awesome-agentic-ai-zh](https://github.com/WenyuChiou/awesome-agentic-ai-zh)

--- a/README.md
+++ b/README.md
@@ -213,3 +213,13 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full PR checklist.
 - [Anthropic · Building effective agents](https://www.anthropic.com/engineering/building-effective-agents): Workflows vs agents and the five workflow shapes.
 - [Google · Why we built ADK 2.0](https://developers.googleblog.com/en/why-we-built-adk-20/): Routing in code and context isolation between nodes.
 - [ai-agent-book](https://github.com/bojieli/ai-agent-book): 《深入理解 AI Agent》 by 李博杰 (Apache-2.0). Chapter 6 grounds the evaluation section.
+
+---
+
+## Acknowledgements
+
+Thanks to these collections for listing this project:
+
+- [walkinglabs/awesome-harness-engineering](https://github.com/walkinglabs/awesome-harness-engineering)
+- [Jenqyang/Awesome-AI-Agents](https://github.com/Jenqyang/Awesome-AI-Agents)
+- [WenyuChiou/awesome-agentic-ai-zh](https://github.com/WenyuChiou/awesome-agentic-ai-zh)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -212,3 +212,13 @@ uv run python sections/01-agent-loop/src/demo.py  # live
 - [Anthropic · Building effective agents](https://www.anthropic.com/engineering/building-effective-agents): workflow 与 agent 的分界，加上五种 workflow 图形。
 - [Google · Why we built ADK 2.0](https://developers.googleblog.com/en/why-we-built-adk-20/): 用代码选路，以及 node 之间的 context 隔离。
 - [ai-agent-book](https://github.com/bojieli/ai-agent-book): 《深入理解 AI Agent》（李博杰著，Apache-2.0）。第 6 章是评估本章的主要出处。
+
+---
+
+## 致谢
+
+感谢这些收录清单把本项目列进去：
+
+- [walkinglabs/awesome-harness-engineering](https://github.com/walkinglabs/awesome-harness-engineering)
+- [Jenqyang/Awesome-AI-Agents](https://github.com/Jenqyang/Awesome-AI-Agents)
+- [WenyuChiou/awesome-agentic-ai-zh](https://github.com/WenyuChiou/awesome-agentic-ai-zh)

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -212,3 +212,13 @@ uv run python sections/01-agent-loop/src/demo.py  # live
 - [Anthropic · Building effective agents](https://www.anthropic.com/engineering/building-effective-agents): workflow 與 agent 的分界，加上五種 workflow 圖形。
 - [Google · Why we built ADK 2.0](https://developers.googleblog.com/en/why-we-built-adk-20/): 用程式碼選路，以及 node 之間的 context 隔離。
 - [ai-agent-book](https://github.com/bojieli/ai-agent-book): 《深入理解 AI Agent》（李博杰著，Apache-2.0）。第 6 章是評估本章的主要出處。
+
+---
+
+## 致謝
+
+感謝這些收錄清單把本專案列進去：
+
+- [walkinglabs/awesome-harness-engineering](https://github.com/walkinglabs/awesome-harness-engineering)
+- [Jenqyang/Awesome-AI-Agents](https://github.com/Jenqyang/Awesome-AI-Agents)
+- [WenyuChiou/awesome-agentic-ai-zh](https://github.com/WenyuChiou/awesome-agentic-ai-zh)


### PR DESCRIPTION
Adds an `Acknowledgements` section after `References` in the root README, listing the three collections that merged PRs adding this project.

- [walkinglabs/awesome-harness-engineering](https://github.com/walkinglabs/awesome-harness-engineering)
- [Jenqyang/Awesome-AI-Agents](https://github.com/Jenqyang/Awesome-AI-Agents)
- [WenyuChiou/awesome-agentic-ai-zh](https://github.com/WenyuChiou/awesome-agentic-ai-zh)

Mirrored across `zh-TW`, `zh-CN`, `ja`, and `ko` with each language's existing heading for acknowledgements.

All three links return 200. No lines over 180 characters. No em or en dashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019G2JZnfiJQc1v796K6upTN